### PR TITLE
Added CommandExecutionException to wrap exceptions thrown in command handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Added a method to get the failure reason of SelectorParseExceptions
  - Added some methods to FlagContext to work with flag values as optionals
  - Allow for use of named suggestion providers with `@Flag`s (cloud-annotations)
+ - Added `CommandExecutionException` which wraps any exception thrown during the execution of command handlers. Should be
+  handled using `CommandManager#registerExceptionHandler`, similar to `NoSuchCommandException`, `ArgumentParseException`, etc.
  
 ### Changed
  - Allow for use of `@Completions` annotation with argument types other than String

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/MethodCommandExecutionHandler.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/MethodCommandExecutionHandler.java
@@ -28,6 +28,7 @@ import cloud.commandframework.annotations.injection.ParameterInjectorRegistry;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.flags.FlagContext;
 import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.exceptions.CommandExecutionException;
 import cloud.commandframework.execution.CommandExecutionHandler;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -115,8 +116,10 @@ class MethodCommandExecutionHandler<C> implements CommandExecutionHandler<C> {
         /* Invoke the command method */
         try {
             this.methodHandle.invokeWithArguments(arguments);
-        } catch (final Throwable e) {
-            e.printStackTrace();
+        } catch (final Error e) {
+            throw e;
+        } catch (final Throwable throwable) {
+            throw new CommandExecutionException(throwable);
         }
     }
 

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/CommandExecutionException.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/CommandExecutionException.java
@@ -1,0 +1,46 @@
+//
+// MIT License
+//
+// Copyright (c) 2020 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.exceptions;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Exception thrown when there is an exception during execution of a command handler
+ *
+ * @since 1.2.0
+ */
+public class CommandExecutionException extends IllegalArgumentException {
+
+    private static final long serialVersionUID = -4785446899438294661L;
+
+    /**
+     * Exception thrown when there is an exception during execution of a command handler
+     *
+     * @param cause Exception thrown during the execution of a command handler
+     */
+    public CommandExecutionException(final @NonNull Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/JDACommandListener.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/JDACommandListener.java
@@ -24,6 +24,7 @@
 package cloud.commandframework.jda;
 
 import cloud.commandframework.exceptions.ArgumentParseException;
+import cloud.commandframework.exceptions.CommandExecutionException;
 import cloud.commandframework.exceptions.InvalidCommandSenderException;
 import cloud.commandframework.exceptions.InvalidSyntaxException;
 import cloud.commandframework.exceptions.NoPermissionException;
@@ -41,6 +42,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 @SuppressWarnings("deprecation")
 public class JDACommandListener<C> extends ListenerAdapter {
 
+    private static final String MESSAGE_INTERNAL_ERROR = "An internal error occurred while attempting to perform this command.";
     private static final String MESSAGE_INVALID_SYNTAX = "Invalid Command Syntax. Correct command syntax is: ";
     private static final String MESSAGE_NO_PERMS = "I'm sorry, but you do not have permission to perform this command. "
             + "Please contact the server administrators if you believe that this is in error.";
@@ -115,6 +117,16 @@ public class JDACommandListener<C> extends ListenerAdapter {
                                         "Invalid Command Argument: " + throwable.getCause()
                                                 .getMessage()
                                 )
+                        );
+                    } else if (throwable instanceof CommandExecutionException) {
+                        this.commandManager.handleException(sender, CommandExecutionException.class,
+                                (CommandExecutionException) throwable, (c, e) -> {
+                                    this.sendMessage(
+                                            event,
+                                            MESSAGE_INTERNAL_ERROR
+                                    );
+                                    throwable.getCause().printStackTrace();
+                                }
                         );
                     } else {
                         this.sendMessage(event, throwable.getMessage());

--- a/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/ExamplePlugin.java
+++ b/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/ExamplePlugin.java
@@ -195,6 +195,7 @@ public final class ExamplePlugin extends JavaPlugin {
                 .withInvalidSenderHandler()
                 .withNoPermissionHandler()
                 .withArgumentParsingHandler()
+                .withCommandExecutionHandler()
                 .withDecorator(
                         component -> Component.text()
                                 .append(Component.text("[", NamedTextColor.DARK_GRAY))


### PR DESCRIPTION
Added `CommandExecutionException` which wraps any exception thrown during the execution of command handlers. Should be handled using `CommandManager#registerExceptionHandler`, similar to `NoSuchCommandException`, `ArgumentParseException`, etc.

closes #133 