### PR TITLE
Register JDA parsers

### DIFF
--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/JDACommandManager.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/JDACommandManager.java
@@ -27,14 +27,21 @@ import cloud.commandframework.CommandManager;
 import cloud.commandframework.CommandTree;
 import cloud.commandframework.execution.CommandExecutionCoordinator;
 import cloud.commandframework.internal.CommandRegistrationHandler;
+import cloud.commandframework.jda.parsers.ChannelArgument;
+import cloud.commandframework.jda.parsers.UserArgument;
 import cloud.commandframework.meta.CommandMeta;
 import cloud.commandframework.meta.SimpleCommandMeta;
+import io.leangen.geantyref.TypeToken;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -94,6 +101,16 @@ public class JDACommandManager<C> extends CommandManager<C> {
 
         /* Register JDA Preprocessor */
         this.registerCommandPreProcessor(new JDACommandPreprocessor<>(this));
+
+        /* Register JDA Parsers */
+        this.getParserRegistry().registerParserSupplier(TypeToken.get(User.class), parserParameters ->
+                new UserArgument.UserParser<>(
+                        new HashSet<>(Arrays.asList(UserArgument.ParserMode.values()))
+                ));
+        this.getParserRegistry().registerParserSupplier(TypeToken.get(MessageChannel.class), parserParameters ->
+                new ChannelArgument.MessageParser<>(
+                        new HashSet<>(Arrays.asList(ChannelArgument.ParserMode.values()))
+                ));
     }
 
     /**

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/ChannelArgument.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/ChannelArgument.java
@@ -34,9 +34,10 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Queue;
+import java.util.Set;
 
 /**
  * Command Argument for {@link MessageChannel}
@@ -46,11 +47,11 @@ import java.util.Queue;
 @SuppressWarnings("unused")
 public final class ChannelArgument<C> extends CommandArgument<C, MessageChannel> {
 
-    private final List<ParserMode> modes;
+    private final Set<ParserMode> modes;
 
     private ChannelArgument(
             final boolean required, final @NonNull String name,
-            final @NonNull List<ParserMode> modes
+            final @NonNull Set<ParserMode> modes
     ) {
         super(required, name, new MessageParser<>(modes), MessageChannel.class);
         this.modes = modes;
@@ -94,7 +95,7 @@ public final class ChannelArgument<C> extends CommandArgument<C, MessageChannel>
      *
      * @return List of Modes
      */
-    public @NotNull List<ParserMode> getModes() {
+    public @NotNull Set<ParserMode> getModes() {
         return modes;
     }
 
@@ -108,7 +109,7 @@ public final class ChannelArgument<C> extends CommandArgument<C, MessageChannel>
 
     public static final class Builder<C> extends CommandArgument.Builder<C, MessageChannel> {
 
-        private List<ParserMode> modes = new ArrayList<>();
+        private Set<ParserMode> modes = new HashSet<>();
 
         private Builder(final @NonNull String name) {
             super(MessageChannel.class, name);
@@ -120,7 +121,7 @@ public final class ChannelArgument<C> extends CommandArgument<C, MessageChannel>
          * @param modes List of Modes
          * @return Builder instance
          */
-        public @NonNull Builder<C> withParsers(final @NonNull List<ParserMode> modes) {
+        public @NonNull Builder<C> withParsers(final @NonNull Set<ParserMode> modes) {
             this.modes = modes;
             return this;
         }
@@ -140,9 +141,14 @@ public final class ChannelArgument<C> extends CommandArgument<C, MessageChannel>
 
     public static final class MessageParser<C> implements ArgumentParser<C, MessageChannel> {
 
-        private final List<ParserMode> modes;
+        private final Set<ParserMode> modes;
 
-        private MessageParser(final @NonNull List<ParserMode> modes) {
+        /**
+         * Construct a new argument parser for {@link MessageChannel}
+         *
+         * @param modes List of parsing modes to use when parsing
+         */
+        public MessageParser(final @NonNull Set<ParserMode> modes) {
             this.modes = modes;
         }
 

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/UserArgument.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/UserArgument.java
@@ -154,7 +154,12 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
 
         private final Set<ParserMode> modes;
 
-        private UserParser(final @NonNull Set<ParserMode> modes) {
+        /**
+         * Construct a new argument parser for {@link User}
+         *
+         * @param modes List of parsing modes to use when parsing
+         */
+        public UserParser(final @NonNull Set<ParserMode> modes) {
             this.modes = modes;
         }
 


### PR DESCRIPTION
This PR registers the `MessageChannel` and `User` argument types for JDA. I also changed a few `List` types to `Set` for storing the active parser modes in `ChannelArgument.java` to match `UserArgument.java`