### PR TITLE
Add named suggestion providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Added ExampleBungeePlugin
  - Added CaptionKeys to cloud-bungee
  - Added BungeeCommandPreprocessor to cloud-bungee
+ - Added named suggestion providers
 
 ## [1.0.2] - 2020-10-18
 

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/Argument.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/Argument.java
@@ -27,6 +27,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.function.BiFunction;
 
 /**
  * Annotation used to indicate that a method parameter is a command argument
@@ -48,6 +49,22 @@ public @interface Argument {
      * @return Argument name
      */
     String parserName() default "";
+
+    /**
+     * Name of the suggestions provider to use. If the string is left empty, the default
+     * provider for the argument parser will be used. Otherwise,
+     * the {@link cloud.commandframework.arguments.parser.ParserRegistry} instance in the
+     * {@link cloud.commandframework.CommandManager} will be queried for a matching suggestion provider.
+     * <p>
+     * For this to work, the suggestion needs to be registered in the parser registry. To do this, use
+     * {@link cloud.commandframework.arguments.parser.ParserRegistry#registerSuggestionProvider(String, BiFunction)}.
+     * The registry instance can be retrieved using {@link cloud.commandframework.CommandManager#getParserRegistry()}.
+     *
+     * @return The name of the suggestion provider, or {@code ""} if the default suggestion provider for the argument parser
+     *         should be used instead
+     * @since 1.1.0
+     */
+    String suggestions() default "";
 
     /**
      * Get the default value

--- a/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
@@ -621,7 +621,7 @@ public final class CommandTree<C> {
                     Objects.requireNonNull(
                             Objects.requireNonNull(
                                     node.value,
-                                    "node.value"
+                                    "node.value: "
                             ).getOwningCommand(),
                             "owning command"
                     ).getCommandPermission()

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/parser/ParserRegistry.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/parser/ParserRegistry.java
@@ -23,11 +23,13 @@
 //
 package cloud.commandframework.arguments.parser;
 
+import cloud.commandframework.context.CommandContext;
 import io.leangen.geantyref.TypeToken;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.lang.annotation.Annotation;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -119,6 +121,32 @@ public interface ParserRegistry<C> {
     <T> @NonNull Optional<ArgumentParser<C, T>> createParser(
             @NonNull String name,
             @NonNull ParserParameters parserParameters
+    );
+
+    /**
+     * Register a new named suggestion provider
+     *
+     * @param name                Name of the suggestions provider. The name is case independent.
+     * @param suggestionsProvider The suggestions provider
+     * @see #getSuggestionProvider(String) Get a suggestion provider
+     * @since 1.1.0
+     */
+    void registerSuggestionProvider(
+            @NonNull String name,
+            @NonNull BiFunction<@NonNull CommandContext<C>, @NonNull String, @NonNull List<String>> suggestionsProvider
+    );
+
+    /**
+     * Get a named suggestion provider, if a suggestion provider with the given name exists in the registry
+     *
+     * @param name Suggestion provider name. The name is case independent.
+     * @return Optional that either contains the suggestion provider name, or nothing ({@link Optional#empty()}) if no
+     *         suggestion provider is registered with the given name
+     * @see #registerSuggestionProvider(String, BiFunction) Register a suggestion provider
+     * @since 1.1.0
+     */
+    @NonNull Optional<BiFunction<@NonNull CommandContext<C>, @NonNull String, @NonNull List<String>>> getSuggestionProvider(
+            @NonNull String name
     );
 
 }


### PR DESCRIPTION
This allows for pre-registration of command suggestion providers, that can then be used in annotated command methods.

Fixes #57.