### PR TITLE
Register missing regex failure caption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fix missing caption registration for the regex caption
+
 ## [1.6.2]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Fix missing caption registration for the regex caption
+- Fix missing caption registration for the regex caption ([#351](https://github.com/Incendo/cloud/pull/351))
 
 ## [1.6.2]
 

--- a/cloud-core/src/main/java/cloud/commandframework/captions/SimpleCaptionRegistry.java
+++ b/cloud-core/src/main/java/cloud/commandframework/captions/SimpleCaptionRegistry.java
@@ -64,6 +64,10 @@ public class SimpleCaptionRegistry<C> implements FactoryDelegatingCaptionRegistr
      */
     public static final String ARGUMENT_PARSE_FAILURE_UUID = "'{input}' is not a valid UUID";
     /**
+     * Default caption for {@link StandardCaptionKeys#ARGUMENT_PARSE_FAILURE_REGEX}
+     */
+    public static final String ARGUMENT_PARSE_FAILURE_REGEX = "'{input}' does not match '{pattern}'";
+    /**
      * Default caption for {@link StandardCaptionKeys#ARGUMENT_PARSE_FAILURE_FLAG_UNKNOWN_FLAG}
      */
     public static final String ARGUMENT_PARSE_FAILURE_FLAG_UNKNOWN_FLAG = "Unknown flag '{flag}'";
@@ -122,6 +126,10 @@ public class SimpleCaptionRegistry<C> implements FactoryDelegatingCaptionRegistr
         this.registerMessageFactory(
                 StandardCaptionKeys.ARGUMENT_PARSE_FAILURE_UUID,
                 (caption, sender) -> ARGUMENT_PARSE_FAILURE_UUID
+        );
+        this.registerMessageFactory(
+                StandardCaptionKeys.ARGUMENT_PARSE_FAILURE_REGEX,
+                (caption, sender) -> ARGUMENT_PARSE_FAILURE_REGEX
         );
         this.registerMessageFactory(
                 StandardCaptionKeys.ARGUMENT_PARSE_FAILURE_FLAG_UNKNOWN_FLAG,

--- a/gradle/libs.versions.yml
+++ b/gradle/libs.versions.yml
@@ -28,7 +28,7 @@ versions:
   jda: 4.2.1_257
 
   # irc
-  pircbotx: 83a4c22e80
+  pircbotx: 12f5639c5d
 
   # minecraft
   guava: 21.0-jre


### PR DESCRIPTION
This PR adds the regex failure caption to the default CaptionRegistry
to fix the error that an IllegalArgumentException occurs on an incorrect regex.
Instead of displaying the correct caption.

I had to bump the pircbotx dependency because jitpack no longer had the old version.