### PR TITLE
Add predicate command filter option to the cloud help system

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
@@ -73,6 +73,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * The manager is responsible for command registration, parsing delegation, etc.
@@ -753,13 +754,30 @@ public abstract class CommandManager<C> {
 
     /**
      * Get a command help handler instance. This can be used to assist in the production
-     * of command help menus, etc.
+     * of command help menus, etc. This command help handler instance will display
+     * all commands registered in this command manager.
      *
      * @return Command help handler. A new instance will be created
      *         each time this method is called.
      */
     public final @NonNull CommandHelpHandler<C> getCommandHelpHandler() {
-        return new CommandHelpHandler<>(this);
+        return new CommandHelpHandler<>(this, cmd -> true);
+    }
+
+    /**
+     * Get a command help handler instance. This can be used to assist in the production
+     * of command help menus, etc. A predicate can be specified to filter what commands
+     * registered in this command manager are visible in the help menu.
+     *
+     * @param commandPredicate Predicate that filters what commands are displayed in
+     *                         the help menu.
+     * @return Command help handler. A new instance will be created
+     *         each time this method is called.
+     */
+    public final @NonNull CommandHelpHandler<C> getCommandHelpHandler(
+            final @NonNull Predicate<Command<C>> commandPredicate
+    ) {
+        return new CommandHelpHandler<>(this, commandPredicate);
     }
 
     /**

--- a/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/MinecraftHelp.java
+++ b/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/MinecraftHelp.java
@@ -23,6 +23,7 @@
 //
 package cloud.commandframework.minecraft.extras;
 
+import cloud.commandframework.Command;
 import cloud.commandframework.CommandComponent;
 import cloud.commandframework.CommandHelpHandler;
 import cloud.commandframework.CommandManager;
@@ -44,6 +45,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
+import java.util.function.Predicate;
 
 /**
  * Opinionated extension of {@link CommandHelpHandler} for Minecraft
@@ -86,6 +88,7 @@ public final class MinecraftHelp<C> {
     private final String commandPrefix;
     private final Map<String, String> messageMap = new HashMap<>();
 
+    private Predicate<Command<C>> commandFilter = c -> true;
     private BiFunction<C, String, String> messageProvider = (sender, key) -> this.messageMap.get(key);
     private HelpColors colors = DEFAULT_HELP_COLORS;
     private int headerFooterLength = DEFAULT_HEADER_FOOTER_LENGTH;
@@ -149,6 +152,17 @@ public final class MinecraftHelp<C> {
      */
     public @NonNull Audience getAudience(final @NonNull C sender) {
         return this.audienceProvider.apply(sender);
+    }
+
+    /**
+     * Sets a filter for what commands are visible inside the help menu.
+     * When the {@link Predicate} tests <i>true</i>, then the command
+     * is included in the listings.
+     *
+     * @param commandPredicate Predicate to filter commands by
+     */
+    public void setCommandFilter(final @NonNull Predicate<Command<C>> commandPredicate) {
+        this.commandFilter = commandPredicate;
     }
 
     /**
@@ -241,7 +255,7 @@ public final class MinecraftHelp<C> {
                 recipient,
                 query,
                 page,
-                this.commandManager.getCommandHelpHandler().queryHelp(recipient, query)
+                this.commandManager.getCommandHelpHandler(this.commandFilter).queryHelp(recipient, query)
         );
     }
 


### PR DESCRIPTION
Can now easily create MinecraftHelp (or other-) help menus for only a portion of the commands registered in the command manager. That way, multiple help commands can be registered.