### PR TITLE
✨ Improve Bukkit command registration logic

### DIFF
--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitPluginRegistrationHandler.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitPluginRegistrationHandler.java
@@ -93,12 +93,12 @@ public class BukkitPluginRegistrationHandler<C> implements CommandRegistrationHa
             final String namespacedAlias = this.getNamespacedLabel(alias);
 
             this.recognizedAliases.add(namespacedAlias);
-            if (!this.bukkitCommands.containsKey(alias)) {
+            if (!this.bukkitCommandOrAliasExists(alias)) {
                 this.recognizedAliases.add(alias);
             }
 
             if (this.bukkitCommandManager.getSplitAliases()) {
-                if (this.bukkitCommands.containsKey(alias)) {
+                if (this.bukkitCommandOrAliasExists(alias)) {
                     this.registerExternal(namespacedAlias, command, bukkitCommand);
                 } else {
                     this.registerExternal(namespacedAlias, command, bukkitCommand);
@@ -107,7 +107,7 @@ public class BukkitPluginRegistrationHandler<C> implements CommandRegistrationHa
             }
         }
 
-        if (!this.bukkitCommands.containsKey(label)) {
+        if (!this.bukkitCommandExists(label)) {
             this.recognizedAliases.add(label);
             this.registerExternal(label, command, bukkitCommand);
         }
@@ -143,6 +143,30 @@ public class BukkitPluginRegistrationHandler<C> implements CommandRegistrationHa
             final @NonNull Command<?> command,
             final @NonNull BukkitCommand<C> bukkitCommand
     ) {
+    }
+
+    /**
+     * Returns true if a command exists in the Bukkit command map, and is not an alias.
+     *
+     * @param commandLabel label to check
+     * @return whether the command exists and is not an alias
+     */
+    private boolean bukkitCommandExists(final String commandLabel) {
+        final org.bukkit.command.Command existingCommand = this.bukkitCommands.get(commandLabel);
+        if (existingCommand == null) {
+            return false;
+        }
+        return existingCommand.getLabel().equals(commandLabel);
+    }
+
+    /**
+     * Returns true if a command exists in the Bukkit command map, whether or not it is an alias.
+     *
+     * @param commandLabel label to check
+     * @return whether the command exists
+     */
+    private boolean bukkitCommandOrAliasExists(final String commandLabel) {
+        return this.bukkitCommands.containsKey(commandLabel);
     }
 
 }


### PR DESCRIPTION
This fixes an inconsistency between the aliases we recognize as registered, and the aliases Bukkit actually registered for us.

When a new command is registered, if a command with that name already exists, Bukkit will not register the new command, ie the existing command gets priority.
However, if the already existing command is an alias, it will replaced by the new command.
Also, if the new command is itself an alias, it will never get priority over an existing alias or command.