### PR TITLE
Let ArgumentDescription#getDescription and #isEmpty have command sender

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/ArgumentDescription.java
+++ b/cloud-core/src/main/java/cloud/commandframework/ArgumentDescription.java
@@ -32,49 +32,54 @@ import static java.util.Objects.requireNonNull;
 /**
  * A description for a {@link CommandArgument}
  *
+ * @param <C> Command sender type
  * @since 1.4.0
  */
-public interface ArgumentDescription {
+public interface ArgumentDescription<C> {
 
     /**
      * Get an empty command description.
      *
+     * @param <C> Command sender type
      * @return Command description
      */
     @SuppressWarnings("deprecation")
-    static @NonNull ArgumentDescription empty() {
-        return Description.EMPTY;
+    static <C> @NonNull ArgumentDescription<C> empty() {
+        return Description.empty();
     }
 
     /**
      * Create a command description instance.
      *
+     * @param <C> Command sender type
      * @param string Command description
      * @return Created command description
      */
     @SuppressWarnings("deprecation")
-    static @NonNull ArgumentDescription of(final @NonNull String string) {
+    static <C> @NonNull ArgumentDescription<C> of(final @NonNull String string) {
         if (requireNonNull(string, "string").isEmpty()) {
-            return Description.EMPTY;
+            return Description.empty();
         } else {
-            return new Description(string);
+            return new Description<>(string);
         }
     }
 
     /**
      * Get the plain-text description.
      *
+     * @param sender Command sender
      * @return Command description
      */
-    @NonNull String getDescription();
+    @NonNull String getDescription(C sender);
 
     /**
      * Get whether or not this description contains contents.
      *
+     * @param sender Command sender
      * @return if this description is empty or not
      */
-    default boolean isEmpty() {
-        return this.getDescription().isEmpty();
+    default boolean isEmpty(final C sender) {
+        return this.getDescription(sender).isEmpty();
     }
 
 }

--- a/cloud-core/src/main/java/cloud/commandframework/Command.java
+++ b/cloud-core/src/main/java/cloud/commandframework/Command.java
@@ -159,7 +159,7 @@ public class Command<C> {
      */
     @Deprecated
     public Command(
-            final @NonNull Map<@NonNull CommandArgument<C, ?>, @NonNull Description> commandArguments,
+            final @NonNull Map<@NonNull CommandArgument<C, ?>, @NonNull Description<C>> commandArguments,
             final @NonNull CommandExecutionHandler<@NonNull C> commandExecutionHandler,
             final @Nullable Class<? extends C> senderType,
             final @NonNull CommandPermission commandPermission,
@@ -180,7 +180,7 @@ public class Command<C> {
      */
     @Deprecated
     public Command(
-            final @NonNull Map<@NonNull CommandArgument<C, ?>, @NonNull Description> commandArguments,
+            final @NonNull Map<@NonNull CommandArgument<C, ?>, @NonNull Description<C>> commandArguments,
             final @NonNull CommandExecutionHandler<@NonNull C> commandExecutionHandler,
             final @Nullable Class<? extends C> senderType,
             final @NonNull CommandMeta commandMeta
@@ -200,7 +200,7 @@ public class Command<C> {
      */
     @Deprecated
     public Command(
-            final @NonNull Map<@NonNull CommandArgument<C, ?>, @NonNull Description> commandArguments,
+            final @NonNull Map<@NonNull CommandArgument<C, ?>, @NonNull Description<C>> commandArguments,
             final @NonNull CommandExecutionHandler<@NonNull C> commandExecutionHandler,
             final @NonNull CommandPermission commandPermission,
             final @NonNull CommandMeta commandMeta
@@ -212,7 +212,7 @@ public class Command<C> {
     // Used for backwards-compatibility
     @SuppressWarnings("deprecation")
     private static <C> @NonNull List<@NonNull CommandComponent<C>> mapToComponents(
-            final @NonNull Map<@NonNull CommandArgument<C, ?>, @NonNull Description> commandArguments
+            final @NonNull Map<@NonNull CommandArgument<C, ?>, @NonNull Description<C>> commandArguments
     ) {
         return commandArguments.entrySet().stream()
                 .map(e -> CommandComponent.of(e.getKey(), e.getValue()))
@@ -235,10 +235,10 @@ public class Command<C> {
     public static <C> @NonNull Builder<C> newBuilder(
             final @NonNull String commandName,
             final @NonNull CommandMeta commandMeta,
-            final @NonNull Description description,
+            final @NonNull Description<C> description,
             final @NonNull String... aliases
     ) {
-        return newBuilder(commandName, commandMeta, (ArgumentDescription) description, aliases);
+        return newBuilder(commandName, commandMeta, (ArgumentDescription<C>) description, aliases);
     }
 
     /**
@@ -256,7 +256,7 @@ public class Command<C> {
     public static <C> @NonNull Builder<C> newBuilder(
             final @NonNull String commandName,
             final @NonNull CommandMeta commandMeta,
-            final @NonNull ArgumentDescription description,
+            final @NonNull ArgumentDescription<C> description,
             final @NonNull String... aliases
     ) {
         final List<CommandComponent<C>> commands = new ArrayList<>();
@@ -358,6 +358,7 @@ public class Command<C> {
     /**
      * Get the description for an argument
      *
+     * @param sender Command sender
      * @param argument Argument
      * @return Argument description
      * @throws IllegalArgumentException If the command argument does not exist
@@ -365,10 +366,10 @@ public class Command<C> {
      *             Use {@link #getArguments()} and search in that, instead.
      */
     @Deprecated
-    public @NonNull String getArgumentDescription(final @NonNull CommandArgument<C, ?> argument) {
+    public @NonNull String getArgumentDescription(final C sender, final @NonNull CommandArgument<C, ?> argument) {
         for (final CommandComponent<C> component : this.components) {
             if (component.getArgument().equals(argument)) {
-                return component.getArgumentDescription().getDescription();
+                return component.getArgumentDescription().getDescription(sender);
             }
         }
         throw new IllegalArgumentException("Command argument not found: " + argument);
@@ -542,7 +543,7 @@ public class Command<C> {
         @Deprecated
         public @NonNull Builder<C> literal(
                 final @NonNull String main,
-                final @NonNull Description description,
+                final @NonNull Description<C> description,
                 final @NonNull String... aliases
         ) {
             return this.argument(StaticArgument.of(main, aliases), description);
@@ -559,7 +560,7 @@ public class Command<C> {
          */
         public @NonNull Builder<C> literal(
                 final @NonNull String main,
-                final @NonNull ArgumentDescription description,
+                final @NonNull ArgumentDescription<C> description,
                 final @NonNull String... aliases
         ) {
             return this.argument(StaticArgument.of(main, aliases), description);
@@ -600,9 +601,9 @@ public class Command<C> {
         @Deprecated
         public <T> @NonNull Builder<C> argument(
                 final @NonNull CommandArgument<C, T> argument,
-                final @NonNull Description description
+                final @NonNull Description<C> description
         ) {
-            return this.argument(argument, (ArgumentDescription) description);
+            return this.argument(argument, (ArgumentDescription<C>) description);
         }
 
         /**
@@ -616,7 +617,7 @@ public class Command<C> {
          */
         public <T> @NonNull Builder<C> argument(
                 final @NonNull CommandArgument<C, T> argument,
-                final @NonNull ArgumentDescription description
+                final @NonNull ArgumentDescription<C> description
         ) {
             if (argument.isArgumentRegistered()) {
                 throw new IllegalArgumentException("The provided argument has already been associated with a command."
@@ -649,9 +650,9 @@ public class Command<C> {
         @Deprecated
         public <T> @NonNull Builder<C> argument(
                 final CommandArgument.@NonNull Builder<C, T> builder,
-                final @NonNull Description description
+                final @NonNull Description<C> description
         ) {
-            return this.argument(builder, (ArgumentDescription) description);
+            return this.argument(builder, (ArgumentDescription<C>) description);
         }
 
         /**
@@ -666,7 +667,7 @@ public class Command<C> {
          */
         public <T> @NonNull Builder<C> argument(
                 final CommandArgument.@NonNull Builder<C, T> builder,
-                final @NonNull ArgumentDescription description
+                final @NonNull ArgumentDescription<C> description
         ) {
             final List<CommandComponent<C>> commandComponents = new ArrayList<>(this.commandComponents);
             commandComponents.add(CommandComponent.of(builder.build(), description));
@@ -728,9 +729,9 @@ public class Command<C> {
                 final @NonNull String name,
                 final @NonNull Pair<@NonNull String, @NonNull String> names,
                 final @NonNull Pair<@NonNull Class<U>, @NonNull Class<V>> parserPair,
-                final @NonNull Description description
+                final @NonNull Description<C> description
         ) {
-            return this.argumentPair(name, names, parserPair, (ArgumentDescription) description);
+            return this.argumentPair(name, names, parserPair, (ArgumentDescription<C>) description);
         }
 
         /**
@@ -755,7 +756,7 @@ public class Command<C> {
                 final @NonNull String name,
                 final @NonNull Pair<@NonNull String, @NonNull String> names,
                 final @NonNull Pair<@NonNull Class<U>, @NonNull Class<V>> parserPair,
-                final @NonNull ArgumentDescription description
+                final @NonNull ArgumentDescription<C> description
         ) {
             if (this.commandManager == null) {
                 throw new IllegalStateException("This cannot be called from a command that has no command manager attached");
@@ -792,9 +793,9 @@ public class Command<C> {
                 final @NonNull Pair<String, String> names,
                 final @NonNull Pair<Class<U>, Class<V>> parserPair,
                 final @NonNull BiFunction<C, Pair<U, V>, O> mapper,
-                final @NonNull Description description
+                final @NonNull Description<C> description
         ) {
-            return this.argumentPair(name, outputType, names, parserPair, mapper, (ArgumentDescription) description);
+            return this.argumentPair(name, outputType, names, parserPair, mapper, (ArgumentDescription<C>) description);
         }
 
         /**
@@ -824,7 +825,7 @@ public class Command<C> {
                 final @NonNull Pair<String, String> names,
                 final @NonNull Pair<Class<U>, Class<V>> parserPair,
                 final @NonNull BiFunction<C, Pair<U, V>, O> mapper,
-                final @NonNull ArgumentDescription description
+                final @NonNull ArgumentDescription<C> description
         ) {
             if (this.commandManager == null) {
                 throw new IllegalStateException("This cannot be called from a command that has no command manager attached");
@@ -860,9 +861,9 @@ public class Command<C> {
                 final @NonNull String name,
                 final @NonNull Triplet<String, String, String> names,
                 final @NonNull Triplet<Class<U>, Class<V>, Class<W>> parserTriplet,
-                final @NonNull Description description
+                final @NonNull Description<C> description
         ) {
-            return this.argumentTriplet(name, names, parserTriplet, (ArgumentDescription) description);
+            return this.argumentTriplet(name, names, parserTriplet, (ArgumentDescription<C>) description);
         }
 
         /**
@@ -888,7 +889,7 @@ public class Command<C> {
                 final @NonNull String name,
                 final @NonNull Triplet<String, String, String> names,
                 final @NonNull Triplet<Class<U>, Class<V>, Class<W>> parserTriplet,
-                final @NonNull ArgumentDescription description
+                final @NonNull ArgumentDescription<C> description
         ) {
             if (this.commandManager == null) {
                 throw new IllegalStateException("This cannot be called from a command that has no command manager attached");
@@ -926,7 +927,7 @@ public class Command<C> {
                 final @NonNull Triplet<String, String, String> names,
                 final @NonNull Triplet<Class<U>, Class<V>, Class<W>> parserTriplet,
                 final @NonNull BiFunction<C, Triplet<U, V, W>, O> mapper,
-                final @NonNull Description description
+                final @NonNull Description<C> description
         ) {
             return this.argumentTriplet(
                     name,
@@ -934,7 +935,7 @@ public class Command<C> {
                     names,
                     parserTriplet,
                     mapper,
-                    (ArgumentDescription) description
+                    (ArgumentDescription<C>) description
             );
         }
 
@@ -966,7 +967,7 @@ public class Command<C> {
                 final @NonNull Triplet<String, String, String> names,
                 final @NonNull Triplet<Class<U>, Class<V>, Class<W>> parserTriplet,
                 final @NonNull BiFunction<C, Triplet<U, V, W>, O> mapper,
-                final @NonNull ArgumentDescription description
+                final @NonNull ArgumentDescription<C> description
         ) {
             if (this.commandManager == null) {
                 throw new IllegalStateException("This cannot be called from a command that has no command manager attached");

--- a/cloud-core/src/main/java/cloud/commandframework/CommandComponent.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandComponent.java
@@ -37,7 +37,7 @@ import java.util.Objects;
 public final class CommandComponent<C> {
 
     private final CommandArgument<C, ?> argument;
-    private final ArgumentDescription description;
+    private final ArgumentDescription<C> description;
 
     /**
      * Initializes a new CommandComponent
@@ -47,7 +47,7 @@ public final class CommandComponent<C> {
      */
     private CommandComponent(
             final @NonNull CommandArgument<C, ?> commandArgument,
-            final @NonNull ArgumentDescription commandDescription
+            final @NonNull ArgumentDescription<C> commandDescription
     ) {
         this.argument = commandArgument;
         this.description = commandDescription;
@@ -65,15 +65,16 @@ public final class CommandComponent<C> {
     /**
      * Gets the command component description
      *
+     * @param sender Command sender
      * @return command component description
      * @deprecated for removal since 1.4.0. Use {@link #getArgumentDescription()} instead.
      */
     @Deprecated
-    public @NonNull Description getDescription() {
+    public @NonNull Description<C> getDescription(final C sender) {
         if (this.description instanceof Description) {
-            return (Description) this.description;
+            return (Description<C>) this.description;
         } else {
-            return new Description(this.description.getDescription());
+            return new Description<>(this.description.getDescription(sender));
         }
     }
 
@@ -83,7 +84,7 @@ public final class CommandComponent<C> {
      * @return command component description
      * @since 1.4.0
      */
-    public @NonNull ArgumentDescription getArgumentDescription() {
+    public @NonNull ArgumentDescription<C> getArgumentDescription() {
         return this.description;
     }
 
@@ -123,7 +124,7 @@ public final class CommandComponent<C> {
     @Deprecated
     public static <C> @NonNull CommandComponent<C> of(
             final @NonNull CommandArgument<C, ?> commandArgument,
-            final @NonNull Description commandDescription
+            final @NonNull Description<C> commandDescription
     ) {
         return new CommandComponent<C>(commandArgument, commandDescription);
     }
@@ -138,7 +139,7 @@ public final class CommandComponent<C> {
      */
     public static <C> @NonNull CommandComponent<C> of(
             final @NonNull CommandArgument<C, ?> commandArgument,
-            final @NonNull ArgumentDescription commandDescription
+            final @NonNull ArgumentDescription<C> commandDescription
     ) {
         return new CommandComponent<C>(commandArgument, commandDescription);
     }

--- a/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
@@ -371,10 +371,10 @@ public abstract class CommandManager<C> {
     public Command.@NonNull Builder<C> commandBuilder(
             final @NonNull String name,
             final @NonNull Collection<String> aliases,
-            final @NonNull Description description,
+            final @NonNull Description<C> description,
             final @NonNull CommandMeta meta
     ) {
-        return commandBuilder(name, aliases, (ArgumentDescription) description, meta);
+        return commandBuilder(name, aliases, (ArgumentDescription<C>) description, meta);
     }
 
     /**
@@ -397,7 +397,7 @@ public abstract class CommandManager<C> {
     public Command.@NonNull Builder<C> commandBuilder(
             final @NonNull String name,
             final @NonNull Collection<String> aliases,
-            final @NonNull ArgumentDescription description,
+            final @NonNull ArgumentDescription<C> description,
             final @NonNull CommandMeta meta
     ) {
         return Command.<C>newBuilder(
@@ -460,10 +460,10 @@ public abstract class CommandManager<C> {
     public Command.@NonNull Builder<C> commandBuilder(
             final @NonNull String name,
             final @NonNull CommandMeta meta,
-            final @NonNull Description description,
+            final @NonNull Description<C> description,
             final @NonNull String... aliases
     ) {
-        return this.commandBuilder(name, meta, (ArgumentDescription) description, aliases);
+        return this.commandBuilder(name, meta, (ArgumentDescription<C>) description, aliases);
     }
 
     /**
@@ -486,7 +486,7 @@ public abstract class CommandManager<C> {
     public Command.@NonNull Builder<C> commandBuilder(
             final @NonNull String name,
             final @NonNull CommandMeta meta,
-            final @NonNull ArgumentDescription description,
+            final @NonNull ArgumentDescription<C> description,
             final @NonNull String... aliases
     ) {
         return Command.<C>newBuilder(
@@ -550,10 +550,10 @@ public abstract class CommandManager<C> {
     @Deprecated
     public Command.@NonNull Builder<C> commandBuilder(
             final @NonNull String name,
-            final @NonNull Description description,
+            final @NonNull Description<C> description,
             final @NonNull String... aliases
     ) {
-        return this.commandBuilder(name, (ArgumentDescription) description, aliases);
+        return this.commandBuilder(name, (ArgumentDescription<C>) description, aliases);
     }
 
     /**
@@ -578,7 +578,7 @@ public abstract class CommandManager<C> {
      */
     public Command.@NonNull Builder<C> commandBuilder(
             final @NonNull String name,
-            final @NonNull ArgumentDescription description,
+            final @NonNull ArgumentDescription<C> description,
             final @NonNull String... aliases
     ) {
         return Command.<C>newBuilder(

--- a/cloud-core/src/main/java/cloud/commandframework/Description.java
+++ b/cloud-core/src/main/java/cloud/commandframework/Description.java
@@ -29,15 +29,11 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 /**
  * {@link CommandArgument} description
  *
+ * @param <C> Command sender type
  * @deprecated to become package-private since 1.4.0. Use {@link ArgumentDescription} instead.
  */
 @Deprecated
-public final class Description implements ArgumentDescription {
-
-    /**
-     * Empty command description
-     */
-    static final Description EMPTY = new Description("");
+public final class Description<C> implements ArgumentDescription<C> {
 
     private final String description;
 
@@ -48,33 +44,36 @@ public final class Description implements ArgumentDescription {
     /**
      * Get an empty command description
      *
+     * @param <C> Command sender type
      * @return Command description
      * @deprecated for removal since 1.4.0. See {@link ArgumentDescription#empty()}
      */
     @Deprecated
-    public static @NonNull Description empty() {
-        return EMPTY;
+    public static <C> @NonNull Description<C> empty() {
+        return new Description<>("");
     }
 
     /**
      * Create a command description instance
      *
+     * @param <C> Command sender type
      * @param string Command description
      * @return Created command description
      * @deprecated for removal since 1.4.0. See {@link ArgumentDescription#of(String)}
      */
     @Deprecated
-    public static @NonNull Description of(final @NonNull String string) {
-        return new Description(string);
+    public static <C> @NonNull Description<C> of(final @NonNull String string) {
+        return new Description<>(string);
     }
 
     /**
      * Get the command description
      *
+     * @param sender Command sender
      * @return Command description
      */
     @Override
-    public @NonNull String getDescription() {
+    public @NonNull String getDescription(final C sender) {
         return this.description;
     }
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/CommandArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/CommandArgument.java
@@ -104,7 +104,7 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
     /**
      * A description that will be used when registering this argument if no override is provided.
      */
-    private final ArgumentDescription defaultDescription;
+    private final ArgumentDescription<C> defaultDescription;
 
     /**
      * Whether or not the argument has been used before
@@ -133,7 +133,7 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
             final @NonNull String defaultValue,
             final @NonNull TypeToken<T> valueType,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription,
+            final @NonNull ArgumentDescription<C> defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>, @NonNull Queue<@NonNull String>,
                     @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
     ) {
@@ -226,7 +226,7 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
             final @NonNull String defaultValue,
             final @NonNull TypeToken<T> valueType,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         this(required, name, parser, defaultValue, valueType, suggestionsProvider, defaultDescription, Collections.emptyList());
     }
@@ -273,7 +273,7 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
             final @NonNull Class<T> valueType,
             final @Nullable BiFunction<@NonNull CommandContext<C>,
                     @NonNull String, @NonNull List<@NonNull String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         this(required, name, parser, defaultValue, TypeToken.get(valueType), suggestionsProvider, defaultDescription);
     }
@@ -449,7 +449,7 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
      *
      * @return the default description
      */
-    public final @NonNull ArgumentDescription getDefaultDescription() {
+    public final @NonNull ArgumentDescription<C> getDefaultDescription() {
         return this.defaultDescription;
     }
 
@@ -569,7 +569,7 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
         private ArgumentParser<C, T> parser;
         private String defaultValue = "";
         private BiFunction<@NonNull CommandContext<C>, @NonNull String, @NonNull List<String>> suggestionsProvider;
-        private @NonNull ArgumentDescription defaultDescription = ArgumentDescription.empty();
+        private @NonNull ArgumentDescription<C> defaultDescription = ArgumentDescription.empty();
 
         private final Collection<BiFunction<@NonNull CommandContext<C>,
                 @NonNull String, @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors = new LinkedList<>();
@@ -680,7 +680,7 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
          * @since 1.4.0
          */
         public @NonNull Builder<@NonNull C, @NonNull T> withDefaultDescription(
-                final @NonNull ArgumentDescription defaultDescription
+                final @NonNull ArgumentDescription<C> defaultDescription
         ) {
             this.defaultDescription = Objects.requireNonNull(defaultDescription, "Default description may not be null");
             return this;
@@ -735,7 +735,7 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
             return this.suggestionsProvider;
         }
 
-        protected final @NonNull ArgumentDescription getDefaultDescription() {
+        protected final @NonNull ArgumentDescription<C> getDefaultDescription() {
             return this.defaultDescription;
         }
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/flags/CommandFlag.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/flags/CommandFlag.java
@@ -46,14 +46,14 @@ public final class CommandFlag<T> {
 
     private final @NonNull String name;
     private final @NonNull String @NonNull [] aliases;
-    private final @NonNull ArgumentDescription description;
+    private final @NonNull ArgumentDescription<?> description;
 
     private final @Nullable CommandArgument<?, T> commandArgument;
 
     private CommandFlag(
             final @NonNull String name,
             final @NonNull String @NonNull [] aliases,
-            final @NonNull ArgumentDescription description,
+            final @NonNull ArgumentDescription<?> description,
             final @Nullable CommandArgument<?, T> commandArgument
     ) {
         this.name = Objects.requireNonNull(name, "name cannot be null");
@@ -94,15 +94,17 @@ public final class CommandFlag<T> {
      * Get the flag description
      * <p>
      *
+     * @param sender Command sender
      * @return Flag description
      * @deprecated for removal since 1.4.0. Use {@link #getArgumentDescription()} instead.
      */
     @Deprecated
-    public cloud.commandframework.@NonNull Description getDescription() {
+    @SuppressWarnings("unchecked")
+    public cloud.commandframework.@NonNull Description<?> getDescription(final Object sender) {
         if (this.description instanceof cloud.commandframework.Description) {
-            return ((cloud.commandframework.Description) this.description);
+            return ((cloud.commandframework.Description<?>) this.description);
         } else {
-            return cloud.commandframework.Description.of(this.description.getDescription());
+            return cloud.commandframework.Description.of(((ArgumentDescription<Object>) this.description).getDescription(sender));
         }
     }
 
@@ -112,7 +114,7 @@ public final class CommandFlag<T> {
      * @return Flag description
      * @since 1.4.0
      */
-    public @NonNull ArgumentDescription getArgumentDescription() {
+    public @NonNull ArgumentDescription<?> getArgumentDescription() {
         return this.description;
     }
 
@@ -152,13 +154,13 @@ public final class CommandFlag<T> {
 
         private final String name;
         private final String[] aliases;
-        private final ArgumentDescription description;
+        private final ArgumentDescription<?> description;
         private final CommandArgument<?, T> commandArgument;
 
         private Builder(
                 final @NonNull String name,
                 final @NonNull String[] aliases,
-                final @NonNull ArgumentDescription description,
+                final @NonNull ArgumentDescription<?> description,
                 final @Nullable CommandArgument<?, T> commandArgument
         ) {
             this.name = name;
@@ -210,8 +212,8 @@ public final class CommandFlag<T> {
          * @deprecated for removal since 1.4.0. Use {@link #withDescription(ArgumentDescription)} instead.
          */
         @Deprecated
-        public Builder<T> withDescription(final cloud.commandframework.@NonNull Description description) {
-            return this.withDescription((ArgumentDescription) description);
+        public Builder<T> withDescription(final cloud.commandframework.@NonNull Description<?> description) {
+            return this.withDescription((ArgumentDescription<?>) description);
         }
 
         /**d
@@ -221,7 +223,7 @@ public final class CommandFlag<T> {
          * @return New builder instance
          * @since 1.4.0
          */
-        public Builder<T> withDescription(final @NonNull ArgumentDescription description) {
+        public Builder<T> withDescription(final @NonNull ArgumentDescription<?> description) {
             return new Builder<>(this.name, this.aliases, description, this.commandArgument);
         }
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/BooleanArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/BooleanArgument.java
@@ -52,7 +52,7 @@ public final class BooleanArgument<C> extends CommandArgument<C, Boolean> {
             final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
-            final @NonNull ArgumentDescription description
+            final @NonNull ArgumentDescription<C> description
     ) {
         super(required, name, new BooleanParser<>(liberal), defaultValue, Boolean.class, suggestionsProvider, description);
         this.liberal = liberal;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ByteArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ByteArgument.java
@@ -51,7 +51,7 @@ public final class ByteArgument<C> extends CommandArgument<C, Byte> {
             final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(required, name, new ByteParser<>(min, max), defaultValue, Byte.class, suggestionsProvider, defaultDescription);
         this.min = min;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/CharArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/CharArgument.java
@@ -48,7 +48,7 @@ public final class CharArgument<C> extends CommandArgument<C, Character> {
             final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>,
                     @NonNull String, @NonNull List<@NonNull String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
         ) {
         super(required, name, new CharacterParser<>(), defaultValue, Character.class, suggestionsProvider, defaultDescription);
     }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DoubleArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DoubleArgument.java
@@ -51,7 +51,7 @@ public final class DoubleArgument<C> extends CommandArgument<C, Double> {
             final String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(required, name, new DoubleParser<>(min, max), defaultValue, Double.class, suggestionsProvider, defaultDescription);
         this.min = min;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/EnumArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/EnumArgument.java
@@ -57,7 +57,7 @@ public class EnumArgument<C, E extends Enum<E>> extends CommandArgument<C, E> {
             final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(required, name, new EnumParser<>(enumClass), defaultValue, enumClass, suggestionsProvider, defaultDescription);
     }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/FloatArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/FloatArgument.java
@@ -51,7 +51,7 @@ public final class FloatArgument<C> extends CommandArgument<C, Float> {
             final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>,
                     @NonNull String, @NonNull List<@NonNull String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(required, name, new FloatParser<>(min, max), defaultValue, Float.class, suggestionsProvider, defaultDescription);
         this.min = min;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/IntegerArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/IntegerArgument.java
@@ -58,7 +58,7 @@ public final class IntegerArgument<C> extends CommandArgument<C, Integer> {
             final String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(required, name, new IntegerParser<>(min, max), defaultValue, Integer.class, suggestionsProvider, defaultDescription);
         this.min = min;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/LongArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/LongArgument.java
@@ -51,7 +51,7 @@ public final class LongArgument<C> extends CommandArgument<C, Long> {
             final String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(required, name, new LongParser<>(min, max), defaultValue, Long.class, suggestionsProvider, defaultDescription);
         this.min = min;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ShortArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ShortArgument.java
@@ -51,7 +51,7 @@ public final class ShortArgument<C> extends CommandArgument<C, Short> {
             final String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(required, name, new ShortParser<>(min, max), defaultValue, Short.class, suggestionsProvider, defaultDescription);
         this.min = min;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringArgument.java
@@ -58,7 +58,7 @@ public final class StringArgument<C> extends CommandArgument<C, String> {
             final @NonNull String defaultValue,
             final @NonNull BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(required, name, new StringParser<>(stringMode, suggestionsProvider),
                 defaultValue, String.class, suggestionsProvider, defaultDescription

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringArrayArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringArrayArgument.java
@@ -49,7 +49,7 @@ public final class StringArrayArgument<C> extends CommandArgument<C, String[]> {
             final boolean required,
             final @NonNull String name,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 required,

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/UUIDArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/UUIDArgument.java
@@ -49,7 +49,7 @@ public final class UUIDArgument<C> extends CommandArgument<C, UUID> {
             final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>,
                     @NonNull String, @NonNull List<@NonNull String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(required, name, new UUIDParser<>(), defaultValue, UUID.class, suggestionsProvider, defaultDescription);
     }

--- a/cloud-core/src/test/java/cloud/commandframework/CommandHelpHandlerTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandHelpHandlerTest.java
@@ -241,7 +241,7 @@ class CommandHelpHandlerTest {
         while (iterator.hasNext()) {
             final CommandComponent<TestCommandSender> component = iterator.next();
 
-            String description = component.getArgumentDescription().getDescription();
+            String description = component.getArgumentDescription().getDescription(new TestCommandSender());
             if (!description.isEmpty()) {
                 description = ": " + description;
             }

--- a/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
@@ -264,10 +264,10 @@ class CommandTreeTest {
         Assertions.assertEquals(TypeToken.get(int.class), arguments.get(3).getValueType());
 
         // Check description is set for all components, is empty when not specified
-        Assertions.assertEquals("", components.get(0).getArgumentDescription().getDescription());
-        Assertions.assertEquals("", components.get(1).getArgumentDescription().getDescription());
-        Assertions.assertEquals("detaildescription", components.get(2).getArgumentDescription().getDescription());
-        Assertions.assertEquals("argumentdescription", components.get(3).getArgumentDescription().getDescription());
+        Assertions.assertEquals("", components.get(0).getArgumentDescription().getDescription(new TestCommandSender()));
+        Assertions.assertEquals("", components.get(1).getArgumentDescription().getDescription(new TestCommandSender()));
+        Assertions.assertEquals("detaildescription", components.get(2).getArgumentDescription().getDescription(new TestCommandSender()));
+        Assertions.assertEquals("argumentdescription", components.get(3).getArgumentDescription().getDescription(new TestCommandSender()));
     }
 
     @Test

--- a/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/MutableCommandBuilder.kt
+++ b/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/MutableCommandBuilder.kt
@@ -57,7 +57,7 @@ public class MutableCommandBuilder<C : Any> {
     @Deprecated(message = "ArgumentDescription should be used over Description", level = DeprecationLevel.HIDDEN)
     public constructor(
         name: String,
-        description: Description = Description.empty(),
+        description: Description<C> = Description.empty(),
         aliases: Array<String> = emptyArray(),
         commandManager: CommandManager<C>
     ) {
@@ -76,7 +76,7 @@ public class MutableCommandBuilder<C : Any> {
      */
     public constructor(
             name: String,
-            description: ArgumentDescription = ArgumentDescription.empty(),
+            description: ArgumentDescription<C> = ArgumentDescription.empty(),
             aliases: Array<String> = emptyArray(),
             commandManager: CommandManager<C>
     ) {
@@ -98,7 +98,7 @@ public class MutableCommandBuilder<C : Any> {
     @Deprecated(message = "ArgumentDescription should be used over Description", level = DeprecationLevel.HIDDEN)
     public constructor(
         name: String,
-        description: Description = Description.empty(),
+        description: Description<C> = Description.empty(),
         aliases: Array<String> = emptyArray(),
         commandManager: CommandManager<C>,
         lambda: MutableCommandBuilder<C>.() -> Unit
@@ -118,7 +118,7 @@ public class MutableCommandBuilder<C : Any> {
      */
     public constructor(
             name: String,
-            description: ArgumentDescription = ArgumentDescription.empty(),
+            description: ArgumentDescription<C> = ArgumentDescription.empty(),
             aliases: Array<String> = emptyArray(),
             commandManager: CommandManager<C>,
             lambda: MutableCommandBuilder<C>.() -> Unit
@@ -213,7 +213,7 @@ public class MutableCommandBuilder<C : Any> {
     @Deprecated(message = "ArgumentDescription should be used over Description", level = DeprecationLevel.HIDDEN)
     public fun copy(
         literal: String,
-        description: Description,
+        description: Description<C>,
         lambda: MutableCommandBuilder<C>.() -> Unit
     ): MutableCommandBuilder<C> =
         copy().apply {
@@ -232,7 +232,7 @@ public class MutableCommandBuilder<C : Any> {
      */
     public fun copy(
             literal: String,
-            description: ArgumentDescription,
+            description: ArgumentDescription<C>,
             lambda: MutableCommandBuilder<C>.() -> Unit
     ): MutableCommandBuilder<C> =
             copy().apply {
@@ -316,7 +316,7 @@ public class MutableCommandBuilder<C : Any> {
     @Deprecated(message = "ArgumentDescription should be used over Description", level = DeprecationLevel.HIDDEN)
     public fun registerCopy(
         literal: String,
-        description: Description,
+        description: Description<C>,
         lambda: MutableCommandBuilder<C>.() -> Unit
     ): MutableCommandBuilder<C> =
         copy(literal, description, lambda).register()
@@ -335,7 +335,7 @@ public class MutableCommandBuilder<C : Any> {
      */
     public fun registerCopy(
             literal: String,
-            description: ArgumentDescription,
+            description: ArgumentDescription<C>,
             lambda: MutableCommandBuilder<C>.() -> Unit
     ): MutableCommandBuilder<C> =
             copy(literal, description, lambda).register()
@@ -504,7 +504,7 @@ public class MutableCommandBuilder<C : Any> {
     @Deprecated(message = "ArgumentDescription should be used over Description", level = DeprecationLevel.HIDDEN)
     public fun argument(
         argument: CommandArgument<C, *>,
-        description: Description = Description.empty()
+        description: Description<C> = Description.empty()
     ): MutableCommandBuilder<C> =
         mutate { it.argument(argument, description) }
 
@@ -518,7 +518,7 @@ public class MutableCommandBuilder<C : Any> {
      */
     public fun argument(
             argument: CommandArgument<C, *>,
-            description: ArgumentDescription = ArgumentDescription.empty()
+            description: ArgumentDescription<C> = ArgumentDescription.empty()
     ): MutableCommandBuilder<C> =
             mutate { it.argument(argument, description) }
 
@@ -534,7 +534,7 @@ public class MutableCommandBuilder<C : Any> {
     @Deprecated(message = "ArgumentDescription should be used over Description", level = DeprecationLevel.HIDDEN)
     public fun argument(
         argument: CommandArgument.Builder<C, *>,
-        description: Description = Description.empty()
+        description: Description<C> = Description.empty()
     ): MutableCommandBuilder<C> =
         mutate { it.argument(argument, description) }
 
@@ -548,7 +548,7 @@ public class MutableCommandBuilder<C : Any> {
      */
     public fun argument(
             argument: CommandArgument.Builder<C, *>,
-            description: ArgumentDescription = ArgumentDescription.empty()
+            description: ArgumentDescription<C> = ArgumentDescription.empty()
     ): MutableCommandBuilder<C> =
             mutate { it.argument(argument, description) }
 
@@ -563,7 +563,7 @@ public class MutableCommandBuilder<C : Any> {
     @Suppress("DEPRECATION")
     @Deprecated(message = "ArgumentDescription should be used over Description", level = DeprecationLevel.HIDDEN)
     public fun argument(
-        description: Description = Description.empty(),
+        description: Description<C> = Description.empty(),
         argumentSupplier: () -> CommandArgument<C, *>
     ): MutableCommandBuilder<C> =
         mutate { it.argument(argumentSupplier(), description) }
@@ -577,7 +577,7 @@ public class MutableCommandBuilder<C : Any> {
      * @since 1.4.0
      */
     public fun argument(
-            description: ArgumentDescription = ArgumentDescription.empty(),
+            description: ArgumentDescription<C> = ArgumentDescription.empty(),
             argumentSupplier: () -> CommandArgument<C, *>
     ): MutableCommandBuilder<C> =
             mutate { it.argument(argumentSupplier(), description) }
@@ -595,7 +595,7 @@ public class MutableCommandBuilder<C : Any> {
     @Deprecated(message = "ArgumentDescription should be used over Description", level = DeprecationLevel.HIDDEN)
     public fun literal(
         name: String,
-        description: Description = Description.empty(),
+        description: Description<C> = Description.empty(),
         vararg aliases: String
     ): MutableCommandBuilder<C> =
         mutate { it.literal(name, description, *aliases) }
@@ -611,7 +611,7 @@ public class MutableCommandBuilder<C : Any> {
      */
     public fun literal(
             name: String,
-            description: ArgumentDescription = ArgumentDescription.empty(),
+            description: ArgumentDescription<C> = ArgumentDescription.empty(),
             vararg aliases: String
     ): MutableCommandBuilder<C> =
             mutate { it.literal(name, description, *aliases) }
@@ -641,7 +641,7 @@ public class MutableCommandBuilder<C : Any> {
     public fun flag(
         name: String,
         aliases: Array<String> = emptyArray(),
-        description: ArgumentDescription = ArgumentDescription.empty(),
+        description: ArgumentDescription<C> = ArgumentDescription.empty(),
         argumentSupplier: () -> CommandArgument<C, *>
     ): MutableCommandBuilder<C> = mutate {
         it.flag(
@@ -666,7 +666,7 @@ public class MutableCommandBuilder<C : Any> {
     public fun flag(
         name: String,
         aliases: Array<String> = emptyArray(),
-        description: ArgumentDescription = ArgumentDescription.empty(),
+        description: ArgumentDescription<C> = ArgumentDescription.empty(),
         argument: CommandArgument<C, *>
     ): MutableCommandBuilder<C> = mutate {
         it.flag(
@@ -691,7 +691,7 @@ public class MutableCommandBuilder<C : Any> {
     public fun flag(
         name: String,
         aliases: Array<String> = emptyArray(),
-        description: ArgumentDescription = ArgumentDescription.empty(),
+        description: ArgumentDescription<C> = ArgumentDescription.empty(),
         argumentBuilder: CommandArgument.Builder<C, *>
     ): MutableCommandBuilder<C> = mutate {
         it.flag(
@@ -715,7 +715,7 @@ public class MutableCommandBuilder<C : Any> {
     public fun flag(
         name: String,
         aliases: Array<String> = emptyArray(),
-        description: ArgumentDescription = ArgumentDescription.empty(),
+        description: ArgumentDescription<C> = ArgumentDescription.empty(),
     ): MutableCommandBuilder<C> = mutate {
         it.flag(
             this.commandManager.flagBuilder(name)

--- a/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/extension/CommandBuildingExtensions.kt
+++ b/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/extension/CommandBuildingExtensions.kt
@@ -43,7 +43,7 @@ import kotlin.reflect.KClass
 @Deprecated(message = "ArgumentDescription should be used over Description", level = DeprecationLevel.HIDDEN)
 public fun <C : Any> CommandManager<C>.commandBuilder(
         name: String,
-        description: Description = Description.empty(),
+        description: Description<C> = Description.empty(),
         aliases: Array<String> = emptyArray(),
         lambda: MutableCommandBuilder<C>.() -> Unit
 ): MutableCommandBuilder<C> =
@@ -60,7 +60,7 @@ public fun <C : Any> CommandManager<C>.commandBuilder(
  */
 public fun <C : Any> CommandManager<C>.commandBuilder(
         name: String,
-        description: ArgumentDescription = ArgumentDescription.empty(),
+        description: ArgumentDescription<C> = ArgumentDescription.empty(),
         aliases: Array<String> = emptyArray(),
         lambda: MutableCommandBuilder<C>.() -> Unit
 ): MutableCommandBuilder<C> =
@@ -80,7 +80,7 @@ public fun <C : Any> CommandManager<C>.commandBuilder(
 @Deprecated(message = "ArgumentDescription should be used over Description", level = DeprecationLevel.HIDDEN)
 public fun <C : Any> CommandManager<C>.buildAndRegister(
         name: String,
-        description: Description = Description.empty(),
+        description: Description<C> = Description.empty(),
         aliases: Array<String> = emptyArray(),
         lambda: MutableCommandBuilder<C>.() -> Unit
 ): MutableCommandBuilder<C> =
@@ -98,7 +98,7 @@ public fun <C : Any> CommandManager<C>.buildAndRegister(
  */
 public fun <C : Any> CommandManager<C>.buildAndRegister(
         name: String,
-        description: ArgumentDescription = ArgumentDescription.empty(),
+        description: ArgumentDescription<C> = ArgumentDescription.empty(),
         aliases: Array<String> = emptyArray(),
         lambda: MutableCommandBuilder<C>.() -> Unit
 ): MutableCommandBuilder<C> =
@@ -143,9 +143,9 @@ public fun <C : Any> Command.Builder<C>.senderType(type: KClass<out C>): Command
         message = "Use interface variant that allows for rich text",
         replaceWith = ReplaceWith("argumentDescription(description)")
 )
-public fun description(
+public fun <C : Any> description(
         description: String = ""
-): Description =
+): Description<C> =
         if (description.isEmpty()) Description.empty() else Description.of(description)
 
 /**
@@ -155,7 +155,7 @@ public fun description(
  * @return the description
  * @since 1.4.0
  */
-public fun argumentDescription(
+public fun <C : Any> argumentDescription(
         description: String = ""
-): ArgumentDescription =
+): ArgumentDescription<C> =
         if (description.isEmpty()) ArgumentDescription.empty() else ArgumentDescription.of(description)

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/EnchantmentArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/EnchantmentArgument.java
@@ -55,7 +55,7 @@ public class EnchantmentArgument<C> extends CommandArgument<C, Enchantment> {
             final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
             ) {
         super(required, name, new EnchantmentParser<>(), defaultValue, Enchantment.class, suggestionsProvider, defaultDescription);
     }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/MaterialArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/MaterialArgument.java
@@ -54,7 +54,7 @@ public class MaterialArgument<C> extends CommandArgument<C, Material> {
             final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
             ) {
         super(required, name, new MaterialParser<>(), defaultValue, Material.class, suggestionsProvider);
     }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/OfflinePlayerArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/OfflinePlayerArgument.java
@@ -60,7 +60,7 @@ public final class OfflinePlayerArgument<C> extends CommandArgument<C, OfflinePl
             final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 required,

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/PlayerArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/PlayerArgument.java
@@ -56,7 +56,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
             final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(required, name, new PlayerParser<>(), defaultValue, Player.class, suggestionsProvider, defaultDescription);
     }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/WorldArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/WorldArgument.java
@@ -54,7 +54,7 @@ public class WorldArgument<C> extends CommandArgument<C, World> {
             final @NonNull String name,
             final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(required, name, new WorldParser<>(), defaultValue, World.class, suggestionsProvider, defaultDescription);
     }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/Location2DArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/Location2DArgument.java
@@ -58,7 +58,7 @@ public final class Location2DArgument<C> extends CommandArgument<C, Location2D> 
             final boolean required,
             final @NonNull String name,
             final @NonNull String defaultValue,
-            final @NonNull ArgumentDescription defaultDescription,
+            final @NonNull ArgumentDescription<C> defaultDescription,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>,
                     @NonNull Queue<@NonNull String>, @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/LocationArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/LocationArgument.java
@@ -64,7 +64,7 @@ public final class LocationArgument<C> extends CommandArgument<C, Location> {
             final @NonNull String name,
             final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription,
+            final @NonNull ArgumentDescription<C> defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>,
                     @NonNull Queue<@NonNull String>, @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
     ) {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultipleEntitySelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultipleEntitySelectorArgument.java
@@ -49,7 +49,7 @@ public final class MultipleEntitySelectorArgument<C> extends CommandArgument<C, 
             final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(required, name, new MultipleEntitySelectorParser<>(), defaultValue, MultipleEntitySelector.class,
                 suggestionsProvider, defaultDescription

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultiplePlayerSelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultiplePlayerSelectorArgument.java
@@ -53,7 +53,7 @@ public final class MultiplePlayerSelectorArgument<C> extends CommandArgument<C, 
             final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(required, name, new MultiplePlayerSelectorParser<>(), defaultValue, MultiplePlayerSelector.class,
                 suggestionsProvider, defaultDescription

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SingleEntitySelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SingleEntitySelectorArgument.java
@@ -49,7 +49,7 @@ public final class SingleEntitySelectorArgument<C> extends CommandArgument<C, Si
             final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 required,

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SinglePlayerSelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SinglePlayerSelectorArgument.java
@@ -53,7 +53,7 @@ public final class SinglePlayerSelectorArgument<C> extends CommandArgument<C, Si
             final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 required,

--- a/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/PlayerArgument.java
+++ b/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/PlayerArgument.java
@@ -57,7 +57,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, ProxiedPlayer> {
             final boolean required,
             final @NonNull String name,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription,
+            final @NonNull ArgumentDescription<C> defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>, @NonNull Queue<@NonNull String>,
                     @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
     ) {

--- a/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/ServerArgument.java
+++ b/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/ServerArgument.java
@@ -57,7 +57,7 @@ public final class ServerArgument<C> extends CommandArgument<C, ServerInfo> {
             final boolean required,
             final @NonNull String name,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription,
+            final @NonNull ArgumentDescription<C> defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>, @NonNull Queue<@NonNull String>,
                     @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
     ) {

--- a/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/MinecraftHelp.java
+++ b/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/MinecraftHelp.java
@@ -503,10 +503,10 @@ public final class MinecraftHelp<C> {
                     );
                     textComponent.append(text(")", this.colors.alternateHighlight));
                 }
-                final ArgumentDescription description = component.getArgumentDescription();
-                if (!description.isEmpty()) {
+                final ArgumentDescription<C> description = component.getArgumentDescription();
+                if (!description.isEmpty(sender)) {
                     textComponent.append(text(" - ", this.colors.accent));
-                    textComponent.append(this.formatDescription(description).colorIfAbsent(this.colors.text));
+                    textComponent.append(this.formatDescription(sender, description).colorIfAbsent(this.colors.text));
                 }
 
                 audience.sendMessage(textComponent);
@@ -515,11 +515,11 @@ public final class MinecraftHelp<C> {
         audience.sendMessage(this.footer(sender));
     }
 
-    private Component formatDescription(final ArgumentDescription description) {
+    private Component formatDescription(final C sender, final ArgumentDescription<C> description) {
         if (description instanceof RichDescription) {
-            return ((RichDescription) description).getContents();
+            return ((RichDescription<C>) description).getContents();
         } else {
-            return this.descriptionDecorator.apply(description.getDescription());
+            return this.descriptionDecorator.apply(description.getDescription(sender));
         }
     }
 

--- a/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/RichDescription.java
+++ b/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/RichDescription.java
@@ -38,11 +38,10 @@ import static java.util.Objects.requireNonNull;
 /**
  * An argument description implementation that uses Adventure components.
  *
+ * @param <C> Command sender type
  * @since 1.4.0
  */
-public final class RichDescription implements ArgumentDescription {
-    private static final RichDescription EMPTY = new RichDescription(Component.empty());
-
+public final class RichDescription<C> implements ArgumentDescription<C> {
     private final Component contents;
 
     RichDescription(final Component contents) {
@@ -52,25 +51,27 @@ public final class RichDescription implements ArgumentDescription {
     /**
      * Get an empty description.
      *
+     * @param <C> Command sender type
      * @return the empty description
      */
-    public static @NonNull RichDescription empty() {
-        return EMPTY;
+    public static <C> @NonNull RichDescription<C> empty() {
+        return new RichDescription<>(Component.empty());
     }
 
     /**
      * Create a new rich description from the provided component.
      *
+     * @param <C> Command sender type
      * @param contents the rich contents
      * @return a new rich description
      */
-    public static @NonNull RichDescription of(final @NonNull ComponentLike contents) {
+    public static <C> @NonNull RichDescription<C> of(final @NonNull ComponentLike contents) {
         final Component componentContents = requireNonNull(contents, "contents").asComponent();
         if (Component.empty().equals(componentContents)) {
-            return EMPTY;
+            return empty();
         }
 
-        return new RichDescription(componentContents);
+        return new RichDescription<>(componentContents);
     }
 
     /* Translatable helper methods */
@@ -78,30 +79,32 @@ public final class RichDescription implements ArgumentDescription {
     /**
      * Create a rich description pointing to a translation key.
      *
+     * @param <C> Command sender type
      * @param key the translation key
      * @return a new rich description
      */
-    public static @NonNull RichDescription translatable(final @NonNull String key) {
+    public static <C> @NonNull RichDescription<C> translatable(final @NonNull String key) {
         requireNonNull(key, "key");
 
-        return new RichDescription(Component.translatable(key));
+        return new RichDescription<>(Component.translatable(key));
     }
 
     /**
      * Create a rich description pointing to a translation key.
      *
+     * @param <C> Command sender type
      * @param key the translation key
      * @param args the arguments to use with the translation key
      * @return a new rich description
      */
-    public static @NonNull RichDescription translatable(
+    public static <C> @NonNull RichDescription<C> translatable(
             final @NonNull String key,
             final @NonNull ComponentLike @NonNull... args
     ) {
         requireNonNull(key, "key");
         requireNonNull(args, "args");
 
-        return new RichDescription(Component.translatable(key, args));
+        return new RichDescription<>(Component.translatable(key, args));
     }
 
     /**
@@ -112,7 +115,7 @@ public final class RichDescription implements ArgumentDescription {
      */
     @Override
     @Deprecated
-    public @NonNull String getDescription() {
+    public @NonNull String getDescription(final C sender) {
         return PlainComponentSerializer.plain().serialize(GlobalTranslator.render(this.contents, Locale.getDefault()));
     }
 
@@ -126,7 +129,7 @@ public final class RichDescription implements ArgumentDescription {
     }
 
     @Override
-    public boolean isEmpty() {
+    public boolean isEmpty(final C sender) {
         return Component.empty().equals(this.contents);
     }
 

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/PlayerArgument.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/PlayerArgument.java
@@ -57,7 +57,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
             final boolean required,
             final @NonNull String name,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription,
+            final @NonNull ArgumentDescription<C> defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>, @NonNull Queue<@NonNull String>,
                     @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
     ) {

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/ServerArgument.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/ServerArgument.java
@@ -57,7 +57,7 @@ public final class ServerArgument<C> extends CommandArgument<C, RegisteredServer
             final boolean required,
             final @NonNull String name,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
-            final @NonNull ArgumentDescription defaultDescription,
+            final @NonNull ArgumentDescription<C> defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>, @NonNull Queue<@NonNull String>,
                     @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
     ) {

--- a/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/ExamplePlugin.java
+++ b/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/ExamplePlugin.java
@@ -26,7 +26,6 @@ package cloud.commandframework.examples.bukkit;
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.CommandTree;
-import cloud.commandframework.Description;
 import cloud.commandframework.keys.SimpleCloudKey;
 import cloud.commandframework.minecraft.extras.MinecraftExceptionHandler;
 import cloud.commandframework.minecraft.extras.MinecraftHelp;


### PR DESCRIPTION
Currently, ArgumentDescriptions have no way to tell who is requesting the description.

This is a useful feature for sending different descriptions depending on the person requesting them.
For example, a custom localization manager would require the requesting user to be known (for platforms without Adventure)

This PR generifies `ArgumentDescription` and `Description` and adds a `C sender` argument to the `getDescription` and `isEmpty` methods.

Potential downsides of this would be the lack of backwards compatibility, but because the signatures have changed compiler errors will be issued rather than runtime exceptions.

Seems to compile fine with `./gradlew clean build`