### PR TITLE
bukkit: Implement ItemStackArgument

### DIFF
--- a/.checkstyle/checkstyle-suppressions.xml
+++ b/.checkstyle/checkstyle-suppressions.xml
@@ -4,4 +4,5 @@
         "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 <suppressions>
     <suppress checks="(?:(?:Member|Method)Name|DesignForExtension|Javadoc.*)" files=".*[\\/]mixin[\\/].*"/>
+    <suppress checks="(?:Javadoc.*)" files=".*[\\/]CraftBukkitReflection.java"/>
 </suppressions>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
  - JDA Role argument parser
+ - Bukkit: Implement parser for ProtoItemStack ([#257](https://github.com/Incendo/cloud/pull/257))
 
 ### Changed
  - Use Command instead of TabCompleteEvent on Bukkit

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandContextKeys.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandContextKeys.java
@@ -1,0 +1,64 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.bukkit;
+
+import cloud.commandframework.keys.CloudKey;
+import cloud.commandframework.keys.SimpleCloudKey;
+import io.leangen.geantyref.TypeToken;
+import org.bukkit.command.CommandSender;
+
+import java.util.Set;
+
+/**
+ * Bukkit related {@link cloud.commandframework.context.CommandContext} keys.
+ *
+ * @since 1.5.0
+ */
+public final class BukkitCommandContextKeys {
+
+    /**
+     * Key used to store the Bukkit native {@link CommandSender} in the {@link cloud.commandframework.context.CommandContext}.
+     *
+     * @since 1.5.0
+     */
+    public static final CloudKey<CommandSender> BUKKIT_COMMAND_SENDER = SimpleCloudKey.of(
+            "BukkitCommandSender",
+            TypeToken.get(CommandSender.class)
+    );
+
+    /**
+     * Key used to store the active {@link CloudBukkitCapabilities} in the {@link cloud.commandframework.context.CommandContext}.
+     *
+     * @since 1.5.0
+     */
+    public static final CloudKey<Set<CloudBukkitCapabilities>> CLOUD_BUKKIT_CAPABILITIES = SimpleCloudKey.of(
+            "CloudBukkitCapabilities",
+            new TypeToken<Set<CloudBukkitCapabilities>>() {
+            }
+    );
+
+    private BukkitCommandContextKeys() {
+    }
+
+}

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandPreprocessor.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandPreprocessor.java
@@ -27,6 +27,8 @@ import cloud.commandframework.execution.preprocessor.CommandPreprocessingContext
 import cloud.commandframework.execution.preprocessor.CommandPreprocessor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
+import java.util.Set;
+
 /**
  * Command preprocessor which decorates incoming {@link cloud.commandframework.context.CommandContext}
  * with Bukkit specific objects
@@ -35,26 +37,29 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  */
 final class BukkitCommandPreprocessor<C> implements CommandPreprocessor<C> {
 
-    private final BukkitCommandManager<C> mgr;
+    private final BukkitCommandManager<C> commandManager;
+    private final Set<CloudBukkitCapabilities> bukkitCapabilities;
 
     /**
      * The Bukkit Command Preprocessor for storing Bukkit-specific contexts in the command contexts
      *
-     * @param mgr The BukkitCommandManager
+     * @param commandManager The BukkitCommandManager
      */
-    BukkitCommandPreprocessor(final @NonNull BukkitCommandManager<C> mgr) {
-        this.mgr = mgr;
+    BukkitCommandPreprocessor(final @NonNull BukkitCommandManager<C> commandManager) {
+        this.commandManager = commandManager;
+        this.bukkitCapabilities = commandManager.queryCapabilities();
     }
 
-    /**
-     * Stores the sender mapped to {@link org.bukkit.command.CommandSender} in the context with the key "BukkitCommandSender",
-     * and a {@link java.util.Set} of {@link CloudBukkitCapabilities} with the key "CloudBukkitCapabilities"
-     */
     @Override
     public void accept(final @NonNull CommandPreprocessingContext<C> context) {
-        context.getCommandContext().store("BukkitCommandSender", this.mgr.getBackwardsCommandSenderMapper().apply(
-                context.getCommandContext().getSender()));
-        context.getCommandContext().store("CloudBukkitCapabilities", this.mgr.queryCapabilities());
+        context.getCommandContext().store(
+                BukkitCommandContextKeys.BUKKIT_COMMAND_SENDER,
+                this.commandManager.getBackwardsCommandSenderMapper().apply(context.getCommandContext().getSender())
+        );
+        context.getCommandContext().store(
+                BukkitCommandContextKeys.CLOUD_BUKKIT_CAPABILITIES,
+                this.bukkitCapabilities
+        );
     }
 
 }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/data/ProtoItemStack.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/data/ProtoItemStack.java
@@ -1,0 +1,63 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.bukkit.data;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Intermediary result for an argument which parses a {@link Material} and optional NBT data.
+ *
+ * @since 1.5.0
+ */
+public interface ProtoItemStack {
+
+    /**
+     * Get the {@link Material} of this {@link ProtoItemStack}.
+     *
+     * @return the {@link Material}
+     * @since 1.5.0
+     */
+    @NonNull Material material();
+
+    /**
+     * Get whether this {@link ProtoItemStack} contains extra data besides the {@link Material}.
+     *
+     * @return whether there is extra data
+     */
+    boolean hasExtraData();
+
+    /**
+     * Create a new {@link ItemStack} from the state of this {@link ProtoItemStack}.
+     *
+     * @param stackSize               stack size
+     * @param respectMaximumStackSize whether to respect the maximum stack size for the material
+     * @return the created {@link ItemStack}
+     * @throws IllegalArgumentException if the {@link ItemStack} could not be created, due to max stack size or other reasons
+     */
+    @NonNull ItemStack createItemStack(int stackSize, boolean respectMaximumStackSize)
+            throws IllegalArgumentException;
+
+}

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/data/package-info.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/data/package-info.java
@@ -1,0 +1,27 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+/**
+ * cloud-bukkit data holders
+ */
+package cloud.commandframework.bukkit.data;

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/internal/CraftBukkitReflection.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/internal/CraftBukkitReflection.java
@@ -1,0 +1,126 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.bukkit.internal;
+
+import com.google.common.annotations.Beta;
+import org.bukkit.Bukkit;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/**
+ * Utilities for doing reflection on CraftBukkit, used by the cloud implementation.
+ *
+ * <p>This is not API to any extent, and as such, may break, change, or be removed without any notice.</p>
+ */
+@Beta
+public final class CraftBukkitReflection {
+
+    private static final String PREFIX_NMS = "net.minecraft.server";
+    private static final String PREFIX_CRAFTBUKKIT = "org.bukkit.craftbukkit";
+    private static final String CRAFT_SERVER = "CraftServer";
+    private static final String VERSION;
+    public static final int MAJOR_REVISION;
+
+    static {
+        final Class<?> serverClass = Bukkit.getServer().getClass();
+        final String pkg = serverClass.getPackage().getName();
+        final String nmsVersion = pkg.substring(pkg.lastIndexOf(".") + 1);
+        if (!nmsVersion.contains("_")) {
+            MAJOR_REVISION = -1;
+            VERSION = null;
+        } else {
+            MAJOR_REVISION = Integer.parseInt(nmsVersion.split("_")[1]);
+            String name = serverClass.getName();
+            name = name.substring(PREFIX_CRAFTBUKKIT.length());
+            name = name.substring(0, name.length() - CRAFT_SERVER.length());
+            VERSION = name;
+        }
+    }
+
+    public static boolean craftBukkit() {
+        return MAJOR_REVISION != -1 && VERSION != null;
+    }
+
+    public static @NonNull Class<?> needNMSClass(final @NonNull String className) throws RuntimeException {
+        return needClass(PREFIX_NMS + VERSION + className);
+    }
+
+    public static @NonNull Class<?> needOBCClass(final @NonNull String className) throws RuntimeException {
+        return needClass(PREFIX_CRAFTBUKKIT + VERSION + className);
+    }
+
+    public static @NonNull Class<?> needClass(final @NonNull String className) throws RuntimeException {
+        try {
+            return Class.forName(className);
+        } catch (final ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static @Nullable Class<?> findClass(final @NonNull String className) {
+        try {
+            return Class.forName(className);
+        } catch (final ClassNotFoundException e) {
+            return null;
+        }
+    }
+
+    public static @NonNull Field needField(final @NonNull Class<?> holder, final @NonNull String name) throws RuntimeException {
+        try {
+            final Field field = holder.getDeclaredField(name);
+            field.setAccessible(true);
+            return field;
+        } catch (final ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static boolean classExists(final @NonNull String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    public static @NonNull Method needMethod(
+            final @NonNull Class<?> holder,
+            final @NonNull String name,
+            final @NonNull Class<?>... params
+    ) throws RuntimeException {
+        try {
+            return holder.getMethod(name, params);
+        } catch (final NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private CraftBukkitReflection() {
+    }
+
+}

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/ItemStackArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/ItemStackArgument.java
@@ -1,0 +1,331 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.bukkit.parsers;
+
+import cloud.commandframework.ArgumentDescription;
+import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.parser.ArgumentParseResult;
+import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.brigadier.argument.WrappedBrigadierParser;
+import cloud.commandframework.bukkit.BukkitCommandManager;
+import cloud.commandframework.bukkit.data.ProtoItemStack;
+import cloud.commandframework.bukkit.internal.CraftBukkitReflection;
+import cloud.commandframework.context.CommandContext;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Queue;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+/**
+ * Argument type for parsing a {@link Material} and optional extra NBT data into a {@link ProtoItemStack}.
+ *
+ * <p>This argument type only provides basic suggestions by default. On Minecraft 1.13 and newer, enabling Brigadier
+ * compatibility through {@link BukkitCommandManager#registerBrigadier()} will allow client side validation and
+ * suggestions to be utilized.</p>
+ *
+ * @param <C> Command sender type
+ * @since 1.5.0
+ */
+public final class ItemStackArgument<C> extends CommandArgument<C, ProtoItemStack> {
+
+    private ItemStackArgument(
+            final boolean required,
+            final @NonNull String name,
+            final @NonNull String defaultValue,
+            final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
+                    @NonNull List<@NonNull String>> suggestionsProvider,
+            final @NonNull ArgumentDescription defaultDescription
+    ) {
+        super(required, name, new Parser<>(), defaultValue, ProtoItemStack.class, suggestionsProvider, defaultDescription);
+    }
+
+    /**
+     * Create a new {@link Builder}.
+     *
+     * @param name Name of the argument
+     * @param <C>  Command sender type
+     * @return Created builder
+     * @since 1.5.0
+     */
+    public static <C> ItemStackArgument.@NonNull Builder<C> builder(final @NonNull String name) {
+        return new ItemStackArgument.Builder<>(name);
+    }
+
+    /**
+     * Create a new required {@link ItemStackArgument}.
+     *
+     * @param name Argument name
+     * @param <C>  Command sender type
+     * @return Created argument
+     * @since 1.5.0
+     */
+    public static <C> @NonNull CommandArgument<C, ProtoItemStack> of(final @NonNull String name) {
+        return ItemStackArgument.<C>builder(name).build();
+    }
+
+    /**
+     * Create a new optional {@link ItemStackArgument}.
+     *
+     * @param name Argument name
+     * @param <C>  Command sender type
+     * @return Created argument
+     * @since 1.5.0
+     */
+    public static <C> @NonNull CommandArgument<C, ProtoItemStack> optional(final @NonNull String name) {
+        return ItemStackArgument.<C>builder(name).asOptional().build();
+    }
+
+
+    /**
+     * Builder for {@link ItemStackArgument}.
+     *
+     * @param <C> sender type
+     * @since 1.5.0
+     */
+    public static final class Builder<C> extends TypedBuilder<C, ProtoItemStack, Builder<C>> {
+
+        private Builder(final @NonNull String name) {
+            super(ProtoItemStack.class, name);
+        }
+
+        @Override
+        public @NonNull ItemStackArgument<C> build() {
+            return new ItemStackArgument<>(
+                    this.isRequired(),
+                    this.getName(),
+                    this.getDefaultValue(),
+                    this.getSuggestionsProvider(),
+                    this.getDefaultDescription()
+            );
+        }
+
+    }
+
+    /**
+     * Parser for {@link ProtoItemStack}. Requires a CraftBukkit based server implementation.
+     *
+     * @param <C> sender type
+     * @since 1.5.0
+     */
+    public static final class Parser<C> implements ArgumentParser<C, ProtoItemStack> {
+
+        private final ArgumentParser<C, ProtoItemStack> parser;
+
+        /**
+         * Create a new {@link Parser}.
+         *
+         * @since 1.5.0
+         */
+        public Parser() {
+            if (!CraftBukkitReflection.craftBukkit()) {
+                throw new UnsupportedOperationException("ItemStack parser requires CraftBukkit");
+            }
+            if (CraftBukkitReflection.MAJOR_REVISION >= 13) {
+                this.parser = new ModernParser<>();
+            } else {
+                this.parser = new LegacyParser<>();
+            }
+        }
+
+        @Override
+        public @NonNull ArgumentParseResult<ProtoItemStack> parse(
+                final @NonNull CommandContext<C> commandContext,
+                final @NonNull Queue<@NonNull String> inputQueue
+        ) {
+            return this.parser.parse(commandContext, inputQueue);
+        }
+
+        @Override
+        public @NonNull List<@NonNull String> suggestions(
+                final @NonNull CommandContext<C> commandContext,
+                final @NonNull String input
+        ) {
+            return Arrays.stream(Material.values())
+                    .map(value -> value.name().toLowerCase(Locale.ROOT))
+                    .collect(Collectors.toList());
+        }
+
+    }
+
+    private static final class ModernParser<C> implements ArgumentParser<C, ProtoItemStack> {
+
+        private static final Class<?> NMS_ITEM_STACK_CLASS = CraftBukkitReflection.needNMSClass("ItemStack");
+        private static final Class<?> CRAFT_ITEM_STACK_CLASS =
+                CraftBukkitReflection.needOBCClass("inventory.CraftItemStack");
+        private static final Class<?> ARGUMENT_ITEM_STACK_CLASS =
+                CraftBukkitReflection.needNMSClass("ArgumentItemStack");
+        private static final Class<?> ARGUMENT_PREDICATE_ITEM_STACK_CLASS =
+                CraftBukkitReflection.needNMSClass("ArgumentPredicateItemStack");
+        private static final Class<?> NMS_ITEM_CLASS = CraftBukkitReflection.needNMSClass("Item");
+        private static final Class<?> CRAFT_MAGIC_NUMBERS_CLASS =
+                CraftBukkitReflection.needOBCClass("util.CraftMagicNumbers");
+        private static final Method GET_MATERIAL_METHOD = CraftBukkitReflection
+                .needMethod(CRAFT_MAGIC_NUMBERS_CLASS, "getMaterial", NMS_ITEM_CLASS);
+        private static final Method CREATE_ITEM_STACK_METHOD = CraftBukkitReflection
+                .needMethod(ARGUMENT_PREDICATE_ITEM_STACK_CLASS, "a", int.class, boolean.class);
+        private static final Method AS_BUKKIT_COPY_METHOD = CraftBukkitReflection
+                .needMethod(CRAFT_ITEM_STACK_CLASS, "asBukkitCopy", NMS_ITEM_STACK_CLASS);
+        private static final Field ITEM_FIELD = CraftBukkitReflection.needField(ARGUMENT_PREDICATE_ITEM_STACK_CLASS, "b");
+        private static final Field COMPOUND_TAG_FIELD = CraftBukkitReflection.needField(ARGUMENT_PREDICATE_ITEM_STACK_CLASS, "c");
+
+        private final ArgumentParser<C, ProtoItemStack> parser;
+
+        ModernParser() {
+            try {
+                this.parser = this.createParser();
+            } catch (final ReflectiveOperationException ex) {
+                throw new RuntimeException("Failed to initialize modern ItemStack parser.", ex);
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        private ArgumentParser<C, ProtoItemStack> createParser() throws ReflectiveOperationException {
+            return new WrappedBrigadierParser<C, Object>(
+                    (ArgumentType<Object>) ARGUMENT_ITEM_STACK_CLASS.getConstructor().newInstance()
+            ).map((ctx, itemInput) -> ArgumentParseResult.success(new ModernProtoItemStack(itemInput)));
+        }
+
+        @Override
+        public @NonNull ArgumentParseResult<@NonNull ProtoItemStack> parse(
+                @NonNull final CommandContext<@NonNull C> commandContext,
+                @NonNull final Queue<@NonNull String> inputQueue
+        ) {
+            // Minecraft has a parser for this - just use it
+            return this.parser.parse(commandContext, inputQueue);
+        }
+
+        private static final class ModernProtoItemStack implements ProtoItemStack {
+
+            private final Object itemInput;
+            private final Material material;
+            private final @Nullable String snbt;
+
+            ModernProtoItemStack(final @NonNull Object itemInput) {
+                this.itemInput = itemInput;
+                try {
+                    this.material = (Material) GET_MATERIAL_METHOD.invoke(null, ITEM_FIELD.get(itemInput));
+                    final Object compoundTag = COMPOUND_TAG_FIELD.get(itemInput);
+                    if (compoundTag != null) {
+                        this.snbt = compoundTag.toString();
+                    } else {
+                        this.snbt = null;
+                    }
+                } catch (final ReflectiveOperationException ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+
+            @Override
+            public @NonNull Material material() {
+                return this.material;
+            }
+
+            @Override
+            public boolean hasExtraData() {
+                return this.snbt != null;
+            }
+
+            @Override
+            public @NonNull ItemStack createItemStack(final int stackSize, final boolean respectMaximumStackSize) {
+                try {
+                    return (ItemStack) AS_BUKKIT_COPY_METHOD.invoke(
+                            null,
+                            CREATE_ITEM_STACK_METHOD.invoke(this.itemInput, stackSize, respectMaximumStackSize)
+                    );
+                } catch (final InvocationTargetException ex) {
+                    final Throwable cause = ex.getCause();
+                    if (cause instanceof CommandSyntaxException) {
+                        throw new IllegalArgumentException(cause.getMessage(), cause);
+                    }
+                    throw new RuntimeException(ex);
+                } catch (final ReflectiveOperationException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+        }
+
+    }
+
+    private static final class LegacyParser<C> implements ArgumentParser<C, ProtoItemStack> {
+
+        private final ArgumentParser<C, ProtoItemStack> parser = new MaterialArgument.MaterialParser<C>()
+                .map((ctx, material) -> ArgumentParseResult.success(new LegacyProtoItemStack(material)));
+
+        @Override
+        public @NonNull ArgumentParseResult<@NonNull ProtoItemStack> parse(
+                @NonNull final CommandContext<@NonNull C> commandContext,
+                @NonNull final Queue<@NonNull String> inputQueue
+        ) {
+            return this.parser.parse(commandContext, inputQueue);
+        }
+
+        private static final class LegacyProtoItemStack implements ProtoItemStack {
+
+            private final Material material;
+
+            private LegacyProtoItemStack(final @NonNull Material material) {
+                this.material = material;
+            }
+
+            @Override
+            public @NonNull Material material() {
+                return this.material;
+            }
+
+            @Override
+            public boolean hasExtraData() {
+                return false;
+            }
+
+            @Override
+            public @NonNull ItemStack createItemStack(final int stackSize, final boolean respectMaximumStackSize)
+                    throws IllegalArgumentException {
+                if (respectMaximumStackSize && stackSize > this.material.getMaxStackSize()) {
+                    throw new IllegalArgumentException(String.format(
+                            "The maximum stack size for %s is %d",
+                            this.material,
+                            this.material.getMaxStackSize()
+                    ));
+                }
+                return new ItemStack(this.material, stackSize);
+            }
+
+        }
+
+    }
+
+}

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/OfflinePlayerArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/OfflinePlayerArgument.java
@@ -28,12 +28,14 @@ import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
 import cloud.commandframework.bukkit.BukkitCaptionKeys;
+import cloud.commandframework.bukkit.BukkitCommandContextKeys;
 import cloud.commandframework.captions.CaptionVariable;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import cloud.commandframework.exceptions.parsing.ParserException;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -177,6 +179,10 @@ public final class OfflinePlayerArgument<C> extends CommandArgument<C, OfflinePl
             List<String> output = new ArrayList<>();
 
             for (Player player : Bukkit.getOnlinePlayers()) {
+                final CommandSender bukkit = commandContext.get(BukkitCommandContextKeys.BUKKIT_COMMAND_SENDER);
+                if (bukkit instanceof Player && !((Player) bukkit).canSee(player)) {
+                    continue;
+                }
                 output.add(player.getName());
             }
 

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/PlayerArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/PlayerArgument.java
@@ -28,11 +28,13 @@ import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
 import cloud.commandframework.bukkit.BukkitCaptionKeys;
+import cloud.commandframework.bukkit.BukkitCommandContextKeys;
 import cloud.commandframework.captions.CaptionVariable;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import cloud.commandframework.exceptions.parsing.ParserException;
 import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -169,6 +171,10 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
             List<String> output = new ArrayList<>();
 
             for (Player player : Bukkit.getOnlinePlayers()) {
+                final CommandSender bukkit = commandContext.get(BukkitCommandContextKeys.BUKKIT_COMMAND_SENDER);
+                if (bukkit instanceof Player && !((Player) bukkit).canSee(player)) {
+                    continue;
+                }
                 output.add(player.getName());
             }
 

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/Location2DArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/Location2DArgument.java
@@ -27,6 +27,7 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.bukkit.BukkitCommandContextKeys;
 import cloud.commandframework.bukkit.parsers.location.LocationArgument.LocationParseException;
 import cloud.commandframework.context.CommandContext;
 import io.leangen.geantyref.TypeToken;
@@ -183,7 +184,7 @@ public final class Location2DArgument<C> extends CommandArgument<C, Location2D> 
                 coordinates[i] = coordinate.getParsedValue().orElseThrow(NullPointerException::new);
             }
             final Location originalLocation;
-            final CommandSender bukkitSender = commandContext.get("BukkitCommandSender");
+            final CommandSender bukkitSender = commandContext.get(BukkitCommandContextKeys.BUKKIT_COMMAND_SENDER);
 
             if (bukkitSender instanceof BlockCommandSender) {
                 originalLocation = ((BlockCommandSender) bukkitSender).getBlock().getLocation();

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/LocationArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/LocationArgument.java
@@ -29,6 +29,7 @@ import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
 import cloud.commandframework.arguments.standard.IntegerArgument;
 import cloud.commandframework.bukkit.BukkitCaptionKeys;
+import cloud.commandframework.bukkit.BukkitCommandContextKeys;
 import cloud.commandframework.captions.Caption;
 import cloud.commandframework.captions.CaptionVariable;
 import cloud.commandframework.context.CommandContext;
@@ -191,7 +192,7 @@ public final class LocationArgument<C> extends CommandArgument<C, Location> {
                 coordinates[i] = coordinate.getParsedValue().orElseThrow(NullPointerException::new);
             }
             final Location originalLocation;
-            final CommandSender bukkitSender = commandContext.get("BukkitCommandSender");
+            final CommandSender bukkitSender = commandContext.get(BukkitCommandContextKeys.BUKKIT_COMMAND_SENDER);
 
             if (bukkitSender instanceof BlockCommandSender) {
                 originalLocation = ((BlockCommandSender) bukkitSender).getBlock().getLocation();

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultipleEntitySelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultipleEntitySelectorArgument.java
@@ -27,6 +27,7 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.bukkit.BukkitCommandContextKeys;
 import cloud.commandframework.bukkit.CloudBukkitCapabilities;
 import cloud.commandframework.bukkit.arguments.selector.MultipleEntitySelector;
 import cloud.commandframework.context.CommandContext;
@@ -38,7 +39,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
 import java.util.Queue;
-import java.util.Set;
 import java.util.function.BiFunction;
 
 public final class MultipleEntitySelectorArgument<C> extends CommandArgument<C, MultipleEntitySelector> {
@@ -133,7 +133,7 @@ public final class MultipleEntitySelectorArgument<C> extends CommandArgument<C, 
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull Queue<@NonNull String> inputQueue
         ) {
-            if (!commandContext.<Set<CloudBukkitCapabilities>>get("CloudBukkitCapabilities").contains(
+            if (!commandContext.get(BukkitCommandContextKeys.CLOUD_BUKKIT_CAPABILITIES).contains(
                     CloudBukkitCapabilities.BRIGADIER)) {
                 return ArgumentParseResult.failure(new SelectorParseException(
                         "",
@@ -153,7 +153,7 @@ public final class MultipleEntitySelectorArgument<C> extends CommandArgument<C, 
 
             List<Entity> entities;
             try {
-                entities = Bukkit.selectEntities(commandContext.get("BukkitCommandSender"), input);
+                entities = Bukkit.selectEntities(commandContext.get(BukkitCommandContextKeys.BUKKIT_COMMAND_SENDER), input);
             } catch (IllegalArgumentException e) {
                 return ArgumentParseResult.failure(new SelectorParseException(
                         input,

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultiplePlayerSelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultiplePlayerSelectorArgument.java
@@ -27,6 +27,7 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.bukkit.BukkitCommandContextKeys;
 import cloud.commandframework.bukkit.CloudBukkitCapabilities;
 import cloud.commandframework.bukkit.arguments.selector.MultiplePlayerSelector;
 import cloud.commandframework.bukkit.parsers.PlayerArgument;
@@ -34,6 +35,7 @@ import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import com.google.common.collect.ImmutableList;
 import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -42,7 +44,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
-import java.util.Set;
 import java.util.function.BiFunction;
 
 public final class MultiplePlayerSelectorArgument<C> extends CommandArgument<C, MultiplePlayerSelector> {
@@ -146,7 +147,7 @@ public final class MultiplePlayerSelectorArgument<C> extends CommandArgument<C, 
             }
             inputQueue.remove();
 
-            if (!commandContext.<Set<CloudBukkitCapabilities>>get("CloudBukkitCapabilities").contains(
+            if (!commandContext.get(BukkitCommandContextKeys.CLOUD_BUKKIT_CAPABILITIES).contains(
                     CloudBukkitCapabilities.BRIGADIER)) {
                 @SuppressWarnings("deprecation")
                 Player player = Bukkit.getPlayer(input);
@@ -159,7 +160,7 @@ public final class MultiplePlayerSelectorArgument<C> extends CommandArgument<C, 
 
             List<Entity> entities;
             try {
-                entities = Bukkit.selectEntities(commandContext.get("BukkitCommandSender"), input);
+                entities = Bukkit.selectEntities(commandContext.get(BukkitCommandContextKeys.BUKKIT_COMMAND_SENDER), input);
             } catch (IllegalArgumentException e) {
                 return ArgumentParseResult.failure(new SelectorParseException(
                         input,
@@ -191,6 +192,10 @@ public final class MultiplePlayerSelectorArgument<C> extends CommandArgument<C, 
             List<String> output = new ArrayList<>();
 
             for (Player player : Bukkit.getOnlinePlayers()) {
+                final CommandSender bukkit = commandContext.get(BukkitCommandContextKeys.BUKKIT_COMMAND_SENDER);
+                if (bukkit instanceof Player && !((Player) bukkit).canSee(player)) {
+                    continue;
+                }
                 output.add(player.getName());
             }
 

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SingleEntitySelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SingleEntitySelectorArgument.java
@@ -27,6 +27,7 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.bukkit.BukkitCommandContextKeys;
 import cloud.commandframework.bukkit.CloudBukkitCapabilities;
 import cloud.commandframework.bukkit.arguments.selector.SingleEntitySelector;
 import cloud.commandframework.context.CommandContext;
@@ -38,7 +39,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
 import java.util.Queue;
-import java.util.Set;
 import java.util.function.BiFunction;
 
 public final class SingleEntitySelectorArgument<C> extends CommandArgument<C, SingleEntitySelector> {
@@ -139,7 +139,7 @@ public final class SingleEntitySelectorArgument<C> extends CommandArgument<C, Si
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull Queue<@NonNull String> inputQueue
         ) {
-            if (!commandContext.<Set<CloudBukkitCapabilities>>get("CloudBukkitCapabilities").contains(
+            if (!commandContext.get(BukkitCommandContextKeys.CLOUD_BUKKIT_CAPABILITIES).contains(
                     CloudBukkitCapabilities.BRIGADIER)) {
                 return ArgumentParseResult.failure(new SelectorParseException(
                         "",
@@ -159,7 +159,7 @@ public final class SingleEntitySelectorArgument<C> extends CommandArgument<C, Si
 
             List<Entity> entities;
             try {
-                entities = Bukkit.selectEntities(commandContext.get("BukkitCommandSender"), input);
+                entities = Bukkit.selectEntities(commandContext.get(BukkitCommandContextKeys.BUKKIT_COMMAND_SENDER), input);
             } catch (IllegalArgumentException e) {
                 return ArgumentParseResult.failure(new SelectorParseException(
                         input,

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SinglePlayerSelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SinglePlayerSelectorArgument.java
@@ -27,6 +27,7 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.bukkit.BukkitCommandContextKeys;
 import cloud.commandframework.bukkit.CloudBukkitCapabilities;
 import cloud.commandframework.bukkit.arguments.selector.SinglePlayerSelector;
 import cloud.commandframework.bukkit.parsers.PlayerArgument;
@@ -34,6 +35,7 @@ import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import com.google.common.collect.ImmutableList;
 import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -42,7 +44,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
-import java.util.Set;
 import java.util.function.BiFunction;
 
 public final class SinglePlayerSelectorArgument<C> extends CommandArgument<C, SinglePlayerSelector> {
@@ -152,7 +153,7 @@ public final class SinglePlayerSelectorArgument<C> extends CommandArgument<C, Si
             }
             inputQueue.remove();
 
-            if (!commandContext.<Set<CloudBukkitCapabilities>>get("CloudBukkitCapabilities").contains(
+            if (!commandContext.get(BukkitCommandContextKeys.CLOUD_BUKKIT_CAPABILITIES).contains(
                     CloudBukkitCapabilities.BRIGADIER)) {
                 @SuppressWarnings("deprecation")
                 Player player = Bukkit.getPlayer(input);
@@ -165,7 +166,7 @@ public final class SinglePlayerSelectorArgument<C> extends CommandArgument<C, Si
 
             List<Entity> entities;
             try {
-                entities = Bukkit.selectEntities(commandContext.get("BukkitCommandSender"), input);
+                entities = Bukkit.selectEntities(commandContext.get(BukkitCommandContextKeys.BUKKIT_COMMAND_SENDER), input);
             } catch (IllegalArgumentException e) {
                 return ArgumentParseResult.failure(new SelectorParseException(
                         input,
@@ -205,6 +206,10 @@ public final class SinglePlayerSelectorArgument<C> extends CommandArgument<C, Si
             List<String> output = new ArrayList<>();
 
             for (Player player : Bukkit.getOnlinePlayers()) {
+                final CommandSender bukkit = commandContext.get(BukkitCommandContextKeys.BUKKIT_COMMAND_SENDER);
+                if (bukkit instanceof Player && !((Player) bukkit).canSee(player)) {
+                    continue;
+                }
                 output.add(player.getName());
             }
 


### PR DESCRIPTION
Implements ItemStackArgument on Bukkit by wrapping the Brigadier ArgumentType on 1.13+, and falling back to the simple Material parser for older versions.

This is a cleaner approach for modern versions than #228 took, however is less functional on legacy versions.

Also in this PR: a little bit of general cleanup to the Bukkit impl