### PR TITLE
Fix concurrent cause of execution exception not being wrapped right

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The code is based on a (W.I.P) paper that can be found [here](https://github.com
 
 ## links  
 
-- JavaDoc: https://javadoc.commandframework.cloud/
+- JavaDoc: https://javadoc.io/doc/cloud.commandframework
 - Wiki: https://github.com/Incendo/cloud/wiki
 - Discord: https://discord.gg/aykZu32
   

--- a/cloud-core/src/main/java/cloud/commandframework/execution/CommandExecutionCoordinator.java
+++ b/cloud-core/src/main/java/cloud/commandframework/execution/CommandExecutionCoordinator.java
@@ -118,6 +118,13 @@ public abstract class CommandExecutionCoordinator<C> {
                     if (this.getCommandTree().getCommandManager().postprocessContext(commandContext, command) == State.ACCEPTED) {
                         try {
                             command.getCommandExecutionHandler().executeFuture(commandContext).get();
+                        } catch (final java.util.concurrent.ExecutionException exception) {
+                            Throwable cause = exception.getCause();
+                            if (cause instanceof CommandExecutionException) {
+                                completableFuture.completeExceptionally(cause);
+                            } else {
+                                completableFuture.completeExceptionally(new CommandExecutionException(cause, commandContext));
+                            }
                         } catch (final CommandExecutionException exception) {
                             completableFuture.completeExceptionally(exception);
                         } catch (final Exception exception) {


### PR DESCRIPTION
Without this, handleException() (in BukkitCommand for example) doesnt work anymore, because the exception type is java.util.concurrent.ExecutionException.

Not sure if the other catch handlers remain required, does executeFuture() potentially throw those? Kept those in.