### PR TITLE
Register the duration argument parser in the default parser registry

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/arguments/parser/StandardParserRegistry.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/parser/StandardParserRegistry.java
@@ -31,6 +31,7 @@ import cloud.commandframework.arguments.standard.BooleanArgument;
 import cloud.commandframework.arguments.standard.ByteArgument;
 import cloud.commandframework.arguments.standard.CharArgument;
 import cloud.commandframework.arguments.standard.DoubleArgument;
+import cloud.commandframework.arguments.standard.DurationArgument;
 import cloud.commandframework.arguments.standard.EnumArgument;
 import cloud.commandframework.arguments.standard.FloatArgument;
 import cloud.commandframework.arguments.standard.IntegerArgument;
@@ -43,6 +44,7 @@ import cloud.commandframework.context.CommandContext;
 import io.leangen.geantyref.GenericTypeReflector;
 import io.leangen.geantyref.TypeToken;
 import java.lang.annotation.Annotation;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -163,6 +165,7 @@ public final class StandardParserRegistry<C> implements ParserRegistry<C> {
             return new BooleanArgument.BooleanParser<>(liberal);
         });
         this.registerParserSupplier(TypeToken.get(UUID.class), options -> new UUIDArgument.UUIDParser<>());
+        this.registerParserSupplier(TypeToken.get(Duration.class), options -> new DurationArgument.DurationParser<>());
     }
 
     private static boolean isPrimitive(final @NonNull TypeToken<?> type) {


### PR DESCRIPTION
This PR registers the new java.time.Duration argument parser to the default registry.

Without this registration the parser is not usable for annotation based commands.

See:
```
 Caused by: java.lang.IllegalArgumentException: Parameter 'arg4' in method 'addUserPermission' has parser 'java.time.Duration' but no parser exists for that type
[06.01 12:27:23.074] SCHWERWIEGEND:     at cloud.commandframework.annotations.AnnotationParser.lambda$buildArgument$6(AnnotationParser.java:590)
[06.01 12:27:23.074] SCHWERWIEGEND:     at java.base/java.util.Optional.orElseThrow(Optional.java:403)
[06.01 12:27:23.074] SCHWERWIEGEND:     at cloud.commandframework.annotations.AnnotationParser.buildArgument(AnnotationParser.java:589)
[06.01 12:27:23.074] SCHWERWIEGEND:     at cloud.commandframework.annotations.AnnotationParser.construct(AnnotationParser.java:441)
[06.01 12:27:23.074] SCHWERWIEGEND:     at cloud.commandframework.annotations.AnnotationParser.parse(AnnotationParser.java:309)
[06.01 12:27:23.074] SCHWERWIEGEND:     at eu.cloudnetservice.cloudnet.node.command.defaults.DefaultCommandProvider.register(DefaultCommandProvider.java:141)
[06.01 12:27:23.074] SCHWERWIEGEND:     at eu.cloudnetservice.cloudnet.node.command.defaults.DefaultCommandProvider.registerDefaultCommands(DefaultCommandProvider.java:208)
[06.01 12:27:23.074] SCHWERWIEGEND:     at eu.cloudnetservice.cloudnet.node.CloudNet.start(CloudNet.java:298)
[06.01 12:27:23.074] SCHWERWIEGEND:     at eu.cloudnetservice.cloudnet.node.BootLogic.main(BootLogic.java:51)
[06.01 12:27:23.074] SCHWERWIEGEND:     ... 13 more
```