### PR TITLE
JDA: Fix webhook messages throwing NPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
  - Issue where suggestions were shown multiple times when using Brigadier ([#184](https://github.com/Incendo/cloud/pull/184))
  - Issue where the command manager was in the wrong state if no commands had been registered ([#196](https://github.com/Incendo/cloud/pull/196))
- - Issues with JDA ([#198](https://github.com/Incendo/cloud/pull/198)) ([#199](https://github.com/Incendo/cloud/pull/199))
+ - Issues with JDA ([#198](https://github.com/Incendo/cloud/pull/198)) ([#199](https://github.com/Incendo/cloud/pull/199)) ([#214](https://github.com/Incendo/cloud/pull/214))
  - Console suggestions for Bukkit
 
 ## [1.3.0] - 2020-12-18

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/JDACommandSender.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/JDACommandSender.java
@@ -66,7 +66,9 @@ public class JDACommandSender {
      * @return Constructed JDA Command Sender
      */
     public static @NonNull JDACommandSender of(final @NonNull MessageReceivedEvent event) {
-        if (event.isFromType(ChannelType.PRIVATE)) {
+        if (event.isWebhookMessage()) {
+            return new JDACommandSender(event, event.getAuthor(), event.getChannel());
+        } else if (event.isFromType(ChannelType.PRIVATE)) {
             return new JDAPrivateSender(event, event.getAuthor(), event.getPrivateChannel());
         }
 


### PR DESCRIPTION
Webhook messages would be constructed as `JDAGuildSender`, which calls `Objects.requireNonNull(event.getMember())` however the JDA documentation states that the `getMember()` method will "be null in case of Message being received in a PrivateChannel or isWebhookMessage() returning true." This PR makes it so if the message is a webhook message, a generic `JDACommandSender` instance will be constructed instead of a `JDAGuildSender` which doesn't require calling `getMember()`