### PR TITLE
✨ Add a ManagerSetting to override existing commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   handled using `CommandManager#registerExceptionHandler`, similar to `NoSuchCommandException`, `ArgumentParseException`, etc.
  - Added registration state to command managers
  - Added ALLOW_UNSAFE_REGISTRATION ManagerSetting to disable state checks when registering commands
+ - Added OVERRIDE_EXISTING_COMMANDS ManagerSetting to allow for overriding of existing commands on supported platforms
  
 ### Changed
  - Allow for use of `@Completions` annotation with argument types other than String

--- a/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
@@ -870,7 +870,14 @@ public abstract class CommandManager<C> {
          *
          * @since 1.2.0
          */
-        ALLOW_UNSAFE_REGISTRATION
+        ALLOW_UNSAFE_REGISTRATION,
+
+        /**
+         * Enables overriding of existing commands on supported platforms.
+         *
+         * @since 1.2.0
+         */
+        OVERRIDE_EXISTING_COMMANDS
     }
 
     /**

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitPluginRegistrationHandler.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitPluginRegistrationHandler.java
@@ -24,6 +24,7 @@
 package cloud.commandframework.bukkit;
 
 import cloud.commandframework.Command;
+import cloud.commandframework.CommandManager;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.StaticArgument;
 import cloud.commandframework.internal.CommandRegistrationHandler;
@@ -88,6 +89,11 @@ public class BukkitPluginRegistrationHandler<C> implements CommandRegistrationHa
                 (CommandArgument<C, ?>) commandArgument,
                 this.bukkitCommandManager
         );
+
+        if (this.bukkitCommandManager.getSetting(CommandManager.ManagerSettings.OVERRIDE_EXISTING_COMMANDS)) {
+            this.bukkitCommands.remove(label);
+            aliases.forEach(alias -> this.bukkitCommands.remove(alias));
+        }
 
         for (final String alias : aliases) {
             final String namespacedAlias = this.getNamespacedLabel(alias);


### PR DESCRIPTION
Adds a setting to override existing commands. On Bukkit, this allows for forcefully registering commands, even when another plugin has already registered one with that name.

The Bukkit command map in particular has a separate entry for each command label/alias, and the namespaced variants are their own entry in the command map as well. Because of this, we can safely remove commands from the map to replace with our own, knowing the removed commands will still be accessible under the namespace of the plugin that registered them, as well as under any aliases which we have not explicitly removed.

This means: In the case another plugin, say Essentials owns the command `/msg` with alias `/message`.
If we remove `/msg` from the command map, the original command will still be accessible through `/essentials:msg`, `/message`, and `/essentials:message`.

Ideally this could be a per-command setting in the command meta, but something like that should probably wait for #152 to be merged. Allowing this to be set per-command in the future is not necessarily incompatible with adding the ManagerSetting, although it could end up being confusing if we have two methods to accomplish the same thing (one global and one per command)