### PR TITLE
Rename CommandContext getOrDefault to getorSupplyDefault

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/context/CommandContext.java
+++ b/cloud-core/src/main/java/cloud/commandframework/context/CommandContext.java
@@ -248,7 +248,7 @@ public final class CommandContext<C> {
      * @return Argument, or supplied default value
      * @since 1.2.0
      */
-    public <T> @Nullable T getOrDefault(
+    public <T> @Nullable T getOrSupplyDefault(
             final @NonNull String key,
             final @NonNull Supplier<@Nullable T> defaultSupplier
     ) {


### PR DESCRIPTION
A method was added to CommandContext to also allow a supplier to supply a value. However, this caused an ambiguous function situation when called with e.g. _null_. The other getOrDefault(key, value) allows for a nullable value, but when the supplier is null, an NPE is thrown.

Up to you whether you find this important enough of an issue. I just had a dependency of cloud suddenly throwing errors only to find out about this change :)

Workaround fix is doing `getOrDefault(key, (Object) null)`