### PR TITLE
Fix partial command suggestions when using a suggestion provider

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringArgument.java
@@ -306,14 +306,6 @@ public final class StringArgument<C> extends CommandArgument<C, String> {
             }
 
             if (this.stringMode == StringMode.SINGLE) {
-                if (commandContext.isSuggestions()) {
-                    final List<String> suggestions = this.suggestionsProvider.apply(commandContext, inputQueue.peek());
-                    if (!suggestions.isEmpty() && !suggestions.contains(input)) {
-                        return ArgumentParseResult.failure(new IllegalArgumentException(
-                                String.format("'%s' is not one of: %s", input, String.join(", ", suggestions))
-                        ));
-                    }
-                }
                 inputQueue.remove();
                 return ArgumentParseResult.success(input);
             } else if (this.stringMode == StringMode.QUOTED) {


### PR DESCRIPTION
This addresses issue https://github.com/Incendo/cloud/issues/144 and possibly further completes https://github.com/Incendo/cloud/pull/122

Fixes suggestions (using a suggestion provider) not showing up while typing because the argument is parsed. Adds a new test which strictly evaluates all the possible behaviors.

Changed the way getSuggestions() works for dynamic arguments. When it tries to parse the command input, it then checks if there are other inputs remaining in the queue, and only then will it recursively go deeper into the command. Now a space needs to be typed in order to view the suggestions a level deeper.

This makes sure suggestion 'pineapple' shows up when the user types 'pine'.

After the parse attempt, it may have consumed the full command queue. To still have proper valid suggestions, the original command queue from before parsing is restored. Otherwise the command suggestion processor glitches out.

<details>
<summary>No longer relevant</summary>
**Important change**: This makes it impossible for suggestion providers/parsers to produce suggestions that do not match user input. For example, when the user types:
`/command he`

It can show suggestions 'help', 'hello' and 'hey', but 'usage' will not be a possible suggestion. If you try to include it in the suggestion provider anyway, it will be filtered as part of post-processing.

For similar reasons, it adds a (possibly) unneeded performance overhead because of filtering the suggestions. In some cases (such as NumberArgument) this is useless.

I've considered adding an extra property ('isSuggestionsFiltered()') to the ArgumentParser, however, I've noticed that everywhere a BiFunction is used for the suggestion provider. I would have to change that to an interface with a suggest() function to add it there. This would break existing API compatibility, so I have not included such changes here.

If changing BiFunction -> Interface and adding 'isSuggestionsFiltered() default true' function is desired, I will add that as well to this PR.
</details>