### PR TITLE
core: Fix single static argument not formatting properly

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/arguments/StandardCommandSyntaxFormatter.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/StandardCommandSyntaxFormatter.java
@@ -104,6 +104,9 @@ public class StandardCommandSyntaxFormatter<C> implements CommandSyntaxFormatter
             } else if (argument instanceof FlagArgument) {
                 formattingInstance.appendBlankSpace();
                 formattingInstance.appendFlag((FlagArgument<?>) argument);
+            } else if (argument instanceof StaticArgument) {
+                formattingInstance.appendBlankSpace();
+                formattingInstance.appendLiteral((StaticArgument<?>) argument);
             } else {
                 formattingInstance.appendBlankSpace();
                 if (argument.isRequired()) {


### PR DESCRIPTION
This fixes the issue, when single literal/static argument is formatted as non-static:

Constructing `/foo` command:
```java
manager.command(builder
        .literal("arg")
        .literal("0")
        .handler(context -> { /**/ }));

manager.command(builder
        .literal("arg")
        .literal("1")
        .handler(context -> { /**/ }));

manager.command(builder
        .literal("arg")
        .literal("2")
        .handler(context -> { /**/ }));
```

Before:
![image](https://user-images.githubusercontent.com/33582973/132126470-87bc4d75-e39e-4012-9d7e-c034efcb2db9.png)

After:
![image](https://user-images.githubusercontent.com/33582973/132126479-de03da7a-2653-43ac-b8fb-a100978d77ad.png)

