### PR TITLE
Add `DurationArgument` for parsing `java.time.Duration`

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DurationArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DurationArgument.java
@@ -215,42 +215,7 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
 
             // 1d_, 5d4m_, etc
             if (Character.isLetter(last)) {
-
-                // if the input contains all the units already, then we can't suggest anything
-                int found = 0;
-                for (char unit : units) {
-                    if (input.contains(String.valueOf(unit))) {
-                        found++;
-                    }
-                }
-                if (found == units.size()) {
-                    return Collections.emptyList();
-                }
-
-                // if the input is just a letter ("d"), return nothing
-                if (!units.contains(last) || chars.length == 1) {
-                    return Collections.emptyList();
-                }
-
-                // if the input is a letter which is already in the input, return nothing ("1d2d")
-                if (charsContainsMultiple(chars, last, false)) {
-                    return Collections.emptyList();
-                }
-
-                // add each of the numbers to the input
-                nums = nums.map(i -> input + i);
-                List<String> numList = nums.collect(Collectors.toList());
-
-                List<String> completions = new ArrayList<>();
-                // add each of the time units to each of the possible combos
-                for (String num : numList) {
-                    for (char unit : units) {
-                        if (!charsContainsMultiple(chars, unit, true)) {
-                            completions.add(num + unit);
-                        }
-                    }
-                }
-                return completions;
+                return Collections.emptyList();
             }
 
             // 1d5_, 5d4m2_, etc

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DurationArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DurationArgument.java
@@ -1,0 +1,321 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.arguments.standard;
+
+import cloud.commandframework.ArgumentDescription;
+import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.parser.ArgumentParseResult;
+import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.captions.CaptionVariable;
+import cloud.commandframework.captions.StandardCaptionKeys;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
+import cloud.commandframework.exceptions.parsing.ParserException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Queue;
+import java.util.function.BiFunction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+
+@SuppressWarnings("unused")
+public final class DurationArgument<C> extends CommandArgument<C, Duration> {
+
+    private DurationArgument(
+            final boolean required,
+            final @NonNull String name,
+            final @NonNull String defaultValue,
+            final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
+                    @NonNull List<@NonNull String>> suggestionsProvider,
+            final @NonNull ArgumentDescription defaultDescription
+    ) {
+        super(
+                required,
+                name,
+                new DurationArgument.DurationParser<>(),
+                defaultValue,
+                Duration.class,
+                suggestionsProvider,
+                defaultDescription
+        );
+    }
+
+    /**
+     * Create a new builder
+     *
+     * @param name Name of the component
+     * @param <C>  Command sender type
+     * @return Created builder
+     */
+    public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
+     * Create a new required command component
+     *
+     * @param name Component name
+     * @param <C>  Command sender type
+     * @return Created component
+     */
+    public static <C> @NonNull CommandArgument<C, Duration> of(final @NonNull String name) {
+        return DurationArgument.<C>newBuilder(name).asRequired().build();
+    }
+
+    /**
+     * Create a new optional command component
+     *
+     * @param name Component name
+     * @param <C>  Command sender type
+     * @return Created component
+     */
+    public static <C> @NonNull CommandArgument<C, Duration> optional(final @NonNull String name) {
+        return DurationArgument.<C>newBuilder(name).asOptional().build();
+    }
+
+    /**
+     * Create a new required command component with a default value
+     *
+     * @param name            Component name
+     * @param defaultDuration Default duration
+     * @param <C>             Command sender type
+     * @return Created component
+     */
+    public static <C> @NonNull CommandArgument<C, Duration> optional(
+            final @NonNull String name,
+            final @NonNull String defaultDuration
+    ) {
+        return DurationArgument.<C>newBuilder(name).asOptionalWithDefault(defaultDuration).build();
+    }
+
+
+    public static final class Builder<C> extends CommandArgument.Builder<C, Duration> {
+
+        private Builder(final @NonNull String name) {
+            super(Duration.class, name);
+        }
+
+        /**
+         * Builder a new boolean component
+         *
+         * @return Constructed component
+         */
+        @Override
+        public @NonNull DurationArgument<C> build() {
+            return new DurationArgument<>(this.isRequired(), this.getName(), this.getDefaultValue(),
+                    this.getSuggestionsProvider(), this.getDefaultDescription()
+            );
+        }
+
+    }
+
+
+    public static final class DurationParser<C> implements ArgumentParser<C, Duration> {
+
+        @Override
+        public @NonNull ArgumentParseResult<Duration> parse(
+                final @NonNull CommandContext<C> commandContext,
+                final @NonNull Queue<String> inputQueue
+        ) {
+            final String input = inputQueue.peek();
+            if (input == null) {
+                return ArgumentParseResult.failure(new NoInputProvidedException(
+                        DurationArgument.DurationParseException.class,
+                        commandContext
+                ));
+            }
+            inputQueue.remove();
+
+            /*
+             * Matches durations in the format of: "2d15h7m12s"
+             */
+            final Matcher matcher = Pattern.compile("(([1-9][0-9]+|[1-9])[dhms])").matcher(input);
+
+            Duration duration = Duration.ofNanos(0);
+
+            while (matcher.find()) {
+                String group = matcher.group();
+                String timeUnit = String.valueOf(group.charAt(group.length() - 1));
+                int timeValue = Integer.parseInt(group.substring(0, group.length() - 1));
+                switch (timeUnit) {
+                    case "d":
+                        duration = duration.plusDays(timeValue);
+                        break;
+                    case "h":
+                        duration = duration.plusHours(timeValue);
+                        break;
+                    case "m":
+                        duration = duration.plusMinutes(timeValue);
+                        break;
+                    case "s":
+                        duration = duration.plusSeconds(timeValue);
+                        break;
+                    default:
+                        return ArgumentParseResult.failure(new DurationArgument.DurationParseException(input, commandContext));
+                }
+            }
+
+            if (duration.isZero()) {
+                return ArgumentParseResult.failure(new DurationArgument.DurationParseException(input, commandContext));
+            }
+
+            return ArgumentParseResult.success(duration);
+        }
+
+        @Override
+        public @NonNull List<@NonNull String> suggestions(
+                final @NonNull CommandContext<C> commandContext,
+                final @NonNull String input
+        ) {
+            char[] chars = input.toLowerCase(Locale.ROOT).toCharArray();
+
+            Stream<String> nums = IntStream.range(1, 10).boxed()
+                    .sorted()
+                    .map(String::valueOf);
+
+            if (chars.length == 0) {
+                return nums.collect(Collectors.toList());
+            }
+
+            List<Character> units = Arrays.asList('d', 'h', 'm', 's');
+
+            char last = chars[chars.length - 1];
+
+            // 1d_, 5d4m_, etc
+            if (Character.isLetter(last)) {
+
+                // if the input contains all the units already, then we can't suggest anything
+                int found = 0;
+                for (char unit : units) {
+                    if (input.contains(String.valueOf(unit))) {
+                        found++;
+                    }
+                }
+                if (found == units.size()) {
+                    return new ArrayList<>();
+                }
+
+                // if the input is just a letter ("d"), return nothing
+                if (!units.contains(last) || chars.length == 1) {
+                    return new ArrayList<>();
+                }
+
+                // if the input is just a letter repeated ("dd"), return nothing
+                char secondLast = chars[chars.length - 2];
+                if (last == secondLast || Character.isLetter(secondLast)) {
+                    return new ArrayList<>();
+                }
+
+                // if the input is a letter which is already in the input, return nothing ("1d2d")
+                if (charsContainsMultiple(chars, last)) {
+                    return new ArrayList<>();
+                }
+
+                // add each of the numbers to the input
+                nums = nums.map(i -> input + i);
+                List<String> numList = nums.collect(Collectors.toList());
+
+                List<String> completions = new ArrayList<>();
+                // add each of the time units to each of the possible combos
+                for (String num : numList) {
+                    for (char unit : units) {
+                        if (unit == last) {
+                            continue;
+                        }
+                        if (!charsContainsMultiple(chars, unit)) {
+                            completions.add(num + unit);
+                        }
+                    }
+                }
+                return completions;
+            }
+
+            // 1d5_, 5d4m2_, etc
+            return units.stream()
+                    .filter(c -> !input.contains(String.valueOf(c)))
+                    .map(c -> input + c)
+                    .collect(Collectors.toList());
+        }
+
+    }
+
+    private static boolean charsContainsMultiple(final char[] chars, final char c) {
+        int count = 0;
+        for (char ch : chars) {
+            if (ch == c) {
+                count++;
+            }
+        }
+        return count > 1;
+    }
+
+
+    /**
+     * Duration parse exception
+     */
+    public static final class DurationParseException extends ParserException {
+
+        private static final long serialVersionUID = 7632293268451349508L;
+        private final String input;
+
+        /**
+         * Construct a new Duration parse exception
+         *
+         * @param input   String input
+         * @param context Command context
+         */
+        public DurationParseException(
+                final @NonNull String input,
+                final @NonNull CommandContext<?> context
+        ) {
+            super(
+                    DurationArgument.DurationParser.class,
+                    context,
+                    StandardCaptionKeys.ARGUMENT_PARSE_FAILURE_DURATION,
+                    CaptionVariable.of("input", input)
+            );
+            this.input = input;
+        }
+
+        /**
+         * Get the supplied input
+         *
+         * @return String value
+         */
+        public @NonNull String getInput() {
+            return this.input;
+        }
+
+    }
+
+}

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DurationArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DurationArgument.java
@@ -159,7 +159,6 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
                         commandContext
                 ));
             }
-            inputQueue.remove();
 
             final Matcher matcher = DURATION_PATTERN.matcher(input);
 
@@ -191,6 +190,7 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
                 return ArgumentParseResult.failure(new DurationArgument.DurationParseException(input, commandContext));
             }
 
+            inputQueue.remove();
             return ArgumentParseResult.success(duration);
         }
 
@@ -202,15 +202,12 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
         ) {
             char[] chars = input.toLowerCase(Locale.ROOT).toCharArray();
 
-            Stream<String> nums = IntStream.range(1, 10).boxed()
-                    .sorted()
-                    .map(String::valueOf);
-
             if (chars.length == 0) {
-                return nums.collect(Collectors.toList());
+                return IntStream.range(1, 10).boxed()
+                        .sorted()
+                        .map(String::valueOf)
+                        .collect(Collectors.toList());
             }
-
-            List<String> units = Arrays.asList("d", "h", "m", "s");
 
             char last = chars[chars.length - 1];
 
@@ -220,7 +217,7 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
             }
 
             // 1d5_, 5d4m2_, etc
-            return units.stream()
+            return Stream.of("d", "h", "m", "s")
                     .filter(unit -> !input.contains(unit))
                     .map(unit -> input + unit)
                     .collect(Collectors.toList());

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DurationArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DurationArgument.java
@@ -47,6 +47,11 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 
+/**
+ * Parses <code>java.time.Duration</code> from a <code>1d2h3m4s</code> format.
+ * @param <C> Command sender type
+ * @since 1.7.0
+ */
 @SuppressWarnings("unused")
 public final class DurationArgument<C> extends CommandArgument<C, Duration> {
 
@@ -80,6 +85,7 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
      * @param name Name of the component
      * @param <C>  Command sender type
      * @return Created builder
+     * @since 1.7.0
      */
     public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
         return new Builder<>(name);
@@ -91,6 +97,7 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
      * @param name Component name
      * @param <C>  Command sender type
      * @return Created component
+     * @since 1.7.0
      */
     public static <C> @NonNull CommandArgument<C, Duration> of(final @NonNull String name) {
         return DurationArgument.<C>newBuilder(name).asRequired().build();
@@ -102,6 +109,7 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
      * @param name Component name
      * @param <C>  Command sender type
      * @return Created component
+     * @since 1.7.0
      */
     public static <C> @NonNull CommandArgument<C, Duration> optional(final @NonNull String name) {
         return DurationArgument.<C>newBuilder(name).asOptional().build();
@@ -114,6 +122,7 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
      * @param defaultDuration Default duration
      * @param <C>             Command sender type
      * @return Created component
+     * @since 1.7.0
      */
     public static <C> @NonNull CommandArgument<C, Duration> optional(
             final @NonNull String name,
@@ -133,6 +142,7 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
          * Builder a new boolean component
          *
          * @return Constructed component
+         * @since 1.7.0
          */
         @Override
         public @NonNull DurationArgument<C> build() {
@@ -144,6 +154,11 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
     }
 
 
+    /**
+     * Represents a duration parser.
+     * @since 1.7.0
+     * @param <C> Command sender type
+     */
     public static final class DurationParser<C> implements ArgumentParser<C, Duration> {
 
         @Override
@@ -193,6 +208,10 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
             return ArgumentParseResult.success(duration);
         }
 
+        /**
+         * Provides suggestions for Durations.
+         * @since 1.7.0
+         */
         @Override
         @SuppressWarnings("MixedMutabilityReturnType")
         public @NonNull List<@NonNull String> suggestions(
@@ -225,7 +244,8 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
     }
 
     /**
-     * Duration parse exception
+     * Represents a duration parse exception.
+     * @since 1.7.0
      */
     public static final class DurationParseException extends ParserException {
 
@@ -237,6 +257,7 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
          *
          * @param input   String input
          * @param context Command context
+         * @since 1.7.0
          */
         public DurationParseException(
                 final @NonNull String input,
@@ -255,6 +276,7 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
          * Get the supplied input
          *
          * @return String value
+         * @since 1.7.0
          */
         public @NonNull String getInput() {
             return this.input;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DurationArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DurationArgument.java
@@ -33,7 +33,6 @@ import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import cloud.commandframework.exceptions.parsing.ParserException;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -51,6 +50,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 @SuppressWarnings("unused")
 public final class DurationArgument<C> extends CommandArgument<C, Duration> {
+
+    /**
+     * Matches durations in the format of: <code>2d15h7m12s</code>
+     */
+    private static final Pattern DURATION_PATTERN = Pattern.compile("(([1-9][0-9]+|[1-9])[dhms])");
 
     private DurationArgument(
             final boolean required,
@@ -157,10 +161,7 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
             }
             inputQueue.remove();
 
-            /*
-             * Matches durations in the format of: "2d15h7m12s"
-             */
-            final Matcher matcher = Pattern.compile("(([1-9][0-9]+|[1-9])[dhms])").matcher(input);
+            final Matcher matcher = DURATION_PATTERN.matcher(input);
 
             Duration duration = Duration.ofNanos(0);
 
@@ -209,7 +210,7 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
                 return nums.collect(Collectors.toList());
             }
 
-            List<Character> units = Arrays.asList('d', 'h', 'm', 's');
+            List<String> units = Arrays.asList("d", "h", "m", "s");
 
             char last = chars[chars.length - 1];
 
@@ -220,23 +221,12 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
 
             // 1d5_, 5d4m2_, etc
             return units.stream()
-                    .filter(c -> !input.contains(String.valueOf(c)))
-                    .map(c -> input + c)
+                    .filter(unit -> !input.contains(unit))
+                    .map(unit -> input + unit)
                     .collect(Collectors.toList());
         }
 
     }
-
-    private static boolean charsContainsMultiple(final char[] chars, final char c, final boolean onlyOne) {
-        int count = 0;
-        for (char ch : chars) {
-            if (ch == c) {
-                count++;
-            }
-        }
-        return onlyOne ? count == 1 : count > 1;
-    }
-
 
     /**
      * Duration parse exception

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DurationArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DurationArgument.java
@@ -33,7 +33,6 @@ import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import cloud.commandframework.exceptions.parsing.ParserException;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DurationArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DurationArgument.java
@@ -35,6 +35,7 @@ import cloud.commandframework.exceptions.parsing.ParserException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Queue;
@@ -193,6 +194,7 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
         }
 
         @Override
+        @SuppressWarnings("MixedMutabilityReturnType")
         public @NonNull List<@NonNull String> suggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
@@ -222,23 +224,17 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
                     }
                 }
                 if (found == units.size()) {
-                    return new ArrayList<>();
+                    return Collections.emptyList();
                 }
 
                 // if the input is just a letter ("d"), return nothing
                 if (!units.contains(last) || chars.length == 1) {
-                    return new ArrayList<>();
-                }
-
-                // if the input is just a letter repeated ("dd"), return nothing
-                char secondLast = chars[chars.length - 2];
-                if (last == secondLast || Character.isLetter(secondLast)) {
-                    return new ArrayList<>();
+                    return Collections.emptyList();
                 }
 
                 // if the input is a letter which is already in the input, return nothing ("1d2d")
-                if (charsContainsMultiple(chars, last)) {
-                    return new ArrayList<>();
+                if (charsContainsMultiple(chars, last, false)) {
+                    return Collections.emptyList();
                 }
 
                 // add each of the numbers to the input
@@ -249,10 +245,7 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
                 // add each of the time units to each of the possible combos
                 for (String num : numList) {
                     for (char unit : units) {
-                        if (unit == last) {
-                            continue;
-                        }
-                        if (!charsContainsMultiple(chars, unit)) {
+                        if (!charsContainsMultiple(chars, unit, true)) {
                             completions.add(num + unit);
                         }
                     }
@@ -269,14 +262,14 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
 
     }
 
-    private static boolean charsContainsMultiple(final char[] chars, final char c) {
+    private static boolean charsContainsMultiple(final char[] chars, final char c, final boolean onlyOne) {
         int count = 0;
         for (char ch : chars) {
             if (ch == c) {
                 count++;
             }
         }
-        return count > 1;
+        return onlyOne ? count == 1 : count > 1;
     }
 
 

--- a/cloud-core/src/main/java/cloud/commandframework/captions/SimpleCaptionRegistry.java
+++ b/cloud-core/src/main/java/cloud/commandframework/captions/SimpleCaptionRegistry.java
@@ -87,6 +87,10 @@ public class SimpleCaptionRegistry<C> implements FactoryDelegatingCaptionRegistr
      * Default caption for {@link StandardCaptionKeys#ARGUMENT_PARSE_FAILURE_COLOR}
      */
     public static final String ARGUMENT_PARSE_FAILURE_COLOR = "'{input}' is not a valid color";
+    /**
+     * Default caption for {@link StandardCaptionKeys#ARGUMENT_PARSE_FAILURE_DURATION}
+     */
+    public static final String ARGUMENT_PARSE_FAILURE_DURATION = "'{input}' is not a duration format";
 
     private final Map<Caption, BiFunction<Caption, C, String>> messageFactories = new HashMap<>();
 
@@ -142,6 +146,10 @@ public class SimpleCaptionRegistry<C> implements FactoryDelegatingCaptionRegistr
         this.registerMessageFactory(
                 StandardCaptionKeys.ARGUMENT_PARSE_FAILURE_COLOR,
                 (caption, sender) -> ARGUMENT_PARSE_FAILURE_COLOR
+        );
+        this.registerMessageFactory(
+                StandardCaptionKeys.ARGUMENT_PARSE_FAILURE_DURATION,
+                (caption, sender) -> ARGUMENT_PARSE_FAILURE_DURATION
         );
     }
 

--- a/cloud-core/src/main/java/cloud/commandframework/captions/StandardCaptionKeys.java
+++ b/cloud-core/src/main/java/cloud/commandframework/captions/StandardCaptionKeys.java
@@ -91,6 +91,10 @@ public final class StandardCaptionKeys {
      * Variables: {input}
      */
     public static final Caption ARGUMENT_PARSE_FAILURE_COLOR = of("argument.parse.failure.color");
+    /**
+     * Variables: {input}
+     */
+    public static final Caption ARGUMENT_PARSE_FAILURE_DURATION = of("argument.parse.failure.duration");
 
     private StandardCaptionKeys() {
     }

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationArgumentSuggestionsTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationArgumentSuggestionsTest.java
@@ -1,0 +1,65 @@
+package cloud.commandframework.arguments.standard;
+
+import cloud.commandframework.CommandManager;
+import cloud.commandframework.TestCommandSender;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static cloud.commandframework.util.TestUtils.createManager;
+
+public class DurationArgumentSuggestionsTest {
+
+    private static CommandManager<TestCommandSender> manager;
+
+    @BeforeAll
+    static void setupManager() {
+        manager = createManager();
+        manager.command(manager.commandBuilder("duration")
+                .argument(DurationArgument.of("duration")));
+    }
+
+
+    @Test
+    void testDurationSuggestions() {
+        final String input = "duration ";
+        final List<String> suggestions = manager.suggest(new TestCommandSender(), input);
+        Assertions.assertEquals(Arrays.asList("1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions);
+
+        final String input2 = "duration 1";
+        final List<String> suggestions2 = manager.suggest(new TestCommandSender(), input2);
+        Assertions.assertEquals(Arrays.asList("1d", "1h", "1m", "1s"), suggestions2);
+
+        final String input3 = "duration 1d";
+        final List<String> suggestions3 = manager.suggest(new TestCommandSender(), input3);
+        Assertions.assertTrue(suggestions3.containsAll(Arrays.asList("1d1h", "1d1m", "1d1s")));
+        Assertions.assertFalse(suggestions3.contains("1d1d"));
+
+        final String input4 = "duration 1d2h";
+        final List<String> suggestions4 = manager.suggest(new TestCommandSender(), input4);
+        Assertions.assertTrue(suggestions4.containsAll(Arrays.asList("1d2h1m", "1d2h1s")));
+        Assertions.assertFalse(suggestions4.contains("1d2h1d"));
+        Assertions.assertFalse(suggestions4.contains("1d2h1h"));
+
+        final String input5 = "duration d";
+        final List<String> suggestions5 = manager.suggest(new TestCommandSender(), input5);
+        Assertions.assertEquals(Collections.emptyList(), suggestions5);
+
+        final String input6 = "duration 1d2d";
+        final List<String> suggestions6 = manager.suggest(new TestCommandSender(), input6);
+        Assertions.assertEquals(Collections.emptyList(), suggestions6);
+
+        final String input7 = "duration 1d2h3m4s";
+        final List<String> suggestions7 = manager.suggest(new TestCommandSender(), input7);
+        Assertions.assertEquals(Collections.emptyList(), suggestions7);
+
+        final String input8 = "duration dd";
+        final List<String> suggestions8 = manager.suggest(new TestCommandSender(), input8);
+        Assertions.assertEquals(Collections.emptyList(), suggestions8);
+    }
+
+
+}

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationArgumentSuggestionsTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationArgumentSuggestionsTest.java
@@ -42,6 +42,11 @@ public class DurationArgumentSuggestionsTest {
         Assertions.assertTrue(suggestions4.containsAll(Arrays.asList("1d2h", "1d2m", "1d2s")));
         Assertions.assertFalse(suggestions4.contains("1d2d"));
 
+        final String input9 = "duration 1d22";
+        final List<String> suggestions9 = manager.suggest(new TestCommandSender(), input9);
+        Assertions.assertTrue(suggestions9.containsAll(Arrays.asList("1d22h", "1d22m", "1d22s")));
+        Assertions.assertFalse(suggestions9.contains("1d22d"));
+
         final String input5 = "duration d";
         final List<String> suggestions5 = manager.suggest(new TestCommandSender(), input5);
         Assertions.assertEquals(Collections.emptyList(), suggestions5);

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationArgumentSuggestionsTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationArgumentSuggestionsTest.java
@@ -35,14 +35,12 @@ public class DurationArgumentSuggestionsTest {
 
         final String input3 = "duration 1d";
         final List<String> suggestions3 = manager.suggest(new TestCommandSender(), input3);
-        Assertions.assertTrue(suggestions3.containsAll(Arrays.asList("1d1h", "1d1m", "1d1s")));
-        Assertions.assertFalse(suggestions3.contains("1d1d"));
+        Assertions.assertEquals(Collections.emptyList(), suggestions3);
 
-        final String input4 = "duration 1d2h";
+        final String input4 = "duration 1d2";
         final List<String> suggestions4 = manager.suggest(new TestCommandSender(), input4);
-        Assertions.assertTrue(suggestions4.containsAll(Arrays.asList("1d2h1m", "1d2h1s")));
-        Assertions.assertFalse(suggestions4.contains("1d2h1d"));
-        Assertions.assertFalse(suggestions4.contains("1d2h1h"));
+        Assertions.assertTrue(suggestions4.containsAll(Arrays.asList("1d2h", "1d2m", "1d2s")));
+        Assertions.assertFalse(suggestions4.contains("1d2d"));
 
         final String input5 = "duration d";
         final List<String> suggestions5 = manager.suggest(new TestCommandSender(), input5);

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationArgumentSuggestionsTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationArgumentSuggestionsTest.java
@@ -1,3 +1,26 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
 package cloud.commandframework.arguments.standard;
 
 import cloud.commandframework.CommandManager;

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationArgumentTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationArgumentTest.java
@@ -40,6 +40,10 @@ public class DurationArgumentTest {
         manager.executeCommand(new TestCommandSender(), "duration 2d").join();
 
         assertThat(storage[0]).isEqualTo(Duration.ofDays(2));
+
+        manager.executeCommand(new TestCommandSender(), "duration 999s").join();
+
+        assertThat(storage[0]).isEqualTo(Duration.ofSeconds(999));
     }
 
     @Test
@@ -47,6 +51,10 @@ public class DurationArgumentTest {
         manager.executeCommand(new TestCommandSender(), "duration 2d12h7m34s").join();
 
         assertThat(storage[0]).isEqualTo(Duration.ofDays(2).plusHours(12).plusMinutes(7).plusSeconds(34));
+
+        manager.executeCommand(new TestCommandSender(), "duration 700h75m1d999s").join();
+
+        assertThat(storage[0]).isEqualTo(Duration.ofDays(1).plusHours(700).plusMinutes(75).plusSeconds(999));
     }
 
     @Test
@@ -54,6 +62,11 @@ public class DurationArgumentTest {
         Assertions.assertThrows(CompletionException.class, () -> manager.executeCommand(
                 new TestCommandSender(),
                 "duration d"
+        ).join());
+
+        Assertions.assertThrows(CompletionException.class, () -> manager.executeCommand(
+                new TestCommandSender(),
+                "duration 1x"
         ).join());
     }
 

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationArgumentTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationArgumentTest.java
@@ -1,0 +1,60 @@
+package cloud.commandframework.arguments.standard;
+
+import cloud.commandframework.CommandManager;
+import cloud.commandframework.TestCommandSender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CompletionException;
+
+import static cloud.commandframework.util.TestUtils.createManager;
+import static com.google.common.truth.Truth.assertThat;
+
+public class DurationArgumentTest {
+
+    private static final Duration[] storage = new Duration[1];
+    private static CommandManager<TestCommandSender> manager;
+
+    @BeforeAll
+    static void setup() {
+        manager = createManager();
+        manager.command(manager.commandBuilder("duration")
+                .argument(DurationArgument.of("duration"))
+                .handler(c -> {
+                    final Duration duration = c.get("duration");
+                    storage[0] = duration;
+                })
+                .build());
+    }
+
+    @AfterEach
+    void reset() {
+        storage[0] = null;
+    }
+
+    @Test
+    void single_single_unit() {
+        manager.executeCommand(new TestCommandSender(), "duration 2d").join();
+
+        assertThat(storage[0]).isEqualTo(Duration.ofDays(2));
+    }
+
+    @Test
+    void single_multiple_units() {
+        manager.executeCommand(new TestCommandSender(), "duration 2d12h7m34s").join();
+
+        assertThat(storage[0]).isEqualTo(Duration.ofDays(2).plusHours(12).plusMinutes(7).plusSeconds(34));
+    }
+
+    @Test
+    void invalid_format_failing() {
+        Assertions.assertThrows(CompletionException.class, () -> manager.executeCommand(
+                new TestCommandSender(),
+                "duration d"
+        ).join());
+    }
+
+}

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationArgumentTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationArgumentTest.java
@@ -1,3 +1,26 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
 package cloud.commandframework.arguments.standard;
 
 import cloud.commandframework.CommandManager;


### PR DESCRIPTION
Expected syntax: `1d12h4m47s` (1 day, 12 hours, 4 minutes, 47 seconds)
Tests are included + passing

Example tab completion:

https://user-images.githubusercontent.com/26070412/147010100-fd209396-8db5-4050-8b0d-014fa633ef5e.mov
