### PR TITLE
feat(core): flag yielding arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Core: Add `DurationArgument` for parsing `java.time.Duration` ([#330](https://github.com/Incendo/cloud/pull/330)) 
 - Core: Add delegating command execution handlers ([#363](https://github.com/Incendo/cloud/pull/363))
 - Core: Add `builder()` getter to `Command.Builder` ([#363](https://github.com/Incendo/cloud/pull/363))
+- Core: Add flag yielding modes to `StringArgument` and `StringArrayArgument` ([#367](https://github.com/Incendo/cloud/pull/367))
 - Annotations: Annotation string processors ([#353](https://github.com/Incendo/cloud/pull/353))
 - Annotations: `@CommandContainer` annotation processing ([#364](https://github.com/Incendo/cloud/pull/364))
 - Annotations: `@CommandMethod` annotation processing for compile-time validation ([#365](https://github.com/Incendo/cloud/pull/365))

--- a/cloud-core/src/main/java/cloud/commandframework/annotations/specifier/FlagYielding.java
+++ b/cloud-core/src/main/java/cloud/commandframework/annotations/specifier/FlagYielding.java
@@ -1,0 +1,43 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.annotations.specifier;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the argument should stop parsing when encountering what
+ * could potentially be a flag.
+ * <p>
+ * This only has an effect on greedy arguments that consume all remaining input.
+ *
+ * @since 1.7.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface FlagYielding {
+
+}

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/compound/FlagArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/compound/FlagArgument.java
@@ -57,8 +57,8 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  */
 public final class FlagArgument<C> extends CommandArgument<C, Object> {
 
-    private static final Pattern FLAG_ALIAS_PATTERN = Pattern.compile(" -(?<name>([A-Za-z]+))");
     private static final Pattern FLAG_PRIMARY_PATTERN = Pattern.compile(" --(?<name>([A-Za-z]+))");
+    private static final Pattern FLAG_ALIAS_PATTERN = Pattern.compile(" -(?<name>([A-Za-z]+))");
 
     /**
      * Dummy object that indicates that flags were parsed successfully
@@ -125,13 +125,13 @@ public final class FlagArgument<C> extends CommandArgument<C, Object> {
         /**
          * Parse command input to figure out what flag is currently being
          * typed at the end of the input queue. If no flag value is being
-         * inputed, returns {@link Optional#empty()}.<br>
+         * inputted, returns {@link Optional#empty()}.<br>
          * <br>
          * Will consume all but the last element from the input queue.
          *
          * @param commandContext Command context
          * @param inputQueue The input queue of arguments
-         * @return current flag being typed, or <i>empty()</i> if none is
+         * @return current flag being typed, or {@code empty()} if none is
          */
         public @NonNull Optional<String> parseCurrentFlag(
                 final @NonNull CommandContext<@NonNull C> commandContext,

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/parser/StandardParameters.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/parser/StandardParameters.java
@@ -60,6 +60,16 @@ public final class StandardParameters {
      */
     public static final ParserParameter<Boolean> GREEDY = create("greedy", TypeToken.get(Boolean.class));
     /**
+     * Indicates that an argument should stop parsing when encountering a potential flag.
+     *
+     * @since 1.7.0
+     * @see cloud.commandframework.annotations.specifier.FlagYielding
+     */
+    public static final ParserParameter<Boolean> FLAG_YIELDING = create(
+            "flag_yielding",
+            TypeToken.get(Boolean.class)
+    );
+    /**
      * Indicates that a string argument should be quoted.
      *
      * @since 1.5.0

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/StringParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/StringParserTest.java
@@ -28,9 +28,6 @@ import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.context.CommandContext;
 import java.util.Collections;
 import java.util.LinkedList;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.Collectors;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -40,50 +37,18 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 
 @ExtendWith(MockitoExtension.class)
-class StringArrayParserTest {
-
-    private StringArrayArgument.StringArrayParser<TestCommandSender> parser;
+class StringParserTest {
 
     @Mock
     private CommandContext<TestCommandSender> context;
 
-    @BeforeEach
-    void setup() {
-        this.parser = new StringArrayArgument.StringArrayParser<>();
-    }
-
-    @Test
-    void Parse_RandomInput_CapturesAll() {
-        // Arrange
-        final LinkedList<String> input = new LinkedList<>();
-        for (int i = 0; i < 10; i++) {
-            input.add(
-                    ThreadLocalRandom.current()
-                            .ints()
-                            .mapToObj(Integer::toString)
-                            .limit(32)
-                            .collect(Collectors.joining())
-            );
-        }
-        final LinkedList<String> inputCopy = new LinkedList<>(input);
-
-        // Act
-        final ArgumentParseResult<String[]> result = this.parser.parse(
-                this.context,
-                input
-        );
-
-        // Assert
-        assertThat(result.getFailure()).isEmpty();
-        assertThat(result.getParsedValue()).hasValue(inputCopy.toArray(new String[0]));
-
-        assertThat(input).isEmpty();
-    }
-
     @Test
     void Parse_GreedyFlagAwareLongFormFlag_EndsAfterFlag() {
         // Arrange
-        final StringArrayArgument.StringArrayParser<TestCommandSender> parser = new StringArrayArgument.StringArrayParser<>(true);
+        final StringArgument.StringParser<TestCommandSender> parser = new StringArgument.StringParser<>(
+                StringArgument.StringMode.GREEDY_FLAG_YIELDING,
+                (context, input) -> Collections.emptyList()
+        );
         final LinkedList<String> input = ArgumentTestHelper.linkedListOf(
                 "this",
                 "is",
@@ -96,14 +61,14 @@ class StringArrayParserTest {
         );
 
         // Act
-        final ArgumentParseResult<String[]> result = parser.parse(
+        final ArgumentParseResult<String> result = parser.parse(
                 this.context,
                 input
         );
 
         // Assert
         assertThat(result.getFailure()).isEmpty();
-        assertThat(result.getParsedValue()).hasValue(new String[] {"this", "is", "a", "string"});
+        assertThat(result.getParsedValue()).hasValue("this is a string");
 
         assertThat(input).containsExactly("--flag", "more", "flag", "content");
     }
@@ -111,7 +76,10 @@ class StringArrayParserTest {
     @Test
     void Parse_GreedyFlagAwareShortFormFlag_EndsAfterFlag() {
         // Arrange
-        final StringArrayArgument.StringArrayParser<TestCommandSender> parser = new StringArrayArgument.StringArrayParser<>(true);
+        final StringArgument.StringParser<TestCommandSender> parser = new StringArgument.StringParser<>(
+                StringArgument.StringMode.GREEDY_FLAG_YIELDING,
+                (context, input) -> Collections.emptyList()
+        );
         final LinkedList<String> input = ArgumentTestHelper.linkedListOf(
                 "this",
                 "is",
@@ -124,14 +92,14 @@ class StringArrayParserTest {
         );
 
         // Act
-        final ArgumentParseResult<String[]> result = parser.parse(
+        final ArgumentParseResult<String> result = parser.parse(
                 this.context,
                 input
         );
 
         // Assert
         assertThat(result.getFailure()).isEmpty();
-        assertThat(result.getParsedValue()).hasValue(new String[] {"this", "is", "a", "string"});
+        assertThat(result.getParsedValue()).hasValue("this is a string");
 
         assertThat(input).containsExactly("-f", "-l", "-a", "-g");
     }

--- a/cloud-core/src/test/java/cloud/commandframework/issue/Issue321.java
+++ b/cloud-core/src/test/java/cloud/commandframework/issue/Issue321.java
@@ -1,0 +1,83 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.issue;
+
+import cloud.commandframework.CommandManager;
+import cloud.commandframework.TestCommandSender;
+import cloud.commandframework.arguments.flags.FlagContext;
+import cloud.commandframework.arguments.standard.StringArrayArgument;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.execution.CommandResult;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+import static cloud.commandframework.util.TestUtils.createManager;
+import static com.google.common.truth.Truth8.assertThat;
+
+/**
+ * Test for https://github.com/Incendo/cloud/issues/321.
+ */
+class Issue321 {
+
+    @Test
+    void flagSucceedingFlagWithStringArrayArgument() {
+        // Arrange
+        final CommandManager<TestCommandSender> commandManager = createManager();
+        commandManager.command(
+                commandManager.commandBuilder("command")
+                        .flag(
+                                commandManager.flagBuilder("flag1")
+                                        .withArgument(
+                                                StringArrayArgument.of(
+                                                        "array",
+                                                        true /* flagYielding */,
+                                                        (context, input) -> Collections.emptyList()
+                                                )
+                                        )
+                        ).flag(
+                                commandManager.flagBuilder("flag2")
+                                        .withArgument(
+                                                StringArrayArgument.of(
+                                                        "array",
+                                                        true /* flagYielding */,
+                                                        (context, input) -> Collections.emptyList()
+                                                )
+                                        )
+                        )
+        );
+
+        // Act
+        final CommandResult<TestCommandSender> result = commandManager.executeCommand(
+                new TestCommandSender(),
+                "command --flag1 one two three --flag2 1 2 3"
+        ).join();
+
+        // Assert
+        final CommandContext<TestCommandSender> context = result.getCommandContext();
+        final FlagContext flags = context.flags();
+
+        assertThat(flags.<String[]>getValue("flag1")).hasValue(new String[] {"one", "two", "three"});
+        assertThat(flags.<String[]>getValue("flag2")).hasValue(new String[] {"1", "2", "3"});
+    }
+}


### PR DESCRIPTION
Implements https://github.com/Incendo/cloud/issues/218
Also confirmed to fix https://github.com/Incendo/cloud/issues/321.

Both `StringArgument` and `StringArrayArgument` now have flag-yielding modes. For annotated command method users, this can be activated using ´@FlagYielding`