### PR TITLE
Correct velocity example not appending error component

### DIFF
--- a/examples/example-velocity/src/main/java/cloud/commandframework/examples/velocity/ExampleVelocityPlugin.java
+++ b/examples/example-velocity/src/main/java/cloud/commandframework/examples/velocity/ExampleVelocityPlugin.java
@@ -83,7 +83,8 @@ public final class ExampleVelocityPlugin {
                         .color(NamedTextColor.WHITE)
                         .append(Component.text('['))
                         .append(Component.text("cloud-velocity-example", TextColor.color(0x1CBAE0)))
-                        .append(Component.text(']'))
+                        .append(Component.text("] "))
+                        .append(component)
                         .build())
                 .apply(commandManager, AudienceProvider.nativeAudience());
         commandManager.command(


### PR DESCRIPTION
Fixes the error message not being appended in the velocity example.