### PR TITLE
🐛 Fix registration of command aliases on Bukkit when using Brigadier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
  - Use the correct default range for Double and Float parsers in the StandardParserRegistry
  - Fix Bukkit alias command suggestions without Brigadier
+ - Fix Bukkit command alias registration when using Brigadier
 
 ## [1.1.0] - 2020-10-24
 

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/CloudCommodoreManager.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/CloudCommodoreManager.java
@@ -68,7 +68,6 @@ class CloudCommodoreManager<C> extends BukkitPluginRegistrationHandler<C> {
             final @NonNull BukkitCommand<C> bukkitCommand
     ) {
         this.registerWithCommodore(label, command);
-        this.registerWithCommodore(String.format("%s:%s", bukkitCommand.getPlugin().getName(), label).toLowerCase(), command);
     }
 
     protected @NonNull CloudBrigadierManager brigadierManager() {


### PR DESCRIPTION
This fixes an issue where for example, if plugin `A` has command `command` registered, and we (plugin `B`) attempt to register a command `cmd` with alias `command`, the alias would not be registered whatsoever due to the existing command owned by plugin `A`. After this fix, in a case like this our alias will be registered still, but only with our namespace prefixed (i.e., `b:command`).

This issue is only present when using Brigadier (Commodore or Paper) and it seems to be fixed by this, without breaking anything when Brigadier is not used (at least in my testing)