### PR TITLE
Don't try to parse empty strings in flag parser

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/arguments/compound/FlagArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/compound/FlagArgument.java
@@ -428,6 +428,15 @@ public final class FlagArgument<C> extends CommandArgument<C, Object> {
                             this.currentFlagBeingParsed = Optional.of(currentFlag);
                             this.currentFlagNameBeingParsed = Optional.of(currentFlagName);
 
+                            // Don't attempt to parse empty strings
+                            if (inputQueue.peek().isEmpty()) {
+                                return ArgumentParseResult.failure(new FlagParseException(
+                                        currentFlag.getName(),
+                                        FailureReason.MISSING_ARGUMENT,
+                                        commandContext
+                                ));
+                            }
+
                             final ArgumentParseResult<?> result =
                                     ((CommandArgument) currentFlag.getCommandArgument())
                                             .getParser()


### PR DESCRIPTION
Parsers won't normally receive an empty string when called by the command tree, however the flag parser sometimes will supply an empty string.