### PR TITLE
Fix multiple chained optionals not working correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+ - Fixes chained optionals not allowing the command to be executed when more than one optional is omitted
 
 ## [1.0.1] - 2020-10-14
 

--- a/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
@@ -287,7 +287,20 @@ public final class CommandTree<C> {
                     if (child.getValue().hasDefaultValue()) {
                         commandQueue.add(child.getValue().getDefaultValue());
                     } else if (!child.getValue().isRequired()) {
-                        return Pair.of(this.cast(child.getValue().getOwningCommand()), null);
+                        if (child.getValue().getOwningCommand() == null) {
+                            /*
+                             * If there are multiple children with different owning commands then it's ambiguous and
+                             * not allowed, therefore we're able to pick any child command, as long as we can find it
+                             */
+                            Node<CommandArgument<C, ?>> node = child;
+                            while (!node.isLeaf()) {
+                                node = node.getChildren().get(0);
+                                if (node.getValue() != null && node.getValue().getOwningCommand() != null) {
+                                    child.getValue().setOwningCommand(node.getValue().getOwningCommand());
+                                }
+                            }
+                        }
+                        return Pair.of(child.getValue().getOwningCommand(), null);
                     } else if (child.isLeaf()) {
                         if (root.getValue() != null && root.getValue().getOwningCommand() != null) {
                             final Command<C> command = root.getValue().getOwningCommand();

--- a/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
@@ -143,6 +143,13 @@ class CommandTreeTest {
                                 .addPreprocessor(RegexPreprocessor.of("[A-Za-z]{3,5}"))
                 )
         );
+
+        /* Build command for testing multiple optionals */
+        manager.command(
+                manager.commandBuilder("optionals")
+                       .argument(StringArgument.optional("opt1"))
+                       .argument(StringArgument.optional("opt2"))
+        );
     }
 
     @Test
@@ -299,6 +306,11 @@ class CommandTreeTest {
                 CompletionException.class,
                 () -> manager.executeCommand(new TestCommandSender(), "preprocess ab").join()
         );
+    }
+
+    @Test
+    void testOptionals() {
+        manager.executeCommand(new TestCommandSender(), "optionals").join();
     }
 
 


### PR DESCRIPTION
There is a problem where the child arguments never forwarded their commands correctly. This will now fix itself when necessary.