### PR TITLE
Expose Command/Context from exceptions where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+ - Expose the Command which led to `InvalidCommandSenderException`s
+ - Expose the CommandContext which led to `CommandExecutionException`s
+
 ## [1.3.0] - 2020-12-18
 
 ### Added

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/MethodCommandExecutionHandler.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/MethodCommandExecutionHandler.java
@@ -120,7 +120,7 @@ class MethodCommandExecutionHandler<C> implements CommandExecutionHandler<C> {
         } catch (final Error e) {
             throw e;
         } catch (final Throwable throwable) {
-            throw new CommandExecutionException(throwable);
+            throw new CommandExecutionException(throwable, commandContext);
         }
     }
 

--- a/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
@@ -142,13 +142,13 @@ public final class CommandTree<C> {
         if (pair.getFirst() != null) {
             final Command<C> command = pair.getFirst();
             if (command.getSenderType().isPresent() && !command.getSenderType().get()
-                    .isAssignableFrom(commandContext
-                            .getSender()
-                            .getClass())) {
+                    .isAssignableFrom(commandContext.getSender().getClass())
+            ) {
                 return Pair.of(null, new InvalidCommandSenderException(
                         commandContext.getSender(),
                         command.getSenderType().get(),
-                        Collections.emptyList()
+                        new ArrayList<>(command.getArguments()),
+                        command
                 ));
             }
         }

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/CommandExecutionException.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/CommandExecutionException.java
@@ -23,7 +23,9 @@
 //
 package cloud.commandframework.exceptions;
 
+import cloud.commandframework.context.CommandContext;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Exception thrown when there is an exception during execution of a command handler
@@ -33,6 +35,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 public class CommandExecutionException extends IllegalArgumentException {
 
     private static final long serialVersionUID = -4785446899438294661L;
+    private final CommandContext<?> commandContext;
 
     /**
      * Exception thrown when there is an exception during execution of a command handler
@@ -40,7 +43,29 @@ public class CommandExecutionException extends IllegalArgumentException {
      * @param cause Exception thrown during the execution of a command handler
      */
     public CommandExecutionException(final @NonNull Throwable cause) {
+        this(cause, null);
+    }
+
+    /**
+     * Exception thrown when there is an exception during execution of a command handler
+     *
+     * @param cause Exception thrown during the execution of a command handler
+     * @param commandContext Command context
+     * @since 1.4.0
+     */
+    public CommandExecutionException(final @NonNull Throwable cause, final @Nullable CommandContext<?> commandContext) {
         super(cause);
+        this.commandContext = commandContext;
+    }
+
+    /**
+     * Get the CommandContext which led to this exception
+     *
+     * @return Command
+     * @since 1.4.0
+     */
+    public @Nullable CommandContext<?> getCommandContext() {
+        return this.commandContext;
     }
 
 }

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/InvalidCommandSenderException.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/InvalidCommandSenderException.java
@@ -23,8 +23,10 @@
 //
 package cloud.commandframework.exceptions;
 
+import cloud.commandframework.Command;
 import cloud.commandframework.arguments.CommandArgument;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
 
@@ -35,6 +37,7 @@ public final class InvalidCommandSenderException extends CommandParseException {
 
     private static final long serialVersionUID = 7372142477529875598L;
     private final Class<?> requiredSender;
+    private final Command<?> command;
 
     /**
      * Construct a new command parse exception
@@ -48,8 +51,27 @@ public final class InvalidCommandSenderException extends CommandParseException {
             final @NonNull Class<?> requiredSender,
             final @NonNull List<@NonNull CommandArgument<?, ?>> currentChain
     ) {
+        this(commandSender, requiredSender, currentChain, null);
+    }
+
+    /**
+     * Construct a new command parse exception
+     *
+     * @param commandSender  Sender who executed the command
+     * @param requiredSender The sender type that is required
+     * @param currentChain   Chain leading up to the exception
+     * @param command        Command
+     * @since 1.4.0
+     */
+    public InvalidCommandSenderException(
+            final @NonNull Object commandSender,
+            final @NonNull Class<?> requiredSender,
+            final @NonNull List<@NonNull CommandArgument<?, ?>> currentChain,
+            final @Nullable Command<?> command
+    ) {
         super(commandSender, currentChain);
         this.requiredSender = requiredSender;
+        this.command = command;
     }
 
     /**
@@ -68,6 +90,16 @@ public final class InvalidCommandSenderException extends CommandParseException {
                 getCommandSender().getClass().getSimpleName(),
                 requiredSender.getSimpleName()
         );
+    }
+
+    /**
+     * Get the Command which the sender is invalid for
+     *
+     * @return Command
+     * @since 1.4.0
+     */
+    public @Nullable Command<?> getCommand() {
+        return this.command;
     }
 
 }

--- a/cloud-core/src/main/java/cloud/commandframework/execution/AsynchronousCommandExecutionCoordinator.java
+++ b/cloud-core/src/main/java/cloud/commandframework/execution/AsynchronousCommandExecutionCoordinator.java
@@ -86,7 +86,7 @@ public final class AsynchronousCommandExecutionCoordinator<C> extends CommandExe
                 } catch (final CommandExecutionException exception) {
                     resultFuture.completeExceptionally(exception);
                 } catch (final Exception exception) {
-                    resultFuture.completeExceptionally(new CommandExecutionException(exception));
+                    resultFuture.completeExceptionally(new CommandExecutionException(exception, commandContext));
                 }
             }
         };

--- a/cloud-core/src/main/java/cloud/commandframework/execution/CommandExecutionCoordinator.java
+++ b/cloud-core/src/main/java/cloud/commandframework/execution/CommandExecutionCoordinator.java
@@ -122,7 +122,7 @@ public abstract class CommandExecutionCoordinator<C> {
                         } catch (final CommandExecutionException exception) {
                             completableFuture.completeExceptionally(exception);
                         } catch (final Exception exception) {
-                            completableFuture.completeExceptionally(new CommandExecutionException(exception));
+                            completableFuture.completeExceptionally(new CommandExecutionException(exception, commandContext));
                         }
                     }
                     completableFuture.complete(new CommandResult<>(commandContext));


### PR DESCRIPTION
This exposes the `Command` which caused the `InvalidCommandSenderException`, which can be useful for changing exception handling based on command meta, and also exposes the `CommandContext` leading up to `CommandExecutionException`s.