### PR TITLE
Make CommandExecutionHandler#executeFuture return CompletableFuture<Void> instead of CompletableFuture<Object>

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/execution/CommandExecutionHandler.java
+++ b/cloud-core/src/main/java/cloud/commandframework/execution/CommandExecutionHandler.java
@@ -54,8 +54,8 @@ public interface CommandExecutionHandler<C> {
      * @return future that completes when the command has finished execution
      * @since 1.6.0
      */
-    default CompletableFuture<@Nullable Object> executeFuture(@NonNull CommandContext<C> commandContext) {
-        final CompletableFuture<Object> future = new CompletableFuture<>();
+    default CompletableFuture<@Nullable Void> executeFuture(@NonNull CommandContext<C> commandContext) {
+        final CompletableFuture<Void> future = new CompletableFuture<>();
         try {
             this.execute(commandContext);
             /* The command executed successfully */
@@ -97,7 +97,7 @@ public interface CommandExecutionHandler<C> {
         }
 
         @Override
-        CompletableFuture<@Nullable Object> executeFuture(
+        CompletableFuture<@Nullable Void> executeFuture(
                 @NonNull CommandContext<C> commandContext
         );
 

--- a/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/coroutines/KotlinAnnotatedMethods.kt
+++ b/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/coroutines/KotlinAnnotatedMethods.kt
@@ -68,13 +68,14 @@ private class KotlinMethodCommandExecutionHandler<C>(
     context: CommandMethodContext<C>
 ) : MethodCommandExecutionHandler<C>(context) {
 
-    override fun executeFuture(commandContext: CommandContext<C>): CompletableFuture<Any?> {
+    override fun executeFuture(commandContext: CommandContext<C>): CompletableFuture<Void?> {
         val instance = context().instance()
         val params = createParameterValues(commandContext, commandContext.flags(), false)
         // We need to propagate exceptions to the caller.
         return coroutineScope
-            .async(this@KotlinMethodCommandExecutionHandler.coroutineContext) {
+            .async<Void?>(this@KotlinMethodCommandExecutionHandler.coroutineContext) {
                 context().method().kotlinFunction?.callSuspend(instance, *params.toTypedArray())
+                null
             }
             .asCompletableFuture()
     }


### PR DESCRIPTION
The value of the completed future is never used, void makes this more obvious