### PR TITLE
Fix command argument not accepting characters _ and -

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/arguments/CommandArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/CommandArgument.java
@@ -54,7 +54,7 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>> 
     /**
      * Pattern for command argument names
      */
-    private static final Pattern NAME_PATTERN = Pattern.compile("[A-Za-z0-9]+");
+    private static final Pattern NAME_PATTERN = Pattern.compile("[A-Za-z0-9\\-_]+");
 
     /**
      * Indicates whether or not the argument is required


### PR DESCRIPTION
I discovered this while working on some code, but strangely, despite the fact I'm using - and _ in the code it has caused no errors to be thrown. Might be this syntax isn't enforced, in any case, it's wrong.