### PR TITLE
Make the flag parser smarter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Added CaptionKeys to cloud-bungee
  - Added BungeeCommandPreprocessor to cloud-bungee
 
-### Chanced
+### Changed
  - Allow for combined presence flags, such that `-a -b -c` is equivalent to `-abc`
 
 ## [1.0.2] - 2020-10-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Added CaptionKeys to cloud-bungee
  - Added BungeeCommandPreprocessor to cloud-bungee
 
+### Chanced
+ - Allow for combined presence flags, such that `-a -b -c` is equivalent to `-abc`
+
 ## [1.0.2] - 2020-10-18
 
 ### Fixed

--- a/cloud-core/src/main/java/cloud/commandframework/LockableCommandManager.java
+++ b/cloud-core/src/main/java/cloud/commandframework/LockableCommandManager.java
@@ -74,7 +74,7 @@ public abstract class LockableCommandManager<C> extends CommandManager<C> {
      * else {@link IllegalStateException} will be called
      *
      * @param command Command to register
-     * @return
+     * @return The command manager instance
      */
     @Override
     public final @NonNull CommandManager<C> command(final @NonNull Command<C> command) {
@@ -95,7 +95,7 @@ public abstract class LockableCommandManager<C> extends CommandManager<C> {
      * else {@link IllegalStateException} will be called
      *
      * @param command Command to register. {@link Command.Builder#build()}} will be invoked.
-     * @return
+     * @return The command manager instance
      */
     @Override
     public final @NonNull CommandManager<C> command(final Command.@NonNull Builder<C> command) {

--- a/cloud-core/src/main/java/cloud/commandframework/LockableCommandManager.java
+++ b/cloud-core/src/main/java/cloud/commandframework/LockableCommandManager.java
@@ -70,7 +70,7 @@ public abstract class LockableCommandManager<C> extends CommandManager<C> {
     /**
      * {@inheritDoc}
      * <p>
-     * This should only be called when {@link #isCommandRegistrationAllowed()} is {@code false},
+     * This should only be called when {@link #isCommandRegistrationAllowed()} is {@code true},
      * else {@link IllegalStateException} will be called
      *
      * @param command Command to register

--- a/cloud-core/src/main/java/cloud/commandframework/LockableCommandManager.java
+++ b/cloud-core/src/main/java/cloud/commandframework/LockableCommandManager.java
@@ -91,7 +91,7 @@ public abstract class LockableCommandManager<C> extends CommandManager<C> {
     /**
      * {@inheritDoc}
      * <p>
-     * This should only be called when {@link #isCommandRegistrationAllowed()} is {@code false},
+     * This should only be called when {@link #isCommandRegistrationAllowed()} is {@code true},
      * else {@link IllegalStateException} will be called
      *
      * @param command Command to register. {@link Command.Builder#build()}} will be invoked.

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/flags/CommandFlag.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/flags/CommandFlag.java
@@ -56,9 +56,9 @@ public final class CommandFlag<T> {
             final @NonNull Description description,
             final @Nullable CommandArgument<?, T> commandArgument
     ) {
-        this.name = name;
-        this.aliases = aliases;
-        this.description = description;
+        this.name = Objects.requireNonNull(name, "name cannot be null");
+        this.aliases = Objects.requireNonNull(aliases, "aliases cannot be null");
+        this.description = Objects.requireNonNull(description, "description cannot be null");
         this.commandArgument = commandArgument;
     }
 
@@ -156,7 +156,8 @@ public final class CommandFlag<T> {
         }
 
         /**
-         * Create a new builder instance using the given flag aliases
+         * Create a new builder instance using the given flag aliases.
+         * These may at most be one character in length
          *
          * @param aliases Flag aliases
          * @return New builder instance
@@ -166,6 +167,14 @@ public final class CommandFlag<T> {
             for (final String alias : aliases) {
                 if (alias.isEmpty()) {
                     continue;
+                }
+                if (alias.length() > 1) {
+                    throw new IllegalArgumentException(
+                           String.format(
+                                   "Alias '%s' has name longer than one character. This is not allowed",
+                                   alias
+                           )
+                    );
                 }
                 filteredAliases.add(alias);
             }

--- a/cloud-core/src/main/java/cloud/commandframework/context/CommandContext.java
+++ b/cloud-core/src/main/java/cloud/commandframework/context/CommandContext.java
@@ -245,6 +245,16 @@ public final class CommandContext<C> {
     }
 
     /**
+     * Get the raw input as a joined string
+     *
+     * @return {@link #getRawInput()} joined with {@code " "} as the delimiter
+     * @since 1.1.0
+     */
+    public @NonNull String getRawInputJoined() {
+        return String.join(" ", this.getRawInput());
+    }
+
+    /**
      * Create an argument timing for a specific argument
      *
      * @param argument Argument

--- a/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
@@ -80,6 +80,12 @@ public class CommandSuggestionsTest {
                         .build())
                 .build());
 
+        manager.command(manager.commandBuilder("flags2")
+                .flag(manager.flagBuilder("first").withAliases("f"))
+                .flag(manager.flagBuilder("second").withAliases("s"))
+                .flag(manager.flagBuilder("third").withAliases("t"))
+                .build());
+
         manager.command(manager.commandBuilder("numbers").argument(IntegerArgument.of("num")));
 
         manager.command(manager.commandBuilder("numberswithmin")
@@ -169,6 +175,15 @@ public class CommandSuggestionsTest {
         final String input3 = "flags 10 --enum foo ";
         final List<String> suggestions3 = manager.suggest(new TestCommandSender(), input3);
         Assertions.assertEquals(Collections.singletonList("--static"), suggestions3);
+        final String input4 = "flags2 ";
+        final List<String> suggestions4 = manager.suggest(new TestCommandSender(), input4);
+        Assertions.assertEquals(Arrays.asList("--first", "--second", "--third", "-f", "-s", "-t"), suggestions4);
+        final String input5 = "flags2 -f";
+        final List<String> suggestions5 = manager.suggest(new TestCommandSender(), input5);
+        Assertions.assertEquals(Arrays.asList("-fs", "-ft", "-f"), suggestions5);
+        final String input6 = "flags2 -f -s";
+        final List<String> suggestions6 = manager.suggest(new TestCommandSender(), input6);
+        Assertions.assertEquals(Arrays.asList("-st", "-s"), suggestions6);
     }
 
     @Test

--- a/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
@@ -117,6 +117,7 @@ class CommandTreeTest {
                         .withAliases("t")
                         .build())
                 .flag(manager.flagBuilder("test2")
+                        .withAliases("f")
                         .build())
                 .flag(manager.flagBuilder("num")
                         .withArgument(IntegerArgument.of("num")).build())
@@ -124,6 +125,7 @@ class CommandTreeTest {
                         .withArgument(EnumArgument.of(FlagEnum.class, "enum")))
                 .handler(c -> {
                     System.out.println("Flag present? " + c.flags().isPresent("test"));
+                    System.out.println("Second flag present? " + c.flags().isPresent("test2"));
                     System.out.println("Numerical flag: " + c.flags().getValue("num", -10));
                     System.out.println("Enum: " + c.flags().getValue("enum", FlagEnum.PROXI));
                 })
@@ -283,6 +285,7 @@ class CommandTreeTest {
                 manager.executeCommand(new TestCommandSender(), "flags --test test2").join());
         manager.executeCommand(new TestCommandSender(), "flags --num 500").join();
         manager.executeCommand(new TestCommandSender(), "flags --num 63 --enum potato --test").join();
+        manager.executeCommand(new TestCommandSender(), "flags -tf --num 63 --enum potato").join();
     }
 
     @Test


### PR DESCRIPTION
It will now allow multiple presence flag aliases to be joined into a single flag, such that `-a -b -c <=> -abc`.

This fixes #75