### PR TITLE
JDA argument parser fixes

### DIFF
--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/UserArgument.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/UserArgument.java
@@ -158,8 +158,13 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
          * Construct a new argument parser for {@link User}
          *
          * @param modes List of parsing modes to use when parsing
+         * @throws java.lang.IllegalStateException If no parsing modes were provided
          */
         public UserParser(final @NonNull Set<ParserMode> modes) {
+            if (modes.isEmpty()) {
+                throw new IllegalArgumentException("At least one parsing mode is required");
+            }
+
             this.modes = modes;
         }
 
@@ -180,7 +185,7 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
             Exception exception = null;
 
             if (modes.contains(ParserMode.MENTION)) {
-                if (input.endsWith(">") || modes.size() == 1) {
+                if (input.startsWith("<@") && input.endsWith(">")) {
                     final String id;
                     if (input.startsWith("<@!")) {
                         id = input.substring(3, input.length() - 1);
@@ -195,6 +200,10 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
                     } catch (final UserNotFoundParseException | NumberFormatException e) {
                         exception = e;
                     }
+                } else {
+                    exception = new IllegalArgumentException(
+                            String.format("Input '%s' is not a user mention.", input)
+                    );
                 }
             }
 

--- a/examples/example-jda/src/main/java/cloud/commandframework/examples/jda/CustomUser.java
+++ b/examples/example-jda/src/main/java/cloud/commandframework/examples/jda/CustomUser.java
@@ -25,22 +25,42 @@ package cloud.commandframework.examples.jda;
 
 import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Optional;
 
 public abstract class CustomUser {
 
+    private final MessageReceivedEvent event;
     private final User user;
     private final MessageChannel channel;
 
     /**
      * Construct a user
      *
+     * @param event   The message received event
      * @param user    Sending user
      * @param channel Channel that the message was sent in
      */
-    protected CustomUser(final @NonNull User user, final @NonNull MessageChannel channel) {
+    protected CustomUser(
+            final @Nullable MessageReceivedEvent event,
+            final @NonNull User user,
+            final @NonNull MessageChannel channel
+    ) {
+        this.event = event;
         this.user = user;
         this.channel = channel;
+    }
+
+    /**
+     * Get the message received event
+     *
+     * @return Optional of the message received event
+     */
+    public final @NonNull Optional<MessageReceivedEvent> getEvent() {
+        return Optional.ofNullable(this.event);
     }
 
     /**

--- a/examples/example-jda/src/main/java/cloud/commandframework/examples/jda/ExampleBot.java
+++ b/examples/example-jda/src/main/java/cloud/commandframework/examples/jda/ExampleBot.java
@@ -35,6 +35,7 @@ import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.utils.ChunkingFilter;
 import net.dv8tion.jda.api.utils.MemberCachePolicy;
@@ -72,27 +73,30 @@ public final class ExampleBot {
                 (sender, permission) -> permissionRegistry.hasPermission(sender.getUser().getIdLong(), permission),
                 CommandExecutionCoordinator.simpleCoordinator(),
                 sender -> {
+                    MessageReceivedEvent event = sender.getEvent().orElse(null);
+
                     if (sender instanceof JDAPrivateSender) {
                         JDAPrivateSender jdaPrivateSender = (JDAPrivateSender) sender;
-                        return new PrivateUser(jdaPrivateSender.getUser(), jdaPrivateSender.getPrivateChannel());
+                        return new PrivateUser(event, jdaPrivateSender.getUser(), jdaPrivateSender.getPrivateChannel());
                     }
 
                     if (sender instanceof JDAGuildSender) {
                         JDAGuildSender jdaGuildSender = (JDAGuildSender) sender;
-                        return new GuildUser(jdaGuildSender.getMember(), jdaGuildSender.getTextChannel());
+                        return new GuildUser(event, jdaGuildSender.getMember(), jdaGuildSender.getTextChannel());
                     }
 
                     throw new UnsupportedOperationException();
                 },
                 user -> {
+                    MessageReceivedEvent event = user.getEvent().orElse(null);
                     if (user instanceof PrivateUser) {
                         PrivateUser privateUser = (PrivateUser) user;
-                        return new JDAPrivateSender(null, privateUser.getUser(), privateUser.getPrivateChannel());
+                        return new JDAPrivateSender(event, privateUser.getUser(), privateUser.getPrivateChannel());
                     }
 
                     if (user instanceof GuildUser) {
                         GuildUser guildUser = (GuildUser) user;
-                        return new JDAGuildSender(null, guildUser.getMember(), guildUser.getTextChannel());
+                        return new JDAGuildSender(event, guildUser.getMember(), guildUser.getTextChannel());
                     }
 
                     throw new UnsupportedOperationException();

--- a/examples/example-jda/src/main/java/cloud/commandframework/examples/jda/GuildUser.java
+++ b/examples/example-jda/src/main/java/cloud/commandframework/examples/jda/GuildUser.java
@@ -25,7 +25,9 @@ package cloud.commandframework.examples.jda;
 
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class GuildUser extends CustomUser {
 
@@ -35,11 +37,12 @@ public final class GuildUser extends CustomUser {
     /**
      * Construct a Guild user
      *
+     * @param event   The message received event
      * @param member  Guild member that sent the message
      * @param channel Text channel that the message was sent in
      */
-    public GuildUser(final @NonNull Member member, final @NonNull TextChannel channel) {
-        super(member.getUser(), channel);
+    public GuildUser(final @Nullable MessageReceivedEvent event, final @NonNull Member member, final @NonNull TextChannel channel) {
+        super(event, member.getUser(), channel);
         this.member = member;
         this.channel = channel;
     }

--- a/examples/example-jda/src/main/java/cloud/commandframework/examples/jda/PrivateUser.java
+++ b/examples/example-jda/src/main/java/cloud/commandframework/examples/jda/PrivateUser.java
@@ -25,7 +25,9 @@ package cloud.commandframework.examples.jda;
 
 import net.dv8tion.jda.api.entities.PrivateChannel;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class PrivateUser extends CustomUser {
 
@@ -34,11 +36,12 @@ public final class PrivateUser extends CustomUser {
     /**
      * Construct a Private user
      *
+     * @param event   The message received event
      * @param user    User that sent the message
      * @param channel Text channel that the message was sent in
      */
-    public PrivateUser(final @NonNull User user, final @NonNull PrivateChannel channel) {
-        super(user, channel);
+    public PrivateUser(final @Nullable MessageReceivedEvent event, final @NonNull User user, final @NonNull PrivateChannel channel) {
+        super(event, user, channel);
         this.privateChannel = channel;
     }
 


### PR DESCRIPTION
## Fix mentioned user argument parsing if a mention is not given
If only `ParserMode.MENTION` was set as a parsing mode, the initial check for `input.endsWith(">")` would be bypassed and the input would begin to be parsed like a mention. If the input was less than three characters long then the `substring` calls would give a very ambiguous error along the lines of `begin 2, end X-1, length X`.

This PR fixes this issue by adding a check to make sure the input is an actual user mention. If the input isn't a mention then an exception will be set stating that the sender's input was not a user mention.

In addition, this PR also removes the `modes.size() == 1` check in the mention parser. I'm not quite sure why this was here, but I don't think that the input parsing check should be bypassed because only one parsing mode is specified. I settled on a check in the `UserParser` constructor to make sure that the parsing modes list isn't empty in order to ensure that at least one parser mode handles the input.

## Fix channel argument parsing
This part has similar changes to the user parser (in regards to making sure at least one parser mode is set and removing the `|| modes.size == 1` check), but it also has some important changes in it as well:

Because the channel argument parser relies on having access to the JDA guild instance, I added a check to make sure that the command context contains `MessageReceivedEvent`. In addition, I also added a check to make sure that the command was not issued from a DM because channels are only available in a guild.

## Add more context keys to JDA preprocessor
This portion adds a vital key (`MessageReceivedEvent`) and a few useful keys to be stored in the command context. Channel argument parsing relies on having `MessageReceivedEvent` available in the command context.

## Adjust JDA example to provide `MessageReceivedEvent` in commandSender mappers
Adding the `MessageReceivedEvent` to the command context requires `backwardsCommandSenderMapper` to be able to map a custom command sender into a `MessageReceivedEvent` successfully. If the [`event` parameter of `JDACommandSender`](https://github.com/Incendo/cloud/blob/547ecf98ffc81741644b0ddda4f013878ed2ce49/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/JDACommandSender.java#L53) is null then the [`JDA4CommandManager`'s `backwardsCommandSenderMapper` will throw a `IllegalStateException`](https://github.com/Incendo/cloud/blob/547ecf98ffc81741644b0ddda4f013878ed2ce49/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/JDA4CommandManager.java#L77). To avoid this, the `MessageReceivedEvent` must be stored in the custom command sender objects and then passed back into the `JDACommandSender` constructor when needed in the `backwardsCommandSenderMapper`.