### PR TITLE
feat: annotation string processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Annotations: Annotation string processors ([#353](https://github.com/Incendo/cloud/pull/353))
+
 ### Fixed
 - Fix missing caption registration for the regex caption ([#351](https://github.com/Incendo/cloud/pull/351))
 

--- a/build-logic/src/main/kotlin/cloud.base-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cloud.base-conventions.gradle.kts
@@ -97,6 +97,7 @@ dependencies {
     testImplementation(libs.jupiterEngine)
     testImplementation(libs.mockitoCore)
     testImplementation(libs.mockitoKotlin)
+    testImplementation(libs.mockitoJupiter)
     testImplementation(libs.truth)
     testImplementation(libs.truthJava8)
     errorprone(libs.errorproneCore)

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/PatternReplacingStringProcessor.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/PatternReplacingStringProcessor.java
@@ -1,0 +1,76 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.annotations;
+
+import java.util.function.Function;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * {@link StringProcessor} that replaces matches of a given {@link Pattern}.
+ *
+ * @since 1.7.0
+ */
+public class PatternReplacingStringProcessor implements StringProcessor {
+
+    private final Pattern pattern;
+    private final Function<MatchResult, String> replacementProvider;
+
+    /**
+     * Creates a new property replacing string processor.
+     *
+     * @param pattern             the pattern to search for
+     * @param replacementProvider function generating the replacement strings
+     */
+    public PatternReplacingStringProcessor(
+            final @NonNull Pattern pattern,
+            final @NonNull Function<@NonNull MatchResult, @Nullable String> replacementProvider
+    ) {
+        this.pattern = pattern;
+        this.replacementProvider = replacementProvider;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NonNull String processString(
+            @NonNull final String input
+    ) {
+        final Matcher matcher = this.pattern.matcher(input);
+
+        // Kind of copied from the JDK 9+ implementation of "Matcher#replaceFirst"
+        final StringBuffer stringBuffer = new StringBuffer();
+        while (matcher.find()) {
+            final String replacement = this.replacementProvider.apply(matcher);
+            matcher.appendReplacement(stringBuffer, replacement == null ? "$0" : replacement);
+        }
+        matcher.appendTail(stringBuffer);
+
+        return stringBuffer.toString();
+    }
+}

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/PropertyReplacingStringProcessor.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/PropertyReplacingStringProcessor.java
@@ -1,0 +1,69 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.annotations;
+
+import java.util.function.Function;
+import java.util.regex.MatchResult;
+import java.util.regex.Pattern;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * {@link PropertyReplacementProvider} that replaces all sub-strings with the format
+ * {@code ${some.property}} with a function-generated string.
+ *
+ * @since 1.7.0
+ */
+public class PropertyReplacingStringProcessor extends PatternReplacingStringProcessor {
+
+    public static final Pattern PROPERTY_REGEX = Pattern.compile("\\$\\{(\\S+)}");
+
+    /**
+     * Creates a new property replacing string processor.
+     *
+     * @param replacementProvider function generating the replacement strings
+     */
+    public PropertyReplacingStringProcessor(
+            final @NonNull Function<@NonNull String, @Nullable String> replacementProvider
+    ) {
+        super(PROPERTY_REGEX, new PropertyReplacementProvider(replacementProvider));
+    }
+
+
+    private static final class PropertyReplacementProvider implements Function<@NonNull MatchResult, @Nullable String> {
+
+        private final Function<String, String> replacementProvider;
+
+        private PropertyReplacementProvider(
+                final @NonNull Function<String, String> replacementProvider
+        ) {
+            this.replacementProvider = replacementProvider;
+        }
+
+        @Override
+        public @Nullable String apply(final @NonNull MatchResult matchResult) {
+            return this.replacementProvider.apply(matchResult.group(1));
+        }
+    }
+}

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/StringProcessor.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/StringProcessor.java
@@ -23,29 +23,43 @@
 //
 package cloud.commandframework.annotations;
 
-import cloud.commandframework.CommandManager;
-import cloud.commandframework.execution.CommandExecutionCoordinator;
-import cloud.commandframework.internal.CommandRegistrationHandler;
-import cloud.commandframework.meta.SimpleCommandMeta;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
-public class TestCommandManager extends CommandManager<TestCommandSender> {
+/**
+ * Processor that intercepts all cloud annotation strings.
+ *
+ * @since 1.7.0
+ */
+@FunctionalInterface
+public interface StringProcessor {
 
-    public TestCommandManager() {
-        super(CommandExecutionCoordinator.simpleCoordinator(), CommandRegistrationHandler.nullCommandRegistrationHandler());
+    /**
+     * Returns a string processor that simply returns the input string.
+     *
+     * @return no-op string processor
+     */
+    static @NonNull StringProcessor noOp() {
+        return new NoOpStringProcessor();
     }
 
-    @Override
-    public final SimpleCommandMeta createDefaultCommandMeta() {
-        return SimpleCommandMeta.empty();
-    }
+    /**
+     * Processes the {@code input} string and returns the processed result.
+     * <p>
+     * This should always return a non-{@code null} result. If the input string
+     * isn't applicable to the processor implementation, the original string should
+     * be returned.
+     *
+     * @param input the input string
+     * @return the processed string
+     */
+    @NonNull String processString(@NonNull String input);
 
-    @Override
-    public final boolean hasPermission(
-            final TestCommandSender sender,
-            final String permission
-    ) {
-        return !permission.equalsIgnoreCase("no");
-    }
 
+    final class NoOpStringProcessor implements StringProcessor {
+
+        @Override
+        public @NonNull String processString(final @NonNull String input) {
+            return input;
+        }
+    }
 }
-

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/NoOpStringProcessorTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/NoOpStringProcessorTest.java
@@ -23,29 +23,27 @@
 //
 package cloud.commandframework.annotations;
 
-import cloud.commandframework.CommandManager;
-import cloud.commandframework.execution.CommandExecutionCoordinator;
-import cloud.commandframework.internal.CommandRegistrationHandler;
-import cloud.commandframework.meta.SimpleCommandMeta;
+import static com.google.common.truth.Truth.assertThat;
 
-public class TestCommandManager extends CommandManager<TestCommandSender> {
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
 
-    public TestCommandManager() {
-        super(CommandExecutionCoordinator.simpleCoordinator(), CommandRegistrationHandler.nullCommandRegistrationHandler());
+class NoOpStringProcessorTest {
+
+    @Test
+    void ProcessString_AnyInput_ReturnsOriginalInput() {
+        // Will force the input string to be scrambled 10 times.
+        for (int i = 0; i < 10; i++) {
+            // Arrange
+            final StringProcessor stringProcessor = StringProcessor.noOp();
+            final String input = ThreadLocalRandom.current().ints().mapToObj(Integer::toString).limit(32).collect(Collectors.joining());
+
+            // Act
+            final String output = stringProcessor.processString(input);
+
+            // Assert
+            assertThat(input).isEqualTo(output);
+        }
     }
-
-    @Override
-    public final SimpleCommandMeta createDefaultCommandMeta() {
-        return SimpleCommandMeta.empty();
-    }
-
-    @Override
-    public final boolean hasPermission(
-            final TestCommandSender sender,
-            final String permission
-    ) {
-        return !permission.equalsIgnoreCase("no");
-    }
-
 }
-

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/PatternReplacingStringProcessorTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/PatternReplacingStringProcessorTest.java
@@ -1,0 +1,92 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.annotations;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Function;
+import java.util.regex.MatchResult;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PatternReplacingStringProcessorTest {
+
+    private static final Pattern TEST_PATTERN = Pattern.compile("\\[(\\S+)]");
+
+    private PatternReplacingStringProcessor patternReplacingStringProcessor;
+
+    @Mock
+    private Function<MatchResult, String> replacementProvider;
+
+    @BeforeEach
+    void setup() {
+        this.patternReplacingStringProcessor = new PatternReplacingStringProcessor(
+                TEST_PATTERN,
+                this.replacementProvider
+        );
+    }
+
+    @Test
+    void ProcessString_MatchingInput_ReplacesGroups() {
+        // Arrange
+        when(this.replacementProvider.apply(any())).thenAnswer(iom -> iom.getArgument(0, MatchResult.class).group(1));
+
+        final String input = "[hello] [world]!";
+
+        // Act
+        final String output = this.patternReplacingStringProcessor.processString(input);
+
+        // Act
+        assertThat(output).isEqualTo("hello world!");
+
+        verify(this.replacementProvider, times(2)).apply(notNull());
+        verifyNoMoreInteractions(this.replacementProvider);
+    }
+
+    @Test
+    void ProcessString_NullReplacement_InputPreserved() {
+        // Arrange
+        final String input = "[input] ...";
+
+        // Act
+        final String output = this.patternReplacingStringProcessor.processString(input);
+
+        // Act
+        assertThat(output).isEqualTo(input);
+
+        verify(this.replacementProvider).apply(notNull());
+        verifyNoMoreInteractions(this.replacementProvider);
+    }
+}

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/PropertyReplacingStringProcessorTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/PropertyReplacingStringProcessorTest.java
@@ -1,0 +1,102 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.annotations;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PropertyReplacingStringProcessorTest {
+
+    private PropertyReplacingStringProcessor propertyReplacingStringProcessor;
+
+    @Mock
+    private Function<String, String> propertyProvider;
+
+    @BeforeEach
+    void setup() {
+        this.propertyReplacingStringProcessor = new PropertyReplacingStringProcessor(this.propertyProvider);
+    }
+
+    @Test
+    void ProcessString_KnownProperty_ReplacesWithValue() {
+        // Arrange
+        when(this.propertyProvider.apply(anyString())).thenAnswer(iom -> "transformed: " + iom.getArgument(0, String.class));
+
+        final String input = "${hello.world}";
+
+        // Act
+        final String output = this.propertyReplacingStringProcessor.processString(input);
+
+        // Assert
+        assertThat(output).isEqualTo("transformed: hello.world");
+
+        verify(this.propertyProvider).apply("hello.world");
+        verifyNoMoreInteractions(this.propertyProvider);
+    }
+
+    @Test
+    void ProcessString_MultipleProperties_ReplacesAll() {
+        // Arrange
+        when(this.propertyProvider.apply(anyString())).thenAnswer(iom -> iom.getArgument(0, String.class));
+
+        final String input = "${cats} are cute, and so are ${dogs}!";
+
+        // Act
+        final String output = this.propertyReplacingStringProcessor.processString(input);
+
+        // Assert
+        assertThat(output).isEqualTo("cats are cute, and so are dogs!");
+
+        verify(this.propertyProvider).apply("cats");
+        verify(this.propertyProvider).apply("dogs");
+        verifyNoMoreInteractions(this.propertyProvider);
+    }
+
+    @Test
+    void ProcessString_NullProperty_InputPreserved() {
+        // Arrange
+        final String input = "${input} ...";
+
+        // Act
+        final String output = this.propertyReplacingStringProcessor.processString(input);
+
+        // Act
+        assertThat(output).isEqualTo(input);
+
+        verify(this.propertyProvider).apply(notNull());
+        verifyNoMoreInteractions(this.propertyProvider);
+    }
+}

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/StringProcessingTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/StringProcessingTest.java
@@ -1,0 +1,133 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.annotations.feature;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.annotations.AnnotationParser;
+import cloud.commandframework.annotations.Argument;
+import cloud.commandframework.annotations.CommandDescription;
+import cloud.commandframework.annotations.CommandMethod;
+import cloud.commandframework.annotations.CommandPermission;
+import cloud.commandframework.annotations.Flag;
+import cloud.commandframework.annotations.PropertyReplacingStringProcessor;
+import cloud.commandframework.annotations.TestCommandManager;
+import cloud.commandframework.annotations.TestCommandSender;
+import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.compound.FlagArgument;
+import cloud.commandframework.arguments.flags.CommandFlag;
+import cloud.commandframework.arguments.parser.StandardParameters;
+import cloud.commandframework.meta.CommandMeta;
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class StringProcessingTest {
+
+    private AnnotationParser<TestCommandSender> annotationParser;
+    private TestCommandManager commandManager;
+
+    @BeforeEach
+    void setup() {
+        this.commandManager = new TestCommandManager();
+        this.annotationParser = new AnnotationParser<>(
+                this.commandManager,
+                TestCommandSender.class,
+                p -> CommandMeta.simple()
+                        .with(CommandMeta.DESCRIPTION, p.get(StandardParameters.DESCRIPTION, "No description"))
+                        .build()
+        );
+    }
+
+    @Test
+    @DisplayName("Tests @CommandMethod, @CommandPermission, @CommandDescription, @Argument & @Flag")
+    @SuppressWarnings("unchecked")
+    void testStringProcessing() {
+        // Arrange
+        final String testProperty = ThreadLocalRandom.current()
+                .ints()
+                .mapToObj(Integer::toString)
+                .limit(32)
+                .collect(Collectors.joining());
+        final String testFlagName = ThreadLocalRandom.current()
+                .ints()
+                .mapToObj(Integer::toString)
+                .limit(32)
+                .collect(Collectors.joining());
+        this.annotationParser.stringProcessor(
+                new PropertyReplacingStringProcessor(
+                        s -> ImmutableMap.of(
+                                "property.test", testProperty,
+                                "property.arg", "argument",
+                                "property.flag", testFlagName
+                        ).get(s)
+                )
+        );
+        final TestClassA testClassA = new TestClassA();
+
+        // Act
+        this.annotationParser.parse(testClassA);
+
+        // Assert
+        final List<Command<TestCommandSender>> commands = new ArrayList<>(this.commandManager.getCommands());
+        assertThat(commands).hasSize(1);
+
+        final Command<TestCommandSender> command = commands.get(0);
+        assertThat(command.toString()).isEqualTo(String.format("%s argument flags", testProperty));
+        assertThat(command.getCommandPermission().toString()).isEqualTo(testProperty);
+        assertThat(command.getCommandMeta().get(CommandMeta.DESCRIPTION)).hasValue(testProperty);
+
+        final List<CommandArgument<TestCommandSender, ?>> arguments = command.getArguments();
+        assertThat(arguments).hasSize(3);
+
+        final FlagArgument<TestCommandSender> flagArgument = (FlagArgument<TestCommandSender>) arguments.get(2);
+        assertThat(flagArgument).isNotNull();
+
+        final List<CommandFlag<?>> flags = new ArrayList<>(flagArgument.getFlags());
+        assertThat(flags).hasSize(1);
+        assertThat(flags.get(0).getName()).isEqualTo(testFlagName);
+    }
+
+
+    private static class TestClassA {
+
+        @CommandDescription("${property.test}")
+        @CommandPermission("${property.test}")
+        @CommandMethod("${property.test} <argument>")
+        public void commandA(
+                final TestCommandSender sender,
+                @Argument("${property.arg}") final String arg,
+                @Flag("${property.flag}") final String flag
+        ) {
+        }
+    }
+}

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/preprocessor/RegexPreprocessor.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/preprocessor/RegexPreprocessor.java
@@ -112,6 +112,7 @@ public final class RegexPreprocessor<C> implements BiFunction<@NonNull CommandCo
     /**
      * Exception thrown when input fails regex matching in {@link RegexPreprocessor}
      */
+    @SuppressWarnings("serial")
     public static final class RegexValidationException extends IllegalArgumentException {
 
         private static final long serialVersionUID = 747826566058072233L;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ByteArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ByteArgument.java
@@ -290,6 +290,7 @@ public final class ByteArgument<C> extends CommandArgument<C, Byte> {
     /**
      * Byte parse exception
      */
+    @SuppressWarnings("serial")
     public static final class ByteParseException extends NumberParseException {
 
         private static final long serialVersionUID = -4724241304872989208L;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DoubleArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DoubleArgument.java
@@ -279,6 +279,7 @@ public final class DoubleArgument<C> extends CommandArgument<C, Double> {
     }
 
 
+    @SuppressWarnings("serial")
     public static final class DoubleParseException extends NumberParseException {
 
         private static final long serialVersionUID = 1764554911581976586L;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/FloatArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/FloatArgument.java
@@ -274,6 +274,7 @@ public final class FloatArgument<C> extends CommandArgument<C, Float> {
     }
 
 
+    @SuppressWarnings("serial")
     public static final class FloatParseException extends NumberParseException {
 
         private static final long serialVersionUID = -1162983846751812292L;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/IntegerArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/IntegerArgument.java
@@ -337,6 +337,7 @@ public final class IntegerArgument<C> extends CommandArgument<C, Integer> {
     }
 
 
+    @SuppressWarnings("serial")
     public static final class IntegerParseException extends NumberParseException {
 
         private static final long serialVersionUID = -6933923056628373853L;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/LongArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/LongArgument.java
@@ -282,6 +282,7 @@ public final class LongArgument<C> extends CommandArgument<C, Long> {
     }
 
 
+    @SuppressWarnings("serial")
     public static final class LongParseException extends NumberParseException {
 
         private static final long serialVersionUID = 4366856282301198232L;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ShortArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ShortArgument.java
@@ -279,6 +279,7 @@ public final class ShortArgument<C> extends CommandArgument<C, Short> {
     }
 
 
+    @SuppressWarnings("serial")
     public static final class ShortParseException extends NumberParseException {
 
         private static final long serialVersionUID = -478674263339091032L;

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/AmbiguousNodeException.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/AmbiguousNodeException.java
@@ -36,7 +36,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * is being inserted into a {@link CommandTree} and an ambiguity
  * is detected.
  */
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "serial"})
 public final class AmbiguousNodeException extends IllegalStateException {
 
     private static final long serialVersionUID = -200207173805584709L;

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/CommandExecutionException.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/CommandExecutionException.java
@@ -32,6 +32,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * @since 1.2.0
  */
+@SuppressWarnings("serial")
 public class CommandExecutionException extends IllegalArgumentException {
 
     private static final long serialVersionUID = -4785446899438294661L;

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/CommandParseException.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/CommandParseException.java
@@ -31,7 +31,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 /**
  * Exception thrown when parsing user input into a command
  */
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "serial"})
 public class CommandParseException extends IllegalArgumentException {
 
     private static final long serialVersionUID = -2415981126382517435L;

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/InvalidCommandSenderException.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/InvalidCommandSenderException.java
@@ -32,6 +32,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 /**
  * Exception thrown when an invalid command sender tries to execute a command
  */
+@SuppressWarnings("serial")
 public final class InvalidCommandSenderException extends CommandParseException {
 
     private static final long serialVersionUID = 7372142477529875598L;

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/NoCommandInLeafException.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/NoCommandInLeafException.java
@@ -31,7 +31,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  * Thrown when a {@link CommandArgument}
  * that is registered as a leaf node, does not contain an owning {@link Command}
  */
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "serial"})
 public final class NoCommandInLeafException extends IllegalStateException {
 
     private static final long serialVersionUID = 3373529875213310821L;

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/NoPermissionException.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/NoPermissionException.java
@@ -33,7 +33,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  * Exception thrown when a command sender misses a permission required
  * to execute a {@link Command}
  */
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "serial"})
 public class NoPermissionException extends CommandParseException {
 
     private static final long serialVersionUID = 7103413337750692843L;

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/parsing/ParserException.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/parsing/ParserException.java
@@ -29,6 +29,7 @@ import cloud.commandframework.context.CommandContext;
 import java.util.Arrays;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
+@SuppressWarnings("serial")
 public class ParserException extends IllegalArgumentException {
 
     private static final long serialVersionUID = -4409795575435072170L;

--- a/gradle/libs.versions.yml
+++ b/gradle/libs.versions.yml
@@ -52,6 +52,7 @@ versions:
   jupiterEngine : 5.8.2
   mockitoCore : 4.1.0
   mockitoKotlin : 4.0.0
+  mockitoJupiter: 4.5.1
   truth : 1.1.3
 
   # build-logic
@@ -206,6 +207,10 @@ dependencies:
     group: org.mockito.kotlin
     name: mockito-kotlin
     version: { ref: mockitoKotlin }
+  mockitoJupiter:
+    group: org.mockito
+    name: mockito-junit-jupiter
+    version: { ref: mockitoJupiter }
   truth:
     group: com.google.truth
     name: truth


### PR DESCRIPTION
adds a system for processing strings found in annotations before they're used by AnnotationParser

implements https://github.com/Incendo/cloud/issues/347

Also, because we're using "-Werror", the code won't actually build (and thus tests won't work) using JDK18. To remedy this, a bunch of `@SuppressWarnings("serial")`s has been added to the exceptions. We don't serialize exceptions, and they're in fact non-serializable because of their members, so this is the appropriate solution (well, the better solution would be to make them serializable, but that's outside the scope of this PR).