### PR TITLE
feat: delegate bukkit permission check to cloud manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Kotlin: Support for suspending command functions using `AnnotationParser<C>.installCoroutineSupport()`
 - Flags can be bound to a permission
 - Paper: Implement KeyedWorldArgument for matching worlds by their namespaced key
+- Bukkit: Delegate permission check in BukkitCommand to command manager
 
 ### Changed
 - Added `executeFuture` to `CommandExecutionHandler` which is now used internally. By default, this delegates to the old 

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommand.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommand.java
@@ -198,4 +198,10 @@ final class BukkitCommand<C> extends org.bukkit.command.Command implements Plugi
         return this.manager.getCommandSyntaxFormatter().apply(this.cloudCommand.getArguments(), null);
     }
 
+    @Override
+    public boolean testPermissionSilent(@NonNull final CommandSender target) {
+        return this.manager.hasPermission(this.manager.getCommandSenderMapper().apply(target),
+                this.cloudCommand.getCommandPermission());
+    }
+
 }


### PR DESCRIPTION
Its possible this was left out for some reason, and if that's the case well whatever, but I noticed that permission changes were not being reflected in the bukkit help menu, and after some debugging, realized the permission check in BukkitCommand was always true because the permission field was null.