### PR TITLE
Apply .trim() before .isEmpty() check to prevent 0-length splits

### DIFF
--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/CloudBukkitListener.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/CloudBukkitListener.java
@@ -44,7 +44,7 @@ final class CloudBukkitListener<C> implements Listener {
 
     @EventHandler
     void onTabCompletion(final @NonNull TabCompleteEvent event) {
-        if (event.getBuffer().isEmpty()) {
+        if (event.getBuffer().trim().isEmpty()) {
             return;
         }
 

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/AsyncCommandSuggestionsListener.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/AsyncCommandSuggestionsListener.java
@@ -43,7 +43,7 @@ final class AsyncCommandSuggestionsListener<C> implements Listener {
 
     @EventHandler
     void onTabCompletion(final @NonNull AsyncTabCompleteEvent event) {
-        if (event.getBuffer().isEmpty()) {
+        if (event.getBuffer().trim().isEmpty()) {
             return;
         }
 


### PR DESCRIPTION
Fixes an `ArrayIndexOutOfBoundsException` when `.split(" ")[0]` is called on a string containing only spaces.