### PR TITLE
Additional tests for ambiguous command registration

### DIFF
--- a/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
@@ -291,12 +291,32 @@ class CommandTreeTest {
 
     @Test
     void testAmbiguousNodes() {
+        // Call newTree(); after each time we leave the Tree in an invalid state
         manager.command(manager.commandBuilder("ambiguous")
                 .argument(StringArgument.of("string"))
         );
         Assertions.assertThrows(AmbiguousNodeException.class, () ->
                 manager.command(manager.commandBuilder("ambiguous")
                         .argument(IntegerArgument.of("integer"))));
+        newTree();
+
+        manager.command(manager.commandBuilder("ambiguous")
+                .argument(StringArgument.of("string"))
+        );
+        Assertions.assertThrows(AmbiguousNodeException.class, () ->
+                manager.command(manager.commandBuilder("ambiguous")
+                        .literal("literal")));
+        newTree();
+
+        manager.command(manager.commandBuilder("ambiguous")
+                .literal("literal")
+        );
+        manager.command(manager.commandBuilder("ambiguous")
+                .literal("literal2"));
+        Assertions.assertThrows(AmbiguousNodeException.class, () ->
+                manager.command(manager.commandBuilder("ambiguous")
+                        .argument(IntegerArgument.of("integer"))));
+        newTree();
     }
 
     @Test


### PR DESCRIPTION
Add tests to cover more scenarios when we want an `AmbiguousNodeException` to be thrown.
Also reset the command tree after tests where we leave it in an invalid state.