### PR TITLE
paper: Add KeyedWorldArgument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Kotlin: Support for suspending command functions using `AnnotationParser<C>.installCoroutineSupport()`
 - Flags can be bound to a permission
+- Paper: Implement KeyedWorldArgument for matching worlds by their namespaced key
 
 ### Changed
 - Added `executeFuture` to `CommandExecutionHandler` which is now used internally. By default, this delegates to the old 

--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -18,7 +18,7 @@ object Versions {
     const val cloudburst = "1.0.0-SNAPSHOT"
     const val adventureApi = "4.8.1"
     const val adventurePlatform = "4.0.0-SNAPSHOT"
-    const val paperApi = "1.15.2-R0.1-SNAPSHOT"
+    const val paperApi = "1.16.5-R0.1-SNAPSHOT"
     const val velocityApi = "1.1.0"
     const val spongeApi7 = "7.3.0"
     const val jetbrainsAnnotations = "20.1.0"

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperBrigadierListener.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperBrigadierListener.java
@@ -55,7 +55,7 @@ class PaperBrigadierListener<C> implements Listener {
         this.brigadierManager.brigadierSenderMapper(sender ->
                 this.paperCommandManager.getCommandSenderMapper().apply(sender.getBukkitSender()));
 
-        new BukkitBrigadierMapper<>(this.paperCommandManager, this.brigadierManager);
+        new PaperBrigadierMapper<>(new BukkitBrigadierMapper<>(this.paperCommandManager, this.brigadierManager));
 
         this.brigadierManager
                 .backwardsBrigadierSenderMapper(new BukkitBackwardsBrigadierSenderMapper<>(this.paperCommandManager));

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperBrigadierMapper.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperBrigadierMapper.java
@@ -39,7 +39,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  */
 final class PaperBrigadierMapper<C> {
 
-    public PaperBrigadierMapper(
+    PaperBrigadierMapper(
             final @NonNull BukkitBrigadierMapper<C> mapper
     ) {
         this.registerMappings(mapper);

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperBrigadierMapper.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperBrigadierMapper.java
@@ -48,7 +48,7 @@ final class PaperBrigadierMapper<C> {
     private void registerMappings(final @NonNull BukkitBrigadierMapper<C> mapper) {
         final Class<?> keyed = CraftBukkitReflection.findClass("org.bukkit.Keyed");
         if (keyed != null && keyed.isAssignableFrom(World.class)) {
-            mapper.mapSimpleNMS(new TypeToken<KeyedWorldArgument.KeyedWorldParser<C>>() {
+            mapper.mapSimpleNMS(new TypeToken<KeyedWorldArgument.Parser<C>>() {
             }, "resource_location");
         }
     }

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperBrigadierMapper.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperBrigadierMapper.java
@@ -1,0 +1,56 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.paper;
+
+import cloud.commandframework.bukkit.BukkitBrigadierMapper;
+import cloud.commandframework.bukkit.internal.CraftBukkitReflection;
+import cloud.commandframework.paper.argument.KeyedWorldArgument;
+import io.leangen.geantyref.TypeToken;
+import org.bukkit.World;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Brigadier mappings for Paper native Brigadier. This is currently only used when the PaperBrigadierListener is in use,
+ * not when the CloudCommodoreManager is in use on Paper. This is because all argument types registered here require
+ * Paper 1.15+ anyways.
+ *
+ * @param <C> sender type
+ */
+final class PaperBrigadierMapper<C> {
+
+    public PaperBrigadierMapper(
+            final @NonNull BukkitBrigadierMapper<C> mapper
+    ) {
+        this.registerMappings(mapper);
+    }
+
+    private void registerMappings(final @NonNull BukkitBrigadierMapper<C> mapper) {
+        final Class<?> keyed = CraftBukkitReflection.findClass("org.bukkit.Keyed");
+        if (keyed != null && keyed.isAssignableFrom(World.class)) {
+            mapper.mapSimpleNMS(new TypeToken<KeyedWorldArgument.KeyedWorldParser<C>>() {
+            }, "resource_location");
+        }
+    }
+
+}

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/argument/KeyedWorldArgument.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/argument/KeyedWorldArgument.java
@@ -42,7 +42,7 @@ import java.util.Queue;
 import java.util.function.BiFunction;
 
 /**
- * cloud argument type that parses Bukkit {@link World worlds} from a namespaced key
+ * Argument type that parses Bukkit {@link World worlds} from a {@link NamespacedKey}.
  *
  * @param <C> Command sender type
  */
@@ -55,44 +55,44 @@ public class KeyedWorldArgument<C> extends CommandArgument<C, World> {
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(required, name, new KeyedWorldParser<>(), defaultValue, World.class, suggestionsProvider, defaultDescription);
+        super(required, name, new Parser<>(), defaultValue, World.class, suggestionsProvider, defaultDescription);
     }
 
     /**
-     * Create a new builder
+     * Create a new {@link Builder}.
      *
      * @param name Name of the argument
      * @param <C>  Command sender type
      * @return Created builder
      */
-    public static <C> KeyedWorldArgument.@NonNull Builder<C> newBuilder(final @NonNull String name) {
+    public static <C> KeyedWorldArgument.@NonNull Builder<C> builder(final @NonNull String name) {
         return new KeyedWorldArgument.Builder<>(name);
     }
 
     /**
-     * Create a new required argument
+     * Create a new required {@link KeyedWorldArgument}.
      *
      * @param name Argument name
      * @param <C>  Command sender type
      * @return Created argument
      */
     public static <C> @NonNull KeyedWorldArgument<C> of(final @NonNull String name) {
-        return KeyedWorldArgument.<C>newBuilder(name).asRequired().build();
+        return KeyedWorldArgument.<C>builder(name).asRequired().build();
     }
 
     /**
-     * Create a new optional argument
+     * Create a new optional {@link KeyedWorldArgument}.
      *
      * @param name Argument name
      * @param <C>  Command sender type
      * @return Created argument
      */
     public static <C> @NonNull KeyedWorldArgument<C> optional(final @NonNull String name) {
-        return KeyedWorldArgument.<C>newBuilder(name).asOptional().build();
+        return KeyedWorldArgument.<C>builder(name).asOptional().build();
     }
 
     /**
-     * Create a new optional argument with a default value
+     * Create a new {@link KeyedWorldArgument} with the specified default value.
      *
      * @param name         Argument name
      * @param defaultValue Default value
@@ -103,7 +103,7 @@ public class KeyedWorldArgument<C> extends CommandArgument<C, World> {
             final @NonNull String name,
             final @NonNull String defaultValue
     ) {
-        return KeyedWorldArgument.<C>newBuilder(name).asOptionalWithDefault(defaultValue).build();
+        return KeyedWorldArgument.<C>builder(name).asOptionalWithDefault(defaultValue).build();
     }
 
     public static final class Builder<C> extends CommandArgument.TypedBuilder<C, World, Builder<C>> {
@@ -125,7 +125,7 @@ public class KeyedWorldArgument<C> extends CommandArgument<C, World> {
 
     }
 
-    public static final class KeyedWorldParser<C> implements ArgumentParser<C, World> {
+    public static final class Parser<C> implements ArgumentParser<C, World> {
 
         @Override
         public @NonNull ArgumentParseResult<@NonNull World> parse(
@@ -135,7 +135,7 @@ public class KeyedWorldArgument<C> extends CommandArgument<C, World> {
             final String input = inputQueue.peek();
             if (input == null) {
                 return ArgumentParseResult.failure(new NoInputProvidedException(
-                        KeyedWorldParser.class,
+                        Parser.class,
                         commandContext
                 ));
             }

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/argument/KeyedWorldArgument.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/argument/KeyedWorldArgument.java
@@ -1,4 +1,27 @@
-package cloud.commandframework.paper.parsers;
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.paper.argument;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
@@ -42,7 +65,7 @@ public class KeyedWorldArgument<C> extends CommandArgument<C, World> {
      * @param <C>  Command sender type
      * @return Created builder
      */
-    public static <C> CommandArgument.@NonNull Builder<C, World> newBuilder(final @NonNull String name) {
+    public static <C> KeyedWorldArgument.@NonNull Builder<C> newBuilder(final @NonNull String name) {
         return new KeyedWorldArgument.Builder<>(name);
     }
 
@@ -53,7 +76,7 @@ public class KeyedWorldArgument<C> extends CommandArgument<C, World> {
      * @param <C>  Command sender type
      * @return Created argument
      */
-    public static <C> @NonNull CommandArgument<C, World> of(final @NonNull String name) {
+    public static <C> @NonNull KeyedWorldArgument<C> of(final @NonNull String name) {
         return KeyedWorldArgument.<C>newBuilder(name).asRequired().build();
     }
 
@@ -64,7 +87,7 @@ public class KeyedWorldArgument<C> extends CommandArgument<C, World> {
      * @param <C>  Command sender type
      * @return Created argument
      */
-    public static <C> @NonNull CommandArgument<C, World> optional(final @NonNull String name) {
+    public static <C> @NonNull KeyedWorldArgument<C> optional(final @NonNull String name) {
         return KeyedWorldArgument.<C>newBuilder(name).asOptional().build();
     }
 
@@ -76,21 +99,21 @@ public class KeyedWorldArgument<C> extends CommandArgument<C, World> {
      * @param <C>          Command sender type
      * @return Created argument
      */
-    public static <C> @NonNull CommandArgument<C, World> optional(
+    public static <C> @NonNull KeyedWorldArgument<C> optional(
             final @NonNull String name,
             final @NonNull String defaultValue
     ) {
         return KeyedWorldArgument.<C>newBuilder(name).asOptionalWithDefault(defaultValue).build();
     }
 
-    public static final class Builder<C> extends CommandArgument.Builder<C, World> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, World, Builder<C>> {
 
         private Builder(final @NonNull String name) {
             super(World.class, name);
         }
 
         @Override
-        public @NonNull CommandArgument<@NonNull C, @NonNull World> build() {
+        public @NonNull KeyedWorldArgument<C> build() {
             return new KeyedWorldArgument<>(
                     this.isRequired(),
                     this.getName(),

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/argument/package-info.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/argument/package-info.java
@@ -1,0 +1,27 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+/**
+ * Paper specific command arguments
+ */
+package cloud.commandframework.paper.argument;

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/parsers/KeyedWorldArgument.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/parsers/KeyedWorldArgument.java
@@ -1,0 +1,151 @@
+package cloud.commandframework.paper.parsers;
+
+import cloud.commandframework.ArgumentDescription;
+import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.parser.ArgumentParseResult;
+import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.bukkit.parsers.WorldArgument;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.World;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.function.BiFunction;
+
+/**
+ * cloud argument type that parses Bukkit {@link World worlds} from a namespaced key
+ *
+ * @param <C> Command sender type
+ */
+public class KeyedWorldArgument<C> extends CommandArgument<C, World> {
+
+    protected KeyedWorldArgument(
+            final boolean required,
+            final @NonNull String name,
+            final @NonNull String defaultValue,
+            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @NonNull ArgumentDescription defaultDescription
+    ) {
+        super(required, name, new KeyedWorldParser<>(), defaultValue, World.class, suggestionsProvider, defaultDescription);
+    }
+
+    /**
+     * Create a new builder
+     *
+     * @param name Name of the argument
+     * @param <C>  Command sender type
+     * @return Created builder
+     */
+    public static <C> CommandArgument.@NonNull Builder<C, World> newBuilder(final @NonNull String name) {
+        return new KeyedWorldArgument.Builder<>(name);
+    }
+
+    /**
+     * Create a new required argument
+     *
+     * @param name Argument name
+     * @param <C>  Command sender type
+     * @return Created argument
+     */
+    public static <C> @NonNull CommandArgument<C, World> of(final @NonNull String name) {
+        return KeyedWorldArgument.<C>newBuilder(name).asRequired().build();
+    }
+
+    /**
+     * Create a new optional argument
+     *
+     * @param name Argument name
+     * @param <C>  Command sender type
+     * @return Created argument
+     */
+    public static <C> @NonNull CommandArgument<C, World> optional(final @NonNull String name) {
+        return KeyedWorldArgument.<C>newBuilder(name).asOptional().build();
+    }
+
+    /**
+     * Create a new optional argument with a default value
+     *
+     * @param name         Argument name
+     * @param defaultValue Default value
+     * @param <C>          Command sender type
+     * @return Created argument
+     */
+    public static <C> @NonNull CommandArgument<C, World> optional(
+            final @NonNull String name,
+            final @NonNull String defaultValue
+    ) {
+        return KeyedWorldArgument.<C>newBuilder(name).asOptionalWithDefault(defaultValue).build();
+    }
+
+    public static final class Builder<C> extends CommandArgument.Builder<C, World> {
+
+        private Builder(final @NonNull String name) {
+            super(World.class, name);
+        }
+
+        @Override
+        public @NonNull CommandArgument<@NonNull C, @NonNull World> build() {
+            return new KeyedWorldArgument<>(
+                    this.isRequired(),
+                    this.getName(),
+                    this.getDefaultValue(),
+                    this.getSuggestionsProvider(),
+                    this.getDefaultDescription()
+            );
+        }
+
+    }
+
+    public static final class KeyedWorldParser<C> implements ArgumentParser<C, World> {
+
+        @Override
+        public @NonNull ArgumentParseResult<@NonNull World> parse(
+                @NonNull final CommandContext<@NonNull C> commandContext,
+                @NonNull final Queue<@NonNull String> inputQueue
+        ) {
+            final String input = inputQueue.peek();
+            if (input == null) {
+                return ArgumentParseResult.failure(new NoInputProvidedException(
+                        KeyedWorldParser.class,
+                        commandContext
+                ));
+            }
+
+            final NamespacedKey key = NamespacedKey.fromString(input);
+            if (key == null) {
+                return ArgumentParseResult.failure(new WorldArgument.WorldParseException(input, commandContext));
+            }
+
+            final World world = Bukkit.getWorld(key);
+            if (world == null) {
+                return ArgumentParseResult.failure(new WorldArgument.WorldParseException(input, commandContext));
+            }
+
+            inputQueue.remove();
+            return ArgumentParseResult.success(world);
+        }
+
+        @Override
+        public @NonNull List<@NonNull String> suggestions(
+                final @NonNull CommandContext<C> commandContext,
+                final @NonNull String input
+        ) {
+            final List<String> completions = new ArrayList<>();
+            for (final World world : Bukkit.getWorlds()) {
+                if (world.getKey().getNamespace().equals(NamespacedKey.MINECRAFT)) {
+                    completions.add(world.getKey().getKey());
+                } else {
+                    completions.add(world.getKey().toString());
+                }
+            }
+            return completions;
+        }
+
+    }
+}


### PR DESCRIPTION
Adds an argument that takes advantage of Paper exposing world's namespaced keys (which should really be the preferred way to reference a world, not its level name).