### PR TITLE
fabric: Catch late command manager instantiation

### DIFF
--- a/cloud-minecraft/cloud-fabric/build.gradle.kts
+++ b/cloud-minecraft/cloud-fabric/build.gradle.kts
@@ -1,3 +1,4 @@
+import net.fabricmc.loom.task.AbstractRunTask
 import net.ltgt.gradle.errorprone.errorprone
 
 plugins {
@@ -41,6 +42,19 @@ tasks {
             links("https://maven.fabricmc.net/docs/yarn-${Versions.fabricMc}+build.${Versions.fabricYarn}/")
         }
     }
+
+    withType(AbstractRunTask::class).configureEach {
+        standardInput = System.`in`
+        jvmArgumentProviders += CommandLineArgumentProvider {
+            if (System.getProperty("idea.active")?.toBoolean() == true || // IntelliJ
+                    System.getenv("TERM") != null || // linux terminals
+                    System.getenv("WT_SESSION") != null) { // Windows terminal
+                listOf("-Dfabric.log.disableAnsi=false")
+            } else {
+                listOf()
+            }
+        }
+    }
 }
 
 
@@ -49,6 +63,7 @@ dependencies {
     mappings("net.fabricmc", "yarn", "${Versions.fabricMc}+build.${Versions.fabricYarn}", classifier = "v2")
     modImplementation("net.fabricmc", "fabric-loader", Versions.fabricLoader)
     modImplementation(fabricApi.module("fabric-command-api-v1", Versions.fabricApi))
+    modImplementation(fabricApi.module("fabric-lifecycle-events-v1", Versions.fabricApi))
 
     modApi(include("me.lucko", "fabric-permissions-api", "0.1-SNAPSHOT"))
 

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/FabricServerCommandManager.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/FabricServerCommandManager.java
@@ -36,6 +36,7 @@ import cloud.commandframework.fabric.data.MultipleEntitySelector;
 import cloud.commandframework.fabric.data.MultiplePlayerSelector;
 import cloud.commandframework.fabric.data.SingleEntitySelector;
 import cloud.commandframework.fabric.data.SinglePlayerSelector;
+import cloud.commandframework.fabric.internal.LateRegistrationCatcher;
 import cloud.commandframework.meta.CommandMeta;
 import io.leangen.geantyref.TypeToken;
 import me.lucko.fabric.api.permissions.v0.Permissions;
@@ -127,6 +128,11 @@ public final class FabricServerCommandManager<C> extends FabricCommandManager<C,
                         null
                 )
         );
+
+        if (LateRegistrationCatcher.hasServerAlreadyStarted()) {
+            throw new IllegalStateException("FabricServerCommandManager was created too late! Because command registration "
+                    + "occurs before the server instance is created, commands should be registered in mod initializers.");
+        }
 
         this.registerParsers();
     }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/internal/LateRegistrationCatcher.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/internal/LateRegistrationCatcher.java
@@ -1,0 +1,54 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+package cloud.commandframework.fabric.internal;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+
+/**
+ * Capture server starting events to provide more useful error
+ * checking on late command registration.
+ */
+public final class LateRegistrationCatcher implements ModInitializer {
+
+    private static boolean serverStartingCalled;
+
+    @Override
+    public void onInitialize() {
+        ServerLifecycleEvents.SERVER_STARTING.register(server -> LateRegistrationCatcher.serverStartingCalled = true);
+    }
+
+    /**
+     * Get whether at least one server in the current environment has already begun starting.
+     *
+     * <p>This indicates that pre-initialization tasks must have completed.</p>
+     *
+     * @return whether a server has already started.
+     */
+    public static boolean hasServerAlreadyStarted() {
+        return LateRegistrationCatcher.serverStartingCalled;
+    }
+
+}

--- a/cloud-minecraft/cloud-fabric/src/main/resources/fabric.mod.json
+++ b/cloud-minecraft/cloud-fabric/src/main/resources/fabric.mod.json
@@ -13,6 +13,12 @@
   "license": "MIT",
   "icon": "assets/cloud/logo.png",
 
+  "entrypoints": {
+    "main": [
+      "cloud.commandframework.fabric.internal.LateRegistrationCatcher"
+    ]
+  },
+
   "mixins": [
     "cloud.mixins.json"
   ],


### PR DESCRIPTION
This would previously result in command registration silently failing,
since commands are registered before the server starts.