### PR TITLE
:bug: Annotations API fix

### DIFF
--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/SyntaxParser.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/SyntaxParser.java
@@ -27,7 +27,6 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.StringTokenizer;
 import java.util.function.Function;
@@ -37,7 +36,7 @@ import java.util.regex.Pattern;
 /**
  * Parses command syntax into syntax fragments
  */
-final class SyntaxParser implements Function<@NonNull String, @NonNull LinkedHashMap<@NonNull String, @NonNull SyntaxFragment>> {
+final class SyntaxParser implements Function<@NonNull String, @NonNull List<@NonNull SyntaxFragment>> {
 
     private static final Predicate<String> PATTERN_ARGUMENT_LITERAL = Pattern.compile("([A-Za-z0-9]+)(|([A-Za-z0-9]+))*")
             .asPredicate();
@@ -47,9 +46,9 @@ final class SyntaxParser implements Function<@NonNull String, @NonNull LinkedHas
             .asPredicate();
 
     @Override
-    public @NonNull LinkedHashMap<@NonNull String, @NonNull SyntaxFragment> apply(final @NonNull String syntax) {
+    public @NonNull List<@NonNull SyntaxFragment> apply(final @NonNull String syntax) {
         final StringTokenizer stringTokenizer = new StringTokenizer(syntax, " ");
-        final LinkedHashMap<String, SyntaxFragment> map = new LinkedHashMap<>();
+        final List<SyntaxFragment> syntaxFragments = new ArrayList<>();
         while (stringTokenizer.hasMoreTokens()) {
             final String token = stringTokenizer.nextToken();
             String major;
@@ -70,9 +69,9 @@ final class SyntaxParser implements Function<@NonNull String, @NonNull LinkedHas
             } else {
                 throw new IllegalArgumentException(String.format("Unrecognizable syntax token '%s'", syntax));
             }
-            map.put(major, new SyntaxFragment(major, minor, mode));
+            syntaxFragments.add(new SyntaxFragment(major, minor, mode));
         }
-        return map;
+        return syntaxFragments;
     }
 
 }


### PR DESCRIPTION
When registering a command such as this:
```java
    @CommandMethod("train ticket <ticket>")
    private void commandGiveTicket(
              final CommandSender sender,
              final @Argument("ticket") String ticketName
    ) {
    }
```

This caused a weird situation where the ticketName argument was bound to the first ticket literal, rather than the second. This broke some things when you had other literals defined on the same level. I tracked it down to how the syntax fragments are parsed, which used a LinkedHashMap. This is not correct, since literals can repeat as argument names. Quite common to do this.

This commit replaces that with a List<SyntaxFragment> and a simple lookup function which only looks for arguments, skipping literals entirely. Literals should never match with @Argument parameters of the method.