### PR TITLE
[JDA] Use Message#getContentDisplay

### DIFF
--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/JDACommandListener.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/JDACommandListener.java
@@ -69,7 +69,7 @@ public class JDACommandListener<C> extends ListenerAdapter {
         }
 
         final String prefix = this.commandManager.getPrefixMapper().apply(sender);
-        String content = message.getContentRaw();
+        String content = message.getContentDisplay();
 
         if (!content.startsWith(prefix)) {
             return;


### PR DESCRIPTION
`Message#getContentRaw` will not resolve any mentionables, such as users and channels. This makes the content `<#241774576822910976> <@115552359458799616>` instead of `#general @Griffin`.

I personally can't think of a reason why you would need the raw format. If you want the mentions, you should use arguments.

Closes https://github.com/ProjectEdenGG/Jayce/issues/1