### PR TITLE
fix tuple toArray implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
  - Deprecated old JDA UserParser that did not take an isolation parameter 
+ 
+### Fixed
+ - Tuple implementations now do not throw an error when using the toArray method
 
 ## [1.4.0] - 2021-01-16
 

--- a/cloud-core/src/main/java/cloud/commandframework/types/tuples/Quartet.java
+++ b/cloud-core/src/main/java/cloud/commandframework/types/tuples/Quartet.java
@@ -147,8 +147,8 @@ public class Quartet<U, V, W, X> implements Tuple {
         final Object[] array = new Object[4];
         array[0] = this.first;
         array[1] = this.second;
-        array[3] = this.third;
-        array[4] = this.fourth;
+        array[2] = this.third;
+        array[3] = this.fourth;
         return array;
     }
 

--- a/cloud-core/src/main/java/cloud/commandframework/types/tuples/Quintet.java
+++ b/cloud-core/src/main/java/cloud/commandframework/types/tuples/Quintet.java
@@ -164,9 +164,9 @@ public class Quintet<U, V, W, X, Y> implements Tuple {
         final Object[] array = new Object[5];
         array[0] = this.first;
         array[1] = this.second;
-        array[3] = this.third;
-        array[4] = this.fourth;
-        array[5] = this.fifth;
+        array[2] = this.third;
+        array[3] = this.fourth;
+        array[4] = this.fifth;
         return array;
     }
 

--- a/cloud-core/src/main/java/cloud/commandframework/types/tuples/Sextet.java
+++ b/cloud-core/src/main/java/cloud/commandframework/types/tuples/Sextet.java
@@ -183,10 +183,10 @@ public class Sextet<U, V, W, X, Y, Z> implements Tuple {
         final Object[] array = new Object[6];
         array[0] = this.first;
         array[1] = this.second;
-        array[3] = this.third;
-        array[4] = this.fourth;
-        array[5] = this.fifth;
-        array[6] = this.sixth;
+        array[2] = this.third;
+        array[3] = this.fourth;
+        array[4] = this.fifth;
+        array[5] = this.sixth;
         return array;
     }
 


### PR DESCRIPTION
Some tuple implementations had an incorrect toArray function where the constructed array had the wrong indexes used