### PR TITLE
Fix Kotlin and Java interop issues.

### DIFF
--- a/cloud-kotlin/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/MutableCommandBuilder.kt
+++ b/cloud-kotlin/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/MutableCommandBuilder.kt
@@ -39,11 +39,22 @@ import kotlin.reflect.KClass
  * A mutable [Command.Builder] wrapper, providing functions to assist in creating commands using the
  * Kotlin builder DSL style
  *
+ * @property commandBuilder the command builder the mutate
+ * @property commandManager the command manager which will own this command
+ * @constructor Create a new [MutableCommandBuilder]
  * @since 1.3.0
  */
-public class MutableCommandBuilder<C : Any> {
-    private val commandManager: CommandManager<C>
-    private var commandBuilder: Command.Builder<C>
+public class MutableCommandBuilder<C : Any>(
+        commandBuilder: Command.Builder<C>,
+        private val commandManager: CommandManager<C>,
+) {
+    /**
+     * The command builder that is being mutated by this [MutableCommandBuilder] instance.
+     *
+     * This is public so that this can be returned to a command builder for interop with java apis.
+     */
+    public var commandBuilder: Command.Builder<C> = commandBuilder
+        private set
 
     /**
      * Create a new [MutableCommandBuilder]
@@ -64,10 +75,7 @@ public class MutableCommandBuilder<C : Any> {
         description: Description = Description.empty(),
         aliases: Array<String> = emptyArray(),
         commandManager: CommandManager<C>
-    ) {
-        this.commandManager = commandManager
-        this.commandBuilder = commandManager.commandBuilder(name, description, *aliases)
-    }
+    ) : this(commandManager.commandBuilder(name, description, *aliases), commandManager)
 
     /**
      * Create a new [MutableCommandBuilder]
@@ -83,10 +91,7 @@ public class MutableCommandBuilder<C : Any> {
         description: ArgumentDescription = ArgumentDescription.empty(),
         aliases: Array<String> = emptyArray(),
         commandManager: CommandManager<C>
-    ) {
-        this.commandManager = commandManager
-        this.commandBuilder = commandManager.commandBuilder(name, description, *aliases)
-    }
+    ) : this(commandManager.commandBuilder(name, description, *aliases), commandManager)
 
     /**
      * Create a new [MutableCommandBuilder] and invoke the provided receiver lambda on it
@@ -131,11 +136,6 @@ public class MutableCommandBuilder<C : Any> {
         lambda: MutableCommandBuilder<C>.() -> Unit
     ) : this(name, description, aliases, commandManager) {
         lambda(this)
-    }
-
-    private constructor(commandManager: CommandManager<C>, commandBuilder: Command.Builder<C>) {
-        this.commandManager = commandManager
-        this.commandBuilder = commandBuilder
     }
 
     /**
@@ -184,7 +184,7 @@ public class MutableCommandBuilder<C : Any> {
      * @since 1.3.0
      */
     public fun copy(): MutableCommandBuilder<C> =
-        MutableCommandBuilder(this.commandManager, this.commandBuilder)
+        MutableCommandBuilder(this.commandBuilder, this.commandManager)
 
     /**
      * Make a new copy of this [MutableCommandBuilder] and invoke the provided receiver lambda on it

--- a/cloud-kotlin/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/MutableCommandBuilder.kt
+++ b/cloud-kotlin/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/MutableCommandBuilder.kt
@@ -45,8 +45,8 @@ import kotlin.reflect.KClass
  * @since 1.3.0
  */
 public class MutableCommandBuilder<C : Any>(
-        commandBuilder: Command.Builder<C>,
-        private val commandManager: CommandManager<C>,
+    commandBuilder: Command.Builder<C>,
+    private val commandManager: CommandManager<C>,
 ) {
     /**
      * The command builder that is being mutated by this [MutableCommandBuilder] instance.

--- a/cloud-kotlin/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/extension/CommandBuildingExtensions.kt
+++ b/cloud-kotlin/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/extension/CommandBuildingExtensions.kt
@@ -130,6 +130,28 @@ public fun <C : Any> Command.Builder<C>.senderType(type: KClass<out C>): Command
     senderType(type.java)
 
 /**
+ * Create a new [MutableCommandBuilder].
+ *
+ * @param commandManager the command manager, which will own this command.
+ * @since 1.6.2
+ */
+public fun <C : Any> Command.Builder<C>.toMutable(
+    commandManager: CommandManager<C>
+): MutableCommandBuilder<C> = MutableCommandBuilder(this, commandManager)
+
+/**
+ * Create a new [MutableCommandBuilder] and invoke the provided receiver lambda on it.
+ *
+ * @param commandManager the command manager, which will own this command.
+ * @param lambda receiver lambda, which will be invoked on the new builder.
+ * @since 1.6.2
+ */
+public fun <C : Any> Command.Builder<C>.mutate(
+    commandManager: CommandManager<C>,
+    lambda: MutableCommandBuilder<C>.() -> Unit
+): MutableCommandBuilder<C> = MutableCommandBuilder(this, commandManager).also(lambda)
+
+/**
  * Get a [Description], defaulting to [Description.empty]
  *
  * @param description description string

--- a/cloud-kotlin/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/extension/CommandBuildingExtensions.kt
+++ b/cloud-kotlin/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/extension/CommandBuildingExtensions.kt
@@ -133,7 +133,7 @@ public fun <C : Any> Command.Builder<C>.senderType(type: KClass<out C>): Command
  * Create a new [MutableCommandBuilder].
  *
  * @param commandManager the command manager, which will own this command.
- * @since 1.6.2
+ * @since 1.6.3
  */
 public fun <C : Any> Command.Builder<C>.toMutable(
     commandManager: CommandManager<C>
@@ -144,7 +144,7 @@ public fun <C : Any> Command.Builder<C>.toMutable(
  *
  * @param commandManager the command manager, which will own this command.
  * @param lambda receiver lambda, which will be invoked on the new builder.
- * @since 1.6.2
+ * @since 1.6.3
  */
 public fun <C : Any> Command.Builder<C>.mutate(
     commandManager: CommandManager<C>,

--- a/cloud-kotlin/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/extension/CommandBuildingExtensions.kt
+++ b/cloud-kotlin/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/extension/CommandBuildingExtensions.kt
@@ -133,7 +133,7 @@ public fun <C : Any> Command.Builder<C>.senderType(type: KClass<out C>): Command
  * Create a new [MutableCommandBuilder].
  *
  * @param commandManager the command manager, which will own this command.
- * @since 1.6.3
+ * @since 1.7.0
  */
 public fun <C : Any> Command.Builder<C>.toMutable(
     commandManager: CommandManager<C>
@@ -144,7 +144,7 @@ public fun <C : Any> Command.Builder<C>.toMutable(
  *
  * @param commandManager the command manager, which will own this command.
  * @param lambda receiver lambda, which will be invoked on the new builder.
- * @since 1.6.3
+ * @since 1.7.0
  */
 public fun <C : Any> Command.Builder<C>.mutate(
     commandManager: CommandManager<C>,


### PR DESCRIPTION
The following PR fixes interop issues between Kotlin and Java.

Currently, there is no way to go from `Command.Builder` -> `MutableCommandBuilder`, nor from `MutableCommandBuilder` -> `Command.Builder`.

This PR fixes it by introducing
- A new constructor for `MutableCommandBuilder`:
  
  ```kotlin
  public constructor(commandBuilder: Command.Builder<C>, commandManager: CommandManager<C>)
  ```
- Making the `commandBuilder` variable public
- Adding the following extensions
  
  ```kotlin
  public fun <C : Any> Command.Builder<C>.toMutable(commandManager: CommandManager<C>): MutableCommandBuilder<C>
  
  public fun <C : Any> Command.Builder<C>.mutate(commandManager: CommandManager<C>, lambda: MutableCommandBuilder<C>.() -> Unit): MutableCommandBuilder<C>
  ```