### PR TITLE
paper: Fix handling of empty slash buffer in async suggestion listener

### DIFF
--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/AsyncCommandSuggestionsListener.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/AsyncCommandSuggestionsListener.java
@@ -42,7 +42,11 @@ final class AsyncCommandSuggestionsListener<C> implements Listener {
 
     @EventHandler
     void onTabCompletion(final @NonNull AsyncTabCompleteEvent event) {
-        if (event.getBuffer().trim().isEmpty()) {
+        /* Turn '(/)plugin:command arg1 arg2 ...' into 'plugin:command arg1 arg2 ...' */
+        final String strippedBuffer = event.getBuffer().startsWith("/")
+                ? event.getBuffer().substring(1)
+                : event.getBuffer();
+        if (strippedBuffer.trim().isEmpty()) {
             return;
         }
 
@@ -50,11 +54,8 @@ final class AsyncCommandSuggestionsListener<C> implements Listener {
         final BukkitPluginRegistrationHandler<C> bukkitPluginRegistrationHandler =
                 (BukkitPluginRegistrationHandler<C>) this.paperCommandManager.getCommandRegistrationHandler();
 
-        /* Turn '(/)plugin:command arg1 arg2 ...' into 'plugin:command' */
-        final String commandLabel = (event.getBuffer().startsWith("/")
-                ? event.getBuffer().substring(1)
-                : event.getBuffer())
-                .split(" ")[0];
+        /* Turn 'plugin:command arg1 arg2 ...' into 'plugin:command' */
+        final String commandLabel = strippedBuffer.split(" ")[0];
         if (!bukkitPluginRegistrationHandler.isRecognized(commandLabel)) {
             return;
         }


### PR DESCRIPTION
Extension on https://github.com/Incendo/cloud/pull/233, empty slashes can also pass through, e.g. `/         `, in which case a similar out of bounds exception will occur.

(should the target of this branch be 1.7.0-dev?)