### PR TITLE
Allow parser parameter annotations for flags as well

### DIFF
--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagExtractor.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagExtractor.java
@@ -28,14 +28,15 @@ import cloud.commandframework.CommandManager;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.flags.CommandFlag;
 import cloud.commandframework.arguments.parser.ArgumentParser;
-import cloud.commandframework.arguments.parser.ParserParameters;
 import cloud.commandframework.arguments.parser.ParserRegistry;
 import cloud.commandframework.permission.Permission;
 import io.leangen.geantyref.TypeToken;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -67,13 +68,15 @@ final class FlagExtractor implements Function<@NonNull Method, Collection<@NonNu
             if (parameter.getType().equals(boolean.class)) {
                 flags.add(builder.build());
             } else {
+                final TypeToken<?> token = TypeToken.get(parameter.getType());
+                final Collection<Annotation> annotations = Arrays.asList(parameter.getAnnotations());
                 final ParserRegistry<?> registry = this.commandManager.getParserRegistry();
                 final ArgumentParser<?, ?> parser;
                 if (flag.parserName().isEmpty()) {
-                    parser = registry.createParser(TypeToken.get(parameter.getType()), ParserParameters.empty())
+                    parser = registry.createParser(token, registry.parseAnnotations(token, annotations))
                             .orElse(null);
                 } else {
-                    parser = registry.createParser(flag.parserName(), ParserParameters.empty())
+                    parser = registry.createParser(flag.parserName(), registry.parseAnnotations(token, annotations))
                             .orElse(null);
                 }
                 if (parser == null) {

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
@@ -26,6 +26,8 @@ package cloud.commandframework.annotations;
 import cloud.commandframework.Command;
 import cloud.commandframework.CommandManager;
 import cloud.commandframework.annotations.parsers.Parser;
+import cloud.commandframework.annotations.specifier.Greedy;
+import cloud.commandframework.annotations.specifier.Quoted;
 import cloud.commandframework.annotations.specifier.Range;
 import cloud.commandframework.annotations.suggestions.Suggestions;
 import cloud.commandframework.arguments.StaticArgument;
@@ -37,29 +39,27 @@ import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.meta.SimpleCommandMeta;
 import io.leangen.geantyref.TypeToken;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-
-import java.util.Set;
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.CompletionException;
 import java.util.function.BiFunction;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AnnotationParserTest {
@@ -107,6 +107,8 @@ class AnnotationParserTest {
                 manager.executeCommand(new TestCommandSender(), "test 101").join());
         manager.executeCommand(new TestCommandSender(), "flagcommand -p").join();
         manager.executeCommand(new TestCommandSender(), "flagcommand --print --word peanut").join();
+        manager.executeCommand(new TestCommandSender(), "parserflagcommand -s \"Hello World\"").join();
+        manager.executeCommand(new TestCommandSender(), "parserflagcommand -s \"Hello World\" -o This is a test").join();
         manager.executeCommand(new TestCommandSender(), "class method").join();
     }
 
@@ -242,6 +244,15 @@ class AnnotationParserTest {
         if (print) {
             System.out.println(word);
         }
+    }
+
+    @CommandMethod("parserflagcommand")
+    public void testQuotedFlags(
+            final TestCommandSender sender,
+            @Flag(value = "sentence", aliases = "s") @Quoted final String sentence,
+            @Flag(value = "other", aliases = "o") @Greedy final String otherStuff
+    ) {
+        System.out.println(sentence + (otherStuff == null ? "" : " " + otherStuff));
     }
 
     @CommandMethod("namedsuggestions <input>")


### PR DESCRIPTION
Evening,

i just stumbled over this behaviour of cloud to not allow argument annotations like `@Quoted` or `@Greedy` for flags. I have a specific use case for that. A user should be able using our template installer to define an executable for the build step. The following method to handle the command is used:

```java
  @CommandMethod("template|t install <template> <versionType> <version>")
  public void installTemplate(
    CommandSource source,
    @Argument("template") ServiceTemplate serviceTemplate,
    @Argument("versionType") ServiceVersionType versionType,
    @Argument("version") ServiceVersion serviceVersion,
    @Flag("force") boolean forceInstall,
    @Flag("executable") @Quoted String executable
  ) {
  ```
  
  The executable should be the full path to a java installation (in my case on windows `java.exe`). When I now tried to run the following command:
 `t install local:Lobby/default magma 1.12.2 --executable "C:\Program Files\Java\jdk1.8.0_241\bin\java.exe"`
 
 cloud failed with:
 `FlagArgument$FlagParseException: No flag started. Don't know what to do with 'Files\Java\jdk1.8.0_241\bin\java.exe"'`
 
I feel like all custom annotation parsers should also be available for flags, especially because the types are not changing from when they are an argument but are "more" optional... I hope this explaination was understandable :)

Have a nice evening!