### PR TITLE
Add support for literal arguments overriding dynamic ones

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringArgument.java
@@ -306,14 +306,6 @@ public final class StringArgument<C> extends CommandArgument<C, String> {
             }
 
             if (this.stringMode == StringMode.SINGLE) {
-                if (commandContext.isSuggestions()) {
-                    final List<String> suggestions = this.suggestionsProvider.apply(commandContext, inputQueue.peek());
-                    if (!suggestions.isEmpty() && !suggestions.contains(input)) {
-                        return ArgumentParseResult.failure(new IllegalArgumentException(
-                                String.format("'%s' is not one of: %s", input, String.join(", ", suggestions))
-                        ));
-                    }
-                }
                 inputQueue.remove();
                 return ArgumentParseResult.success(input);
             } else if (this.stringMode == StringMode.QUOTED) {

--- a/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
@@ -97,6 +97,15 @@ public class CommandSuggestionsTest {
                 }))
                 .literal("literal")
                 .build());
+
+        manager.command(manager.commandBuilder("literal_with_variable")
+                .argument(StringArgument.<TestCommandSender>newBuilder("arg").withSuggestionsProvider((context, input) -> {
+                    return Arrays.asList("veni", "vidi");
+                }).build())
+                .literal("now"));
+        manager.command(manager.commandBuilder("literal_with_variable")
+                .literal("vici")
+                .literal("later"));
     }
 
     @Test
@@ -275,6 +284,27 @@ public class CommandSuggestionsTest {
         final String input9 = "partial bonjour ";
         final List<String> suggestions9 = manager.suggest(new TestCommandSender(), input9);
         Assertions.assertEquals(Collections.singletonList("literal"), suggestions9);
+    }
+
+    void testLiteralWithVariable() {
+        final String input = "literal_with_variable ";
+        final List<String> suggestions = manager.suggest(new TestCommandSender(), input);
+        Assertions.assertEquals(Arrays.asList("vici", "veni", "vidi"), suggestions);
+        final String input2 = "literal_with_variable v";
+        final List<String> suggestions2 = manager.suggest(new TestCommandSender(), input2);
+        Assertions.assertEquals(Arrays.asList("vici", "veni", "vidi"), suggestions2);
+        final String input3 = "literal_with_variable vi";
+        final List<String> suggestions3 = manager.suggest(new TestCommandSender(), input3);
+        Assertions.assertEquals(Arrays.asList("vici", "vidi"), suggestions3);
+        final String input4 = "literal_with_variable vidi";
+        final List<String> suggestions4 = manager.suggest(new TestCommandSender(), input4);
+        Assertions.assertEquals(Collections.emptyList(), suggestions4);
+        final String input5 = "literal_with_variable vidi ";
+        final List<String> suggestions5 = manager.suggest(new TestCommandSender(), input5);
+        Assertions.assertEquals(Collections.singletonList("now"), suggestions5);
+        final String input6 = "literal_with_variable vici ";
+        final List<String> suggestions6 = manager.suggest(new TestCommandSender(), input6);
+        Assertions.assertEquals(Collections.singletonList("later"), suggestions6);
     }
 
     public enum TestEnum {

--- a/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
@@ -225,7 +225,7 @@ class CommandTreeTest {
         Assertions.assertFalse(
                 manager.getCommandTree().getSuggestions(
                         new CommandContext<>(new TestCommandSender(), manager.getCaptionRegistry()),
-                        new LinkedList<>(Collections.singletonList("test "))
+                        new LinkedList<>(Arrays.asList("test", ""))
                 ).isEmpty());
     }
 

--- a/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
@@ -300,22 +300,30 @@ class CommandTreeTest {
                         .argument(IntegerArgument.of("integer"))));
         newTree();
 
+        // Literal and argument can co-exist, not ambiguous
         manager.command(manager.commandBuilder("ambiguous")
                 .argument(StringArgument.of("string"))
         );
-        Assertions.assertThrows(AmbiguousNodeException.class, () ->
-                manager.command(manager.commandBuilder("ambiguous")
-                        .literal("literal")));
+        manager.command(manager.commandBuilder("ambiguous")
+                .literal("literal"));
         newTree();
 
+        // Two literals (different names) and argument can co-exist, not ambiguous
         manager.command(manager.commandBuilder("ambiguous")
-                .literal("literal")
-        );
+                .literal("literal"));
         manager.command(manager.commandBuilder("ambiguous")
                 .literal("literal2"));
-        Assertions.assertThrows(AmbiguousNodeException.class, () ->
+
+        manager.command(manager.commandBuilder("ambiguous")
+                .argument(IntegerArgument.of("integer")));
+        newTree();
+
+        // Two literals with the same name can not co-exist, causes 'duplicate command chains' error
+        manager.command(manager.commandBuilder("ambiguous")
+                .literal("literal"));
+        Assertions.assertThrows(IllegalStateException.class, () ->
                 manager.command(manager.commandBuilder("ambiguous")
-                        .argument(IntegerArgument.of("integer"))));
+                        .literal("literal")));
         newTree();
     }
 


### PR DESCRIPTION
This is a proposed fix for issue https://github.com/Incendo/cloud/issues/137

Prerequisite pulls:
- https://github.com/Incendo/cloud/pull/146
- https://github.com/Incendo/cloud/pull/147

**TODO: Brigadier needs to be updated to supply the right suggestions**

I've added support for literals overriding variable arguments in the command tree. In the past this threw ambiguity exceptions, I've rewritten the ambiguity detection to be smarter. It was checking whether the number of children was > 1 if any of the arguments was not static, which broke a lot of things.

Now it allows only one variable (parsed) argument as a child, but allows multiple literal static arguments to co-exist. When parsing the command, it will first check for the literal arguments (and aliases). If none of those match, then it will parse variable ones.

This adds support for command registration such as:
```
/command literal help
/command <variable> help
```

Which when invoked as:
`/command literal help`

Will execute the first, while invoked as:
`/command arg help`

Executes the other. Added a test for this as well.

In addition, I've had to fix a problem in the code itself that occurs when running tests. When doing the ambiguity test, it checks if an exception is thrown when ambiguity occurs. However, the tree does not clean up the failing command, so it is left in an invalid state. This caused all later-running tests to fail as well. As a result it heavily depended on test execution order whether all the tests succeeded. I fixed this by cleaning up some of the added node children upon failure.