### PR TITLE
annotations: Also apply builder modifiers from class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Added `executeFuture` to `CommandExecutionHandler` which is now used internally. By default, this delegates to the old 
   `execute` method
+- Annotations: Apply builder modifiers from class annotations ([#303](https://github.com/Incendo/cloud/pull/303))
 
 ### Fixed
 - Bukkit: Permission checking and syntax string for Bukkit '/help' command

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/AnnotationParser.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/AnnotationParser.java
@@ -522,7 +522,10 @@ public final class AnnotationParser<C> {
             for (final CommandFlag<?> flag : flags) {
                 builder = builder.flag(flag);
             }
-            for (final Annotation annotation : method.getDeclaredAnnotations()) {
+
+            /* Apply builder modifiers */
+            for (final Annotation annotation
+                    : AnnotationAccessor.of(classAnnotations, AnnotationAccessor.of(method)).annotations()) {
                 @SuppressWarnings("rawtypes")
                 final BiFunction builderModifier = this.builderModifiers.get(annotation.annotationType());
                 if (builderModifier == null) {
@@ -530,6 +533,7 @@ public final class AnnotationParser<C> {
                 }
                 builder = (Command.Builder<C>) builderModifier.apply(annotation, builder);
             }
+
             /* Construct and register the command */
             final Command<C> builtCommand = builder.build();
             commands.add(builtCommand);


### PR DESCRIPTION
Current behavior allows applying the same builder modifier to a method multiple times by using the annotation more than once.

I think it might be more intuitive if a builder modifier applied to the class was only used on methods which don't also have that modifier applied (ex below), but I didn't make that change to keep the aforementioned behavior of repeating annotations.

```java
@MyAnnotation("Class default")
class Commands {
  @CommandMethod(...)
  void someCommandUsingClassDefaultForMyAnnotation(...) {}

  @MyAnnotation("Different value")
  @CommandMethod(...)
  void usesSpecificValueInstead(...) {}
}
```

That kind of behavior is still possible as the class builder modifiers will be applied before the method specific ones, but both modifiers will apply.