### PR TITLE
Fix cloud swallowing exceptions in `suspend` methods.

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/execution/AsynchronousCommandExecutionCoordinator.java
+++ b/cloud-core/src/main/java/cloud/commandframework/execution/AsynchronousCommandExecutionCoordinator.java
@@ -51,16 +51,6 @@ public final class AsynchronousCommandExecutionCoordinator<C> extends CommandExe
     private final Executor executor;
     private final boolean synchronizeParsing;
 
-    /**
-     * Create a new {@link Builder} instance
-     *
-     * @param <C> Command sender type
-     * @return Builder
-     */
-    public static <C> @NonNull Builder<C> newBuilder() {
-        return new Builder<>();
-    }
-
     private AsynchronousCommandExecutionCoordinator(
             final @Nullable Executor executor,
             final boolean synchronizeParsing,
@@ -70,6 +60,16 @@ public final class AsynchronousCommandExecutionCoordinator<C> extends CommandExe
         this.executor = executor == null ? ForkJoinPool.commonPool() : executor;
         this.synchronizeParsing = synchronizeParsing;
         this.commandManager = commandTree.getCommandManager();
+    }
+
+    /**
+     * Create a new {@link Builder} instance
+     *
+     * @param <C> Command sender type
+     * @return Builder
+     */
+    public static <C> @NonNull Builder<C> newBuilder() {
+        return new Builder<>();
     }
 
     @Override

--- a/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/coroutines/KotlinAnnotatedMethods.kt
+++ b/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/coroutines/KotlinAnnotatedMethods.kt
@@ -27,13 +27,13 @@ import cloud.commandframework.annotations.AnnotationParser
 import cloud.commandframework.annotations.MethodCommandExecutionHandler
 import cloud.commandframework.context.CommandContext
 import cloud.commandframework.execution.CommandExecutionCoordinator
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.future.future
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 import java.util.concurrent.CompletableFuture
 import java.util.function.Predicate
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.future.future
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.reflect.full.callSuspend
@@ -45,15 +45,15 @@ import kotlin.reflect.jvm.kotlinFunction
  * @since 1.6.0
  */
 public fun <C> AnnotationParser<C>.installCoroutineSupport(
-        scope: CoroutineScope = GlobalScope,
-        context: CoroutineContext = EmptyCoroutineContext
+    scope: CoroutineScope = GlobalScope,
+    context: CoroutineContext = EmptyCoroutineContext
 ) {
     if (manager().commandExecutionCoordinator() is CommandExecutionCoordinator.SimpleCoordinator) {
         RuntimeException(
-                """You are highly advised to not use the simple command execution coordinator together
+            """You are highly advised to not use the simple command execution coordinator together
                             with coroutine support. Consider using the asynchronous command execution coordinator instead."""
         )
-                .printStackTrace()
+            .printStackTrace()
     }
 
     val predicate = Predicate<Method> { it.kotlinFunction?.isSuspend == true }
@@ -63,9 +63,9 @@ public fun <C> AnnotationParser<C>.installCoroutineSupport(
 }
 
 private class KotlinMethodCommandExecutionHandler<C>(
-        private val coroutineScope: CoroutineScope,
-        private val coroutineContext: CoroutineContext,
-        context: CommandMethodContext<C>
+    private val coroutineScope: CoroutineScope,
+    private val coroutineContext: CoroutineContext,
+    context: CommandMethodContext<C>
 ) : MethodCommandExecutionHandler<C>(context) {
 
     override fun executeFuture(commandContext: CommandContext<C>): CompletableFuture<Void?> {

--- a/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/coroutines/KotlinAnnotatedMethods.kt
+++ b/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/coroutines/KotlinAnnotatedMethods.kt
@@ -27,13 +27,13 @@ import cloud.commandframework.annotations.AnnotationParser
 import cloud.commandframework.annotations.MethodCommandExecutionHandler
 import cloud.commandframework.context.CommandContext
 import cloud.commandframework.execution.CommandExecutionCoordinator
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.async
-import kotlinx.coroutines.future.asCompletableFuture
+import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 import java.util.concurrent.CompletableFuture
 import java.util.function.Predicate
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.future.future
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.reflect.full.callSuspend
@@ -45,15 +45,15 @@ import kotlin.reflect.jvm.kotlinFunction
  * @since 1.6.0
  */
 public fun <C> AnnotationParser<C>.installCoroutineSupport(
-    scope: CoroutineScope = GlobalScope,
-    context: CoroutineContext = EmptyCoroutineContext
+        scope: CoroutineScope = GlobalScope,
+        context: CoroutineContext = EmptyCoroutineContext
 ) {
     if (manager().commandExecutionCoordinator() is CommandExecutionCoordinator.SimpleCoordinator) {
         RuntimeException(
-            """You are highly advised to not use the simple command execution coordinator together
+                """You are highly advised to not use the simple command execution coordinator together
                             with coroutine support. Consider using the asynchronous command execution coordinator instead."""
         )
-            .printStackTrace()
+                .printStackTrace()
     }
 
     val predicate = Predicate<Method> { it.kotlinFunction?.isSuspend == true }
@@ -63,20 +63,23 @@ public fun <C> AnnotationParser<C>.installCoroutineSupport(
 }
 
 private class KotlinMethodCommandExecutionHandler<C>(
-    private val coroutineScope: CoroutineScope,
-    private val coroutineContext: CoroutineContext,
-    context: CommandMethodContext<C>
+        private val coroutineScope: CoroutineScope,
+        private val coroutineContext: CoroutineContext,
+        context: CommandMethodContext<C>
 ) : MethodCommandExecutionHandler<C>(context) {
 
     override fun executeFuture(commandContext: CommandContext<C>): CompletableFuture<Void?> {
         val instance = context().instance()
         val params = createParameterValues(commandContext, commandContext.flags(), false)
+
         // We need to propagate exceptions to the caller.
-        return coroutineScope
-            .async<Void?>(this@KotlinMethodCommandExecutionHandler.coroutineContext) {
-                context().method().kotlinFunction?.callSuspend(instance, *params.toTypedArray())
-                null
+        return coroutineScope.future(this@KotlinMethodCommandExecutionHandler.coroutineContext) {
+            try {
+                context().method().kotlinFunction!!.callSuspend(instance, *params.toTypedArray())
+            } catch (e: InvocationTargetException) { // unwrap invocation exception
+                e.cause?.let { throw it } ?: throw e // if cause exists, throw, else rethrow invocation exception
             }
-            .asCompletableFuture()
+            null
+        }
     }
 }

--- a/cloud-kotlin-extensions/src/test/kotlin/cloud/commandframework/kotlin/coroutines/KotlinAnnotatedMethodsTest.kt
+++ b/cloud-kotlin-extensions/src/test/kotlin/cloud/commandframework/kotlin/coroutines/KotlinAnnotatedMethodsTest.kt
@@ -31,9 +31,6 @@ import cloud.commandframework.execution.AsynchronousCommandExecutionCoordinator
 import cloud.commandframework.internal.CommandRegistrationHandler
 import cloud.commandframework.meta.CommandMeta
 import cloud.commandframework.meta.SimpleCommandMeta
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.runBlocking
@@ -41,6 +38,9 @@ import kotlinx.coroutines.withContext
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 class KotlinAnnotatedMethodsTest {
 
@@ -65,8 +65,8 @@ class KotlinAnnotatedMethodsTest {
         AnnotationParser(commandManager, TestCommandSender::class.java) {
             SimpleCommandMeta.empty()
         }
-                .also { it.installCoroutineSupport() }
-                .parse(CommandMethods())
+            .also { it.installCoroutineSupport() }
+            .parse(CommandMethods())
 
         commandManager.executeCommand(TestCommandSender(), "test").await()
     }
@@ -75,8 +75,9 @@ class KotlinAnnotatedMethodsTest {
     fun `test suspending command methods with exception`(): Unit = runBlocking {
         AnnotationParser(commandManager, TestCommandSender::class.java) {
             SimpleCommandMeta.empty()
-        }.also { it.installCoroutineSupport() }
-                .parse(CommandMethods())
+        }
+            .also { it.installCoroutineSupport() }
+            .parse(CommandMethods())
 
         assertThrows<CommandExecutionException> {
             commandManager.executeCommand(TestCommandSender(), "test-exception").await()
@@ -86,10 +87,10 @@ class KotlinAnnotatedMethodsTest {
     private class TestCommandSender
 
     private class TestCommandManager : CommandManager<TestCommandSender>(
-            AsynchronousCommandExecutionCoordinator.newBuilder<TestCommandSender>()
-                    .withExecutor(executorService)
-                    .build(),
-            CommandRegistrationHandler.nullCommandRegistrationHandler()
+        AsynchronousCommandExecutionCoordinator.newBuilder<TestCommandSender>()
+            .withExecutor(executorService)
+            .build(),
+        CommandRegistrationHandler.nullCommandRegistrationHandler()
     ) {
 
         override fun hasPermission(sender: TestCommandSender, permission: String): Boolean = true
@@ -101,9 +102,9 @@ class KotlinAnnotatedMethodsTest {
 
         @CommandMethod("test")
         public suspend fun suspendingCommand(): Unit =
-                withContext(Dispatchers.Default) {
-                    println("called from thread: ${Thread.currentThread().name}")
-                }
+            withContext(Dispatchers.Default) {
+                println("called from thread: ${Thread.currentThread().name}")
+            }
 
         @CommandMethod("test-exception")
         public suspend fun suspendingCommandWithException(): Unit = throw IllegalStateException()


### PR DESCRIPTION
Fixes #306.

Moves the `resultFuture.complete` invocation to the `commandConsumer` lambda rather than completing it before the command execution is finished.

Previously, the `resultFuture` was being `complete`d immediately after `commandConsumer` was invoked, and since `commandConsumer` runs in a non-blocking manner, it swallowed the exception.

Therefore, `resultFuture.complete` was moved into the `commandConsumer`, specifically within `whenComplete`. That way, it would only be completed when the execution has been finished.

There was also some other minor refactors, so that there's only one `return resultFuture`, which occurs at the end of the method, just to keep the code less complex.