### PR TITLE
build: add revapi to core api modules

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(libs.gradleKotlinJvm)
     implementation(libs.gradleDokka)
     implementation(libs.spotless)
+    implementation(libs.revapi)
 
     // https://github.com/gradle/gradle/issues/15383#issuecomment-779893192
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))

--- a/cloud-annotations/build.gradle.kts
+++ b/cloud-annotations/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("cloud.base-conventions")
+    id("com.palantir.revapi")
 }
 
 dependencies {

--- a/cloud-core/build.gradle.kts
+++ b/cloud-core/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("cloud.base-conventions")
+    id("com.palantir.revapi")
 }
 
 dependencies {

--- a/cloud-services/build.gradle.kts
+++ b/cloud-services/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("cloud.base-conventions")
+    id("com.palantir.revapi")
 }
 
 dependencies {

--- a/cloud-tasks/build.gradle.kts
+++ b/cloud-tasks/build.gradle.kts
@@ -1,3 +1,4 @@
 plugins {
     id("cloud.base-conventions")
+    id("com.palantir.revapi")
 }

--- a/gradle/libs.versions.yml
+++ b/gradle/libs.versions.yml
@@ -60,6 +60,7 @@ versions:
   gradleTestLogger: 3.1.0
   gradleErrorprone: 2.0.2
   spotless: *spotless
+  revapi: 1.7.0
 
 dependencies:
   checkerQual:
@@ -248,6 +249,10 @@ dependencies:
     group: com.diffplug.spotless
     name: spotless-plugin-gradle
     version: { ref: spotless }
+  revapi:
+    group: com.palantir.gradle.revapi
+    name: gradle-revapi
+    version: { ref: revapi }
 
 bundles:
   coroutines:


### PR DESCRIPTION
this way we can detect API/ABI breaks between versions. it'll compare to the previous tag.