### PR TITLE
Register Long parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  
 ### Fixed
  - Tuple implementations now do not throw an error when using the toArray method
+ - Argument parser for `long` types was not registered
 
 ## [1.4.0] - 2021-01-16
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/parser/StandardParserRegistry.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/parser/StandardParserRegistry.java
@@ -32,6 +32,7 @@ import cloud.commandframework.arguments.standard.DoubleArgument;
 import cloud.commandframework.arguments.standard.EnumArgument;
 import cloud.commandframework.arguments.standard.FloatArgument;
 import cloud.commandframework.arguments.standard.IntegerArgument;
+import cloud.commandframework.arguments.standard.LongArgument;
 import cloud.commandframework.arguments.standard.ShortArgument;
 import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.arguments.standard.StringArrayArgument;
@@ -108,6 +109,11 @@ public final class StandardParserRegistry<C> implements ParserRegistry<C> {
                 new IntegerArgument.IntegerParser<>(
                         (int) options.get(StandardParameters.RANGE_MIN, Integer.MIN_VALUE),
                         (int) options.get(StandardParameters.RANGE_MAX, Integer.MAX_VALUE)
+                ));
+        this.registerParserSupplier(TypeToken.get(Long.class), options ->
+                new LongArgument.LongParser<>(
+                        (long) options.get(StandardParameters.RANGE_MIN, Long.MIN_VALUE),
+                        (long) options.get(StandardParameters.RANGE_MAX, Long.MAX_VALUE)
                 ));
         this.registerParserSupplier(TypeToken.get(Float.class), options ->
                 new FloatArgument.FloatParser<>(

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/LongArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/LongArgument.java
@@ -169,12 +169,18 @@ public final class LongArgument<C> extends CommandArgument<C, Long> {
 
     }
 
-    private static final class LongParser<C> implements ArgumentParser<C, Long> {
+    public static final class LongParser<C> implements ArgumentParser<C, Long> {
 
         private final long min;
         private final long max;
 
-        private LongParser(final long min, final long max) {
+        /**
+         * Construct a new long parser
+         *
+         * @param min Minimum acceptable value
+         * @param max Maximum acceptable value
+         */
+        public LongParser(final long min, final long max) {
             this.min = min;
             this.max = max;
         }


### PR DESCRIPTION
For some reason this parser wasn't registered and it was private. It seems to work fine so I registered it in the `StandardParserRegistry`. I'm also not sure whether to put this as a fix or an addition in the changelog. I've marked it as a fix but I can change it if desired.