### PR TITLE
core: fix And/OrPermission losing conditional tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Bukkit: Permission checking and syntax string for Bukkit '/help' command
+- And/OrPermission factory method `of` did not preserve the conditional tree
 
 ## [1.5.0]
 

--- a/cloud-core/src/main/java/cloud/commandframework/permission/AndPermission.java
+++ b/cloud-core/src/main/java/cloud/commandframework/permission/AndPermission.java
@@ -50,11 +50,7 @@ public final class AndPermission implements CommandPermission {
      * @return Constructed permission
      */
     public static @NonNull CommandPermission of(final @NonNull Collection<CommandPermission> permissions) {
-        final Set<CommandPermission> permissionSet = new HashSet<>();
-        for (final CommandPermission permission : permissions) {
-            permissionSet.addAll(permission.getPermissions());
-        }
-        return new AndPermission(permissionSet);
+        return new AndPermission(new HashSet<>(permissions));
     }
 
     @Override

--- a/cloud-core/src/main/java/cloud/commandframework/permission/OrPermission.java
+++ b/cloud-core/src/main/java/cloud/commandframework/permission/OrPermission.java
@@ -50,11 +50,7 @@ public final class OrPermission implements CommandPermission {
      * @return Constructed permission
      */
     public static @NonNull CommandPermission of(final @NonNull Collection<CommandPermission> permissions) {
-        final Set<CommandPermission> permissionSet = new HashSet<>();
-        for (final CommandPermission permission : permissions) {
-            permissionSet.addAll(permission.getPermissions());
-        }
-        return new OrPermission(permissionSet);
+        return new OrPermission(new HashSet<>(permissions));
     }
 
     @Override


### PR DESCRIPTION
If you tried to construct an Or permission from two and permissions, you would lose the `and` part of the conditional tree and just one big or permission would be created.