### PR TITLE
JDA: Add isolation levels to user argument

### DIFF
--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/JDACommandManager.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/JDACommandManager.java
@@ -105,7 +105,8 @@ public class JDACommandManager<C> extends CommandManager<C> {
         /* Register JDA Parsers */
         this.getParserRegistry().registerParserSupplier(TypeToken.get(User.class), parserParameters ->
                 new UserArgument.UserParser<>(
-                        new HashSet<>(Arrays.asList(UserArgument.ParserMode.values()))
+                        new HashSet<>(Arrays.asList(UserArgument.ParserMode.values())),
+                        UserArgument.Isolation.GUILD
                 ));
         this.getParserRegistry().registerParserSupplier(TypeToken.get(MessageChannel.class), parserParameters ->
                 new ChannelArgument.MessageParser<>(

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/JDACommandManager.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/JDACommandManager.java
@@ -106,7 +106,7 @@ public class JDACommandManager<C> extends CommandManager<C> {
         this.getParserRegistry().registerParserSupplier(TypeToken.get(User.class), parserParameters ->
                 new UserArgument.UserParser<>(
                         new HashSet<>(Arrays.asList(UserArgument.ParserMode.values())),
-                        UserArgument.Isolation.GUILD
+                        UserArgument.Isolation.GLOBAL
                 ));
         this.getParserRegistry().registerParserSupplier(TypeToken.get(MessageChannel.class), parserParameters ->
                 new ChannelArgument.MessageParser<>(

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/UserArgument.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/UserArgument.java
@@ -121,7 +121,7 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
     public static final class Builder<C> extends CommandArgument.Builder<C, User> {
 
         private Set<ParserMode> modes = new HashSet<>();
-        private Isolation isolationLevel = Isolation.GUILD;
+        private Isolation isolationLevel = Isolation.GLOBAL;
 
         private Builder(final @NonNull String name) {
             super(User.class, name);

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/UserArgument.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/UserArgument.java
@@ -182,6 +182,18 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
          * Construct a new argument parser for {@link User}
          *
          * @param modes List of parsing modes to use when parsing
+         * @throws java.lang.IllegalArgumentException If no parsing modes were provided
+         * @deprecated Use {@link #UserParser(Set, Isolation)} instead.
+         */
+        @Deprecated
+        public UserParser(final @NonNull Set<ParserMode> modes) {
+            this(modes, Isolation.GLOBAL);
+        }
+
+        /**
+         * Construct a new argument parser for {@link User}
+         *
+         * @param modes          List of parsing modes to use when parsing
          * @param isolationLevel Level of isolation to maintain when parsing
          * @throws java.lang.IllegalArgumentException If no parsing modes were provided
          */


### PR DESCRIPTION
Currently, when a user argument is parsed, cloud will use the `JDA` class's `getUsersByName()`/`getUserById()` method which attempts to fetch a user from anywhere that the bot can see. This means that if a user provides a name or ID for a user that is in a different guild, the bot may leak information about users in a different guild if the command handler does not check if the user is in the same guild that the command message was sent from. 

This PR adds two levels of isolation to this argument:
`GLOBAL` = the current functionality (any user the bot can see).
`GUILD` = only members in the same guild that the command was executed in.

Using the `GUILD` isolation with a command that is executed in a DM will only allow the author to specify themself for the user argument. 