### PR TITLE
:sparkles: Allow for recursive annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
  - Allow for combined presence flags, such that `-a -b -c` is equivalent to `-abc`
- - Allow for class annotations as a default for when an annotation is not present on a method.
+ - Allow for class annotations as a default for when an annotation is not present on a method
+ - Allow for annotated annotations
  
 ### Fixed
  - Fix arguments with no required children not being executors (cloud-brigadier)

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/AnnotationParser.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/AnnotationParser.java
@@ -116,10 +116,8 @@ public final class AnnotationParser<C> {
     ) {
         A innerCandidate = null;
         for (final Annotation annotation : annotations) {
-            if (checkedAnnotations.contains(annotation.annotationType())) {
+            if (!checkedAnnotations.add(annotation.annotationType())) {
                 continue;
-            } else {
-                checkedAnnotations.add(annotation.annotationType());
             }
             if (annotation.annotationType().equals(clazz)) {
                 return (A) annotation;

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/AnnotationParser.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/AnnotationParser.java
@@ -106,16 +106,36 @@ public final class AnnotationParser<C> {
         ));
     }
 
+    @SuppressWarnings("unchecked")
+    static <A extends Annotation> @Nullable A getAnnotationRecursively(
+            final @NonNull Annotation[] annotations,
+            final @NonNull Class<A> clazz
+    ) {
+        A innerCandidate = null;
+        for (final Annotation annotation : annotations) {
+            if (annotation.annotationType().equals(clazz)) {
+                return (A) annotation;
+            }
+            if (annotation.annotationType().getPackage().getName().startsWith("java.lang")) {
+                continue;
+            }
+            final A inner = getAnnotationRecursively(annotation.annotationType().getAnnotations(), clazz);
+            if (inner != null) {
+                innerCandidate = inner;
+            }
+        }
+        return innerCandidate;
+    }
+
     static <A extends Annotation> @Nullable A getMethodOrClassAnnotation(
             final @NonNull Method method,
             final @NonNull Class<A> clazz
     ) {
-        if (method.isAnnotationPresent(clazz)) {
-            return method.getAnnotation(clazz);
-        } else if (method.getDeclaringClass().isAnnotationPresent(clazz)) {
-            return method.getDeclaringClass().getAnnotation(clazz);
+        A annotation = getAnnotationRecursively(method.getAnnotations(), clazz);
+        if (annotation == null) {
+            annotation = getAnnotationRecursively(method.getDeclaringClass().getAnnotations(), clazz);
         }
-        return null;
+        return annotation;
     }
 
     static <A extends Annotation> boolean methodOrClassHasAnnotation(

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
@@ -86,20 +86,26 @@ class AnnotationParserTest {
         final Class<AnnotatedClass> annotatedClass = AnnotatedClass.class;
         final Method annotatedMethod = annotatedClass.getDeclaredMethod("annotatedMethod");
 
+        System.out.println("Looking for @CommandDescription");
         final CommandDescription commandDescription = AnnotationParser.getMethodOrClassAnnotation(annotatedMethod,
                 CommandDescription.class);
         Assertions.assertNotNull(commandDescription);
         Assertions.assertEquals("Hello World!", commandDescription.value());
 
+        System.out.println("Looking for @CommandPermission");
         final CommandPermission commandPermission = AnnotationParser.getMethodOrClassAnnotation(annotatedMethod,
                 CommandPermission.class);
         Assertions.assertNotNull(commandPermission);
         Assertions.assertEquals("some.permission", commandPermission.value());
 
+        System.out.println("Looking for @CommandMethod");
         final CommandMethod commandMethod = AnnotationParser.getMethodOrClassAnnotation(annotatedMethod,
                 CommandMethod.class);
         Assertions.assertNotNull(commandMethod);
         Assertions.assertEquals("method", commandMethod.value());
+
+        System.out.println("Looking for @Regex");
+        final Regex regex = AnnotationParser.getMethodOrClassAnnotation(annotatedMethod, Regex.class);
     }
 
     @ProxiedBy("proxycommand")
@@ -131,12 +137,13 @@ class AnnotationParserTest {
 
 
     @CommandPermission("some.permission")
-    @Target({ElementType.METHOD})
+    @Target(ElementType.METHOD)
     @Retention(RetentionPolicy.RUNTIME)
     private @interface AnnotatedAnnotation {
     }
 
 
+    @Bad1
     @CommandDescription("Hello World!")
     private static class AnnotatedClass {
 
@@ -145,6 +152,20 @@ class AnnotationParserTest {
         public static void annotatedMethod() {
         }
 
+    }
+
+
+    @Bad2
+    @Target({ElementType.METHOD, ElementType.TYPE})
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface Bad1 {
+    }
+
+
+    @Bad1
+    @Target({ElementType.METHOD, ElementType.TYPE})
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface Bad2 {
     }
 
 }

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
@@ -105,6 +105,7 @@ class AnnotationParserTest {
         Assertions.assertEquals("method", commandMethod.value());
 
         System.out.println("Looking for @Regex");
+        @SuppressWarnings("unused")
         final Regex regex = AnnotationParser.getMethodOrClassAnnotation(annotatedMethod, Regex.class);
     }
 

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
@@ -32,6 +32,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -76,6 +81,27 @@ class AnnotationParserTest {
         Assertions.assertEquals(NAMED_SUGGESTIONS, manager.suggest(new TestCommandSender(), "namedsuggestions "));
     }
 
+    @Test
+    void testAnnotationResolver() throws Exception {
+        final Class<AnnotatedClass> annotatedClass = AnnotatedClass.class;
+        final Method annotatedMethod = annotatedClass.getDeclaredMethod("annotatedMethod");
+
+        final CommandDescription commandDescription = AnnotationParser.getMethodOrClassAnnotation(annotatedMethod,
+                CommandDescription.class);
+        Assertions.assertNotNull(commandDescription);
+        Assertions.assertEquals("Hello World!", commandDescription.value());
+
+        final CommandPermission commandPermission = AnnotationParser.getMethodOrClassAnnotation(annotatedMethod,
+                CommandPermission.class);
+        Assertions.assertNotNull(commandPermission);
+        Assertions.assertEquals("some.permission", commandPermission.value());
+
+        final CommandMethod commandMethod = AnnotationParser.getMethodOrClassAnnotation(annotatedMethod,
+                CommandMethod.class);
+        Assertions.assertNotNull(commandMethod);
+        Assertions.assertEquals("method", commandMethod.value());
+    }
+
     @ProxiedBy("proxycommand")
     @CommandMethod("test|t literal <int> [string]")
     public void testCommand(
@@ -101,6 +127,24 @@ class AnnotationParserTest {
     public void testNamedSuggestionProviders(
             @Argument(value = "input", suggestions = "some-name") final String argument
     ) {
+    }
+
+
+    @CommandPermission("some.permission")
+    @Target({ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface AnnotatedAnnotation {
+    }
+
+
+    @CommandDescription("Hello World!")
+    private static class AnnotatedClass {
+
+        @CommandMethod("method")
+        @AnnotatedAnnotation
+        public static void annotatedMethod() {
+        }
+
     }
 
 }


### PR DESCRIPTION
This allows people to make annotated annotations, that contain default perms, etc.