### PR TITLE
feat(bukkit/paper): add root command deletion support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Annotations: Annotation string processors ([#353](https://github.com/Incendo/cloud/pull/353))
 - Annotations: `@CommandContainer` annotation processing ([#364](https://github.com/Incendo/cloud/pull/364))
 - Annotations: `@CommandMethod` annotation processing for compile-time validation ([#365](https://github.com/Incendo/cloud/pull/365))
+- Add root command deletion support (core/pircbotx/javacord/jda/bukkit/paper) ([#369](https://github.com/Incendo/cloud/pull/369),
+  [#371](https://github.com/Incendo/cloud/pull/371))
 
 ### Fixed
 - Core: Fix missing caption registration for the regex caption ([#351](https://github.com/Incendo/cloud/pull/351))

--- a/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
@@ -439,7 +439,8 @@ public abstract class CommandManager<C> {
         // Mark the command for deletion.
         final CommandTree.Node<@Nullable CommandArgument<C, ?>> node = this.commandTree.getNamedNode(rootCommand);
         if (node == null) {
-            throw new IllegalArgumentException(String.format("No root command named '%s' exists", rootCommand));
+            // If the node doesn't exist, we don't really need to delete it...
+            return;
         }
 
         // The registration handler gets to act before we destruct the command.

--- a/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
@@ -963,14 +963,10 @@ public final class CommandTree<C> {
     }
 
     private boolean removeNode(final @NonNull Node<@Nullable CommandArgument<C, ?>> node) {
-        if (node.isLeaf()) {
-            if (this.getRootNodes().contains(node)) {
-                this.internalTree.removeChild(node);
-            } else {
-                return node.getParent().removeChild(node);
-            }
+        if (this.getRootNodes().contains(node)) {
+            this.internalTree.removeChild(node);
         } else {
-            throw new IllegalStateException(String.format("Cannot delete intermediate node '%s'", node));
+            return node.getParent().removeChild(node);
         }
 
         return false;

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandManager.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandManager.java
@@ -130,6 +130,7 @@ public class BukkitCommandManager<C> extends CommandManager<C> implements Brigad
 
         /* Register capabilities */
         CloudBukkitCapabilities.CAPABLE.forEach(this::registerCapability);
+        this.registerCapability(CloudCapability.StandardCapabilities.ROOT_COMMAND_DELETION);
 
         /* Register Bukkit Preprocessor */
         this.registerCommandPreProcessor(new BukkitCommandPreprocessor<>(this));

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/CloudBukkitListener.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/CloudBukkitListener.java
@@ -27,6 +27,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.event.server.PluginDisableEvent;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 
@@ -47,4 +48,10 @@ final class CloudBukkitListener<C> implements Listener {
         this.bukkitCommandManager.lockIfBrigadierCapable();
     }
 
+    @EventHandler(priority = EventPriority.HIGHEST)
+    void onPluginDisable(final @NonNull PluginDisableEvent event) {
+        if (event.getPlugin().equals(this.bukkitCommandManager.getOwningPlugin())) {
+            this.bukkitCommandManager.rootCommands().forEach(this.bukkitCommandManager::deleteRootCommand);
+        }
+    }
 }

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperBrigadierListener.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperBrigadierListener.java
@@ -79,16 +79,24 @@ class PaperBrigadierListener<C> implements Listener {
 
         final CommandTree<C> commandTree = this.paperCommandManager.getCommandTree();
 
-        String label = event.getCommandLabel();
-        if (label.contains(":")) {
-            label = label.split(Pattern.quote(":"))[1];
+        final String label;
+        if (event.getCommandLabel().contains(":")) {
+            label = event.getCommandLabel().split(Pattern.quote(":"))[1];
+        } else {
+            label = event.getCommandLabel();
         }
 
         final CommandTree.Node<CommandArgument<C, ?>> node = commandTree.getNamedNode(label);
         if (node == null) {
             return;
         }
+
         final BiPredicate<BukkitBrigadierCommandSource, CommandPermission> permissionChecker = (s, p) -> {
+            // We need to check that the command still exists...
+            if (commandTree.getNamedNode(label) == null) {
+                return false;
+            }
+
             final C sender = this.paperCommandManager.getCommandSenderMapper().apply(s.getBukkitSender());
             return this.paperCommandManager.hasPermission(sender, p);
         };

--- a/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/ExamplePlugin.java
+++ b/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/ExamplePlugin.java
@@ -35,6 +35,7 @@ import cloud.commandframework.annotations.Confirmation;
 import cloud.commandframework.annotations.Flag;
 import cloud.commandframework.annotations.Regex;
 import cloud.commandframework.annotations.specifier.Greedy;
+import cloud.commandframework.annotations.suggestions.Suggestions;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ParserParameters;
 import cloud.commandframework.arguments.parser.StandardParameters;
@@ -51,6 +52,7 @@ import cloud.commandframework.bukkit.parsers.WorldArgument;
 import cloud.commandframework.bukkit.parsers.selector.SingleEntitySelectorArgument;
 import cloud.commandframework.captions.Caption;
 import cloud.commandframework.captions.SimpleCaptionRegistry;
+import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.execution.AsynchronousCommandExecutionCoordinator;
 import cloud.commandframework.execution.CommandExecutionCoordinator;
 import cloud.commandframework.extra.confirmation.CommandConfirmationManager;
@@ -71,6 +73,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -454,7 +457,7 @@ public final class ExamplePlugin extends JavaPlugin {
                 }));
     }
 
-    @CommandMethod("example help [query]")
+    @CommandMethod("example|e|ex help [query]")
     @CommandDescription("Help menu")
     public void commandHelp(
             final @NonNull CommandSender sender,
@@ -526,6 +529,36 @@ public final class ExamplePlugin extends JavaPlugin {
     ) {
         this.manager.taskRecipe().begin(location).synchronous((@NonNull TaskConsumer<Location>) sender::teleport)
                 .execute(() -> sender.sendMessage("You have been teleported!"));
+    }
+
+    @CommandMethod("removeall")
+    public void removeAll(
+            final @NonNull CommandSender sender
+    ) {
+        this.manager.rootCommands().forEach(this.manager::deleteRootCommand);
+        sender.sendMessage("All root commands have been deleted :)");
+    }
+
+    @CommandMethod("removesingle <command>")
+    public void removeSingle(
+            final @NonNull CommandSender sender,
+            final @Argument(value = "command", suggestions = "commands") String command
+    ) {
+        this.manager.deleteRootCommand(command);
+        sender.sendMessage("Deleted the root command :)");
+    }
+
+    @Suggestions("commands")
+    public List<String> commands(
+            final @NonNull CommandContext<CommandSender> context,
+            final @NonNull String input
+    ) {
+        return new ArrayList<>(this.manager.rootCommands());
+    }
+
+    @CommandMethod("disableme")
+    public void disableMe() {
+        this.getServer().getPluginManager().disablePlugin(this);
     }
 
 


### PR DESCRIPTION
The Brigadier part is one big hack, but I refuse to use reflection to modify the internal root command & then force-syncing and whatnot. This works well enough, and I won't spend more time on this feature as it shouldn't exist to begin with.