### PR TITLE
✨ Throw AmbiguousNodeException for more ambiguous cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  
 ### Fixed
  - Fix arguments with no required children not being executors (cloud-brigadier)
+ - Detect and throw an exception for ambiguous nodes in more cases
 
 ## [1.0.2] - 2020-10-18
 

--- a/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
@@ -729,7 +729,9 @@ public final class CommandTree<C> {
         }
         final int size = node.children.size();
         for (final Node<CommandArgument<C, ?>> child : node.children) {
-            if (child.getValue() != null && !child.getValue().isRequired() && size > 1) {
+            if (child.getValue() != null
+                    && !(child.getValue() instanceof StaticArgument)
+                    && size > 1) {
                 throw new AmbiguousNodeException(
                         node.getValue(),
                         child.getValue(),

--- a/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
@@ -31,6 +31,7 @@ import cloud.commandframework.arguments.standard.FloatArgument;
 import cloud.commandframework.arguments.standard.IntegerArgument;
 import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.exceptions.AmbiguousNodeException;
 import cloud.commandframework.exceptions.NoPermissionException;
 import cloud.commandframework.meta.SimpleCommandMeta;
 import cloud.commandframework.types.tuples.Pair;
@@ -286,6 +287,16 @@ class CommandTreeTest {
         manager.executeCommand(new TestCommandSender(), "flags --num 500").join();
         manager.executeCommand(new TestCommandSender(), "flags --num 63 --enum potato --test").join();
         manager.executeCommand(new TestCommandSender(), "flags -tf --num 63 --enum potato").join();
+    }
+
+    @Test
+    void testAmbiguousNodes() {
+        manager.command(manager.commandBuilder("ambiguous")
+                .argument(StringArgument.of("string"))
+        );
+        Assertions.assertThrows(AmbiguousNodeException.class, () ->
+                manager.command(manager.commandBuilder("ambiguous")
+                        .argument(IntegerArgument.of("integer"))));
     }
 
     @Test


### PR DESCRIPTION
AmbiguousNodeException will now be thrown when ambiguous commands such as
``/command <player>`` and ``/command <location>`` are attempted to be registered.