### PR TITLE
Bump Adventure API version to 4.8.1

### DIFF
--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -16,7 +16,7 @@ object Versions {
     const val commodore = "1.10"
     const val bungeecord = "1.8-SNAPSHOT"
     const val cloudburst = "1.0.0-SNAPSHOT"
-    const val adventureApi = "4.7.0"
+    const val adventureApi = "4.8.1"
     const val adventurePlatform = "4.0.0-SNAPSHOT"
     const val paperApi = "1.15.2-R0.1-SNAPSHOT"
     const val velocityApi = "1.1.0"

--- a/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/RichDescription.java
+++ b/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/RichDescription.java
@@ -26,7 +26,6 @@ package cloud.commandframework.minecraft.extras;
 import cloud.commandframework.ArgumentDescription;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
-import net.kyori.adventure.text.serializer.plain.PlainComponentSerializer;
 import net.kyori.adventure.translation.GlobalTranslator;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -112,7 +111,8 @@ public final class RichDescription implements ArgumentDescription {
     @Override
     @Deprecated
     public @NonNull String getDescription() {
-        return PlainComponentSerializer.plain().serialize(GlobalTranslator.render(this.contents, Locale.getDefault()));
+        return net.kyori.adventure.text.serializer.plain.PlainComponentSerializer.plain()
+                .serialize(GlobalTranslator.render(this.contents, Locale.getDefault()));
     }
 
     /**


### PR DESCRIPTION
Fixes classes missing at runtime when cloud is shaded using Maven, which doesn't correctly pick up the newer AdventureAPI version from adventure-bukkit-platform metadata.