### PR TITLE
chore(core): deprecate prefixed accessors/mutators in CommandManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Core: Add `builder()` getter to `Command.Builder` ([#363](https://github.com/Incendo/cloud/pull/363))
 - Core: Add flag yielding modes to `StringArgument` and `StringArrayArgument` ([#367](https://github.com/Incendo/cloud/pull/367))
 - Core: Add [apiguardian](https://github.com/apiguardian-team/apiguardian) `@API` annotations ([#368](https://github.com/Incendo/cloud/pull/368))
+- Core: Deprecate prefixed getters/setters in `CommandManager` ([#377](https://github.com/Incendo/cloud/pull/377))
 - Annotations: Annotation string processors ([#353](https://github.com/Incendo/cloud/pull/353))
 - Annotations: `@CommandContainer` annotation processing ([#364](https://github.com/Incendo/cloud/pull/364))
 - Annotations: `@CommandMethod` annotation processing for compile-time validation ([#365](https://github.com/Incendo/cloud/pull/365))

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/AnnotationParser.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/AnnotationParser.java
@@ -439,7 +439,7 @@ public final class AnnotationParser<C> {
                 ));
             }
             try {
-                this.manager.getParserRegistry().registerSuggestionProvider(
+                this.manager.parserRegistry().registerSuggestionProvider(
                         this.processString(suggestions.value()),
                         new MethodSuggestionsProvider<>(instance, method)
                 );
@@ -476,7 +476,7 @@ public final class AnnotationParser<C> {
                 if (suggestions.isEmpty()) {
                     suggestionsProvider = (context, input) -> Collections.emptyList();
                 } else {
-                    suggestionsProvider = this.manager.getParserRegistry().getSuggestionProvider(suggestions)
+                    suggestionsProvider = this.manager.parserRegistry().getSuggestionProvider(suggestions)
                             .orElseThrow(() -> new NullPointerException(
                                     String.format(
                                             "Cannot find the suggestions provider with name '%s'",
@@ -493,12 +493,12 @@ public final class AnnotationParser<C> {
                         parameters -> methodArgumentParser;
                 final String name = this.processString(parser.name());
                 if (name.isEmpty()) {
-                    this.manager.getParserRegistry().registerParserSupplier(
+                    this.manager.parserRegistry().registerParserSupplier(
                             TypeToken.get(method.getGenericReturnType()),
                             parserFunction
                     );
                 } else {
-                    this.manager.getParserRegistry().registerNamedParserSupplier(
+                    this.manager.parserRegistry().registerNamedParserSupplier(
                             name,
                             parserFunction
                     );
@@ -687,12 +687,12 @@ public final class AnnotationParser<C> {
         final Parameter parameter = argumentPair.getParameter();
         final Collection<Annotation> annotations = Arrays.asList(parameter.getAnnotations());
         final TypeToken<?> token = TypeToken.get(parameter.getParameterizedType());
-        final ParserParameters parameters = this.manager.getParserRegistry()
+        final ParserParameters parameters = this.manager.parserRegistry()
                 .parseAnnotations(token, annotations);
         /* Create the argument parser */
         final ArgumentParser<C, ?> parser;
         if (argumentPair.getArgument().parserName().isEmpty()) {
-            parser = this.manager.getParserRegistry()
+            parser = this.manager.parserRegistry()
                     .createParser(token, parameters)
                     .orElseThrow(() -> new IllegalArgumentException(
                             String.format("Parameter '%s' in method '%s' "
@@ -702,7 +702,7 @@ public final class AnnotationParser<C> {
                                     token.getType().getTypeName()
                             )));
         } else {
-            parser = this.manager.getParserRegistry()
+            parser = this.manager.parserRegistry()
                     .createParser(argumentPair.getArgument().parserName(), parameters)
                     .orElseThrow(() -> new IllegalArgumentException(
                             String.format("Parameter '%s' in method '%s' "
@@ -745,7 +745,7 @@ public final class AnnotationParser<C> {
         } else if (!argument.suggestions().isEmpty()) { /* Check whether or not a suggestion provider should be set */
             final String suggestionProviderName = argument.suggestions();
             final Optional<BiFunction<CommandContext<C>, String, List<String>>> suggestionsFunction =
-                    this.manager.getParserRegistry().getSuggestionProvider(suggestionProviderName);
+                    this.manager.parserRegistry().getSuggestionProvider(suggestionProviderName);
             argumentBuilder.withSuggestionsProvider(
                     suggestionsFunction.orElseThrow(() ->
                             new IllegalArgumentException(String.format(

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/Argument.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/Argument.java
@@ -65,7 +65,7 @@ public @interface Argument {
      * <p>
      * For this to work, the suggestion needs to be registered in the parser registry. To do this, use
      * {@link cloud.commandframework.arguments.parser.ParserRegistry#registerSuggestionProvider(String, BiFunction)}.
-     * The registry instance can be retrieved using {@link cloud.commandframework.CommandManager#getParserRegistry()}.
+     * The registry instance can be retrieved using {@link cloud.commandframework.CommandManager#parserRegistry()}.
      *
      * @return The name of the suggestion provider, or {@code ""} if the default suggestion provider for the argument parser
      *         should be used instead

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/Flag.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/Flag.java
@@ -72,7 +72,7 @@ public @interface Flag {
      * <p>
      * For this to work, the suggestion needs to be registered in the parser registry. To do this, use
      * {@link cloud.commandframework.arguments.parser.ParserRegistry#registerSuggestionProvider(String, BiFunction)}.
-     * The registry instance can be retrieved using {@link cloud.commandframework.CommandManager#getParserRegistry()}.
+     * The registry instance can be retrieved using {@link cloud.commandframework.CommandManager#parserRegistry()}.
      *
      * @return The name of the suggestion provider, or {@code ""} if the default suggestion provider for the argument parser
      *         should be used instead

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagExtractor.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagExtractor.java
@@ -75,7 +75,7 @@ final class FlagExtractor implements Function<@NonNull Method, Collection<@NonNu
             } else {
                 final TypeToken<?> token = TypeToken.get(parameter.getType());
                 final Collection<Annotation> annotations = Arrays.asList(parameter.getAnnotations());
-                final ParserRegistry<?> registry = this.commandManager.getParserRegistry();
+                final ParserRegistry<?> registry = this.commandManager.parserRegistry();
                 final ArgumentParser<?, ?> parser;
                 final String parserName = this.annotationParser.processString(flag.parserName());
                 if (parserName.isEmpty()) {

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/parsers/Parser.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/parsers/Parser.java
@@ -61,7 +61,7 @@ public @interface Parser {
      * <p>
      * For this to work, the suggestion needs to be registered in the parser registry. To do this, use
      * {@link cloud.commandframework.arguments.parser.ParserRegistry#registerSuggestionProvider(String, BiFunction)}.
-     * The registry instance can be retrieved using {@link cloud.commandframework.CommandManager#getParserRegistry()}.
+     * The registry instance can be retrieved using {@link cloud.commandframework.CommandManager#parserRegistry()}.
      *
      * @return The name of the suggestion provider, or {@code ""}
      */

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
@@ -72,10 +72,10 @@ class AnnotationParserTest {
     void setup() {
         manager = new TestCommandManager();
         annotationParser = new AnnotationParser<>(manager, TestCommandSender.class, p -> SimpleCommandMeta.empty());
-        manager.getParserRegistry().registerNamedParserSupplier("potato", p -> new StringArgument.StringParser<>(
+        manager.parserRegistry().registerNamedParserSupplier("potato", p -> new StringArgument.StringParser<>(
                 StringArgument.StringMode.SINGLE, (c, s) -> Collections.singletonList("potato")));
         /* Register a suggestion provider */
-        manager.getParserRegistry().registerSuggestionProvider(
+        manager.parserRegistry().registerSuggestionProvider(
                 "some-name",
                 (context, input) -> NAMED_SUGGESTIONS
         );
@@ -156,7 +156,7 @@ class AnnotationParserTest {
     @Test
     void testAnnotatedSuggestionsProviders() {
         final BiFunction<CommandContext<TestCommandSender>, String, List<String>> suggestionsProvider =
-                this.manager.getParserRegistry().getSuggestionProvider("cows").orElse(null);
+                this.manager.parserRegistry().getSuggestionProvider("cows").orElse(null);
         Assertions.assertNotNull(suggestionsProvider);
         Assertions.assertTrue(suggestionsProvider.apply(new CommandContext<>(new TestCommandSender(), manager), "")
                 .contains("Stella"));
@@ -164,7 +164,7 @@ class AnnotationParserTest {
 
     @Test
     void testAnnotatedArgumentParser() {
-        final ArgumentParser<TestCommandSender, CustomType> parser = this.manager.getParserRegistry().createParser(
+        final ArgumentParser<TestCommandSender, CustomType> parser = this.manager.parserRegistry().createParser(
                 TypeToken.get(CustomType.class),
                 ParserParameters.empty()
         ).orElseThrow(() -> new NullPointerException("Could not find CustomType parser"));

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/TestCommandManager.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/TestCommandManager.java
@@ -27,6 +27,7 @@ import cloud.commandframework.CommandManager;
 import cloud.commandframework.execution.CommandExecutionCoordinator;
 import cloud.commandframework.internal.CommandRegistrationHandler;
 import cloud.commandframework.meta.SimpleCommandMeta;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class TestCommandManager extends CommandManager<TestCommandSender> {
 
@@ -41,8 +42,8 @@ public class TestCommandManager extends CommandManager<TestCommandSender> {
 
     @Override
     public final boolean hasPermission(
-            final TestCommandSender sender,
-            final String permission
+            final @NonNull TestCommandSender sender,
+            final @NonNull String permission
     ) {
         return !permission.equalsIgnoreCase("no");
     }

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/StringProcessingTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/StringProcessingTest.java
@@ -97,7 +97,7 @@ class StringProcessingTest {
         this.annotationParser.parse(testClassA);
 
         // Assert
-        final List<Command<TestCommandSender>> commands = new ArrayList<>(this.commandManager.getCommands());
+        final List<Command<TestCommandSender>> commands = new ArrayList<>(this.commandManager.commands());
         assertThat(commands).hasSize(1);
 
         final Command<TestCommandSender> command = commands.get(0);

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/issue/Issue262.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/issue/Issue262.java
@@ -54,7 +54,7 @@ class Issue262 {
     @BeforeEach
     void setup() {
         this.manager = new TestCommandManager();
-        this.commandHelpHandler = this.manager.getCommandHelpHandler();
+        this.commandHelpHandler = this.manager.createCommandHelpHandler();
         this.annotationParser = new AnnotationParser<>(
                 this.manager,
                 TestCommandSender.class,

--- a/cloud-core/src/main/java/cloud/commandframework/CommandHelpHandler.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandHelpHandler.java
@@ -61,7 +61,7 @@ public final class CommandHelpHandler<C> {
      */
     public @NonNull List<@NonNull VerboseHelpEntry<C>> getAllCommands() {
         final List<VerboseHelpEntry<C>> syntaxHints = new ArrayList<>();
-        for (final Command<C> command : this.commandManager.getCommands()) {
+        for (final Command<C> command : this.commandManager.commands()) {
             /* Check command is not filtered */
             if (!this.commandPredicate.test(command)) {
                 continue;
@@ -71,7 +71,7 @@ public final class CommandHelpHandler<C> {
             final String description = command.getCommandMeta().getOrDefault(CommandMeta.DESCRIPTION, "");
             syntaxHints.add(new VerboseHelpEntry<>(
                     command,
-                    this.commandManager.getCommandSyntaxFormatter()
+                    this.commandManager.commandSyntaxFormatter()
                             .apply(arguments, null),
                     description
             ));
@@ -89,10 +89,10 @@ public final class CommandHelpHandler<C> {
      */
     public @NonNull List<@NonNull String> getLongestSharedChains() {
         final List<String> chains = new ArrayList<>();
-        this.commandManager.getCommandTree().getRootNodes().forEach(node ->
+        this.commandManager.commandTree().getRootNodes().forEach(node ->
                 chains.add(Objects.requireNonNull(node.getValue())
                         .getName() + this.commandManager
-                        .getCommandSyntaxFormatter()
+                        .commandSyntaxFormatter()
                         .apply(
                                 Collections
                                         .emptyList(),
@@ -179,7 +179,7 @@ public final class CommandHelpHandler<C> {
                 final String description = command.getCommandMeta().getOrDefault(CommandMeta.DESCRIPTION, "");
                 syntaxHints.add(new VerboseHelpEntry<>(
                         command,
-                        this.commandManager.getCommandSyntaxFormatter()
+                        this.commandManager.commandSyntaxFormatter()
                                 .apply(arguments, null),
                         description
                 ));
@@ -191,7 +191,7 @@ public final class CommandHelpHandler<C> {
         }
 
         /* Traverse command to find the most specific help topic */
-        final CommandTree.Node<CommandArgument<C, ?>> node = this.commandManager.getCommandTree()
+        final CommandTree.Node<CommandArgument<C, ?>> node = this.commandManager.commandTree()
                 .getNamedNode(availableCommandLabels.iterator().next());
 
         final List<CommandArgument<C, ?>> traversedNodes = new LinkedList<>();
@@ -240,7 +240,7 @@ public final class CommandHelpHandler<C> {
                         continue;
                     }
                 }
-                final String currentDescription = this.commandManager.getCommandSyntaxFormatter().apply(traversedNodes, null);
+                final String currentDescription = this.commandManager.commandSyntaxFormatter().apply(traversedNodes, null);
                 /* Attempt to parse the longest possible description for the children */
                 final List<String> childSuggestions = new LinkedList<>();
                 for (final CommandTree.Node<CommandArgument<C, ?>> child : head.getChildren()) {
@@ -258,7 +258,7 @@ public final class CommandHelpHandler<C> {
                             child.getValue().getOwningCommand().getCommandPermission()
                     )) {
                         traversedNodesSub.add(child.getValue());
-                        childSuggestions.add(this.commandManager.getCommandSyntaxFormatter().apply(traversedNodesSub, child));
+                        childSuggestions.add(this.commandManager.commandSyntaxFormatter().apply(traversedNodesSub, child));
                     }
                 }
                 return new MultiHelpTopic<>(currentDescription, childSuggestions);

--- a/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
@@ -256,6 +256,7 @@ public abstract class CommandManager<C> {
      *
      * @return the caption variable replacement handler
      * @since 1.7.0
+     * @see #captionVariableReplacementHandler(CaptionVariableReplacementHandler)
      */
     @API(status = API.Status.STABLE, since = "1.7.0")
     public @NonNull CaptionVariableReplacementHandler captionVariableReplacementHandler() {
@@ -267,6 +268,7 @@ public abstract class CommandManager<C> {
      *
      * @param captionVariableReplacementHandler new replacement handler
      * @since 1.7.0
+     * @see #captionVariableReplacementHandler()
      */
     @API(status = API.Status.STABLE, since = "1.7.0")
     public void captionVariableReplacementHandler(
@@ -279,8 +281,23 @@ public abstract class CommandManager<C> {
      * Get the command syntax formatter
      *
      * @return Command syntax formatter
+     * @deprecated for removal since 1.7.0. Use the non-prefixed getter {@link #commandSyntaxFormatter()} instead.
      */
+    @Deprecated
+    @API(status = API.Status.DEPRECATED, since = "1.7.0")
     public @NonNull CommandSyntaxFormatter<C> getCommandSyntaxFormatter() {
+        return this.commandSyntaxFormatter();
+    }
+
+    /**
+     * Returns the command syntax formatter.
+     *
+     * @return the syntax formatter
+     * @since 1.7.0
+     * @see #commandSyntaxFormatter(CommandSyntaxFormatter)
+     */
+    @API(status = API.Status.STABLE, since = "1.7.0")
+    public @NonNull CommandSyntaxFormatter<C> commandSyntaxFormatter() {
         return this.commandSyntaxFormatter;
     }
 
@@ -288,8 +305,26 @@ public abstract class CommandManager<C> {
      * Set the command syntax formatter
      *
      * @param commandSyntaxFormatter New formatter
+     * @deprecated for removal since 1.7.0. Use the non-prefixed setter {@link #commandSyntaxFormatter(CommandSyntaxFormatter)}
+     *         instead.
      */
+    @Deprecated
+    @API(status = API.Status.DEPRECATED, since = "1.7.0")
     public void setCommandSyntaxFormatter(final @NonNull CommandSyntaxFormatter<C> commandSyntaxFormatter) {
+        this.commandSyntaxFormatter(commandSyntaxFormatter);
+    }
+
+    /**
+     * Sets the command syntax formatter.
+     * <p>
+     * The command syntax formatter is used to format the command syntax hints that are used in help and error messages.
+     *
+     * @param commandSyntaxFormatter new formatter
+     * @since 1.7.0
+     * @see #commandSyntaxFormatter()
+     */
+    @API(status = API.Status.STABLE, since = "1.7.0")
+    public void commandSyntaxFormatter(final @NonNull CommandSyntaxFormatter<C> commandSyntaxFormatter) {
         this.commandSyntaxFormatter = commandSyntaxFormatter;
     }
 
@@ -297,9 +332,40 @@ public abstract class CommandManager<C> {
      * Get the command registration handler
      *
      * @return Command registration handler
+     * @deprecated for removal since 1.7.0. Use the non-prefixed getter {@link #commandRegistrationHandler()} instead.
      */
+    @Deprecated
+    @API(status = API.Status.DEPRECATED, since = "1.7.0")
     public @NonNull CommandRegistrationHandler getCommandRegistrationHandler() {
+        return this.commandRegistrationHandler();
+    }
+
+    /**
+     * Returns the command registration handler.
+     * <p>
+     * The command registration handler is able to intercept newly created/deleted commands, in order to propagate
+     * these changes to the native command handler of the platform.
+     * <p>
+     * In platforms without a native command concept, this is likely to return
+     * {@link CommandRegistrationHandler#nullCommandRegistrationHandler()}.
+     *
+     * @return the command registration handler
+     * @since 1.7.0
+     */
+    public @NonNull CommandRegistrationHandler commandRegistrationHandler() {
         return this.commandRegistrationHandler;
+    }
+
+    @Deprecated
+    @API(status = API.Status.DEPRECATED, since = "1.7.0")
+    protected final void setCommandRegistrationHandler(final @NonNull CommandRegistrationHandler commandRegistrationHandler) {
+        this.commandRegistrationHandler(commandRegistrationHandler);
+    }
+
+    @API(status = API.Status.STABLE, since = "1.7.0")
+    protected final void commandRegistrationHandler(final @NonNull CommandRegistrationHandler commandRegistrationHandler) {
+        this.requireState(RegistrationState.BEFORE_REGISTRATION);
+        this.commandRegistrationHandler = commandRegistrationHandler;
     }
 
     /**
@@ -307,6 +373,8 @@ public abstract class CommandManager<C> {
      *
      * @param capability the capability
      * @since 1.7.0
+     * @see #hasCapability(CloudCapability)
+     * @see #capabilities()
      */
     @API(status = API.Status.STABLE, since = "1.7.0")
     protected final void registerCapability(final @NonNull CloudCapability capability) {
@@ -319,6 +387,7 @@ public abstract class CommandManager<C> {
      * @param capability the capability
      * @return {@code true} if the implementation has the {@code capability}, {@code false} if not
      * @since 1.7.0
+     * @see #capabilities()
      */
     @API(status = API.Status.STABLE, since = "1.7.0")
     public boolean hasCapability(final @NonNull CloudCapability capability) {
@@ -330,15 +399,11 @@ public abstract class CommandManager<C> {
      *
      * @return the currently registered capabilities
      * @since 1.7.0
+     * @see #hasCapability(CloudCapability)
      */
     @API(status = API.Status.STABLE, since = "1.7.0")
     public @NonNull Collection<@NonNull CloudCapability> capabilities() {
         return Collections.unmodifiableSet(new HashSet<>(this.capabilities));
-    }
-
-    protected final void setCommandRegistrationHandler(final @NonNull CommandRegistrationHandler commandRegistrationHandler) {
-        this.requireState(RegistrationState.BEFORE_REGISTRATION);
-        this.commandRegistrationHandler = commandRegistrationHandler;
     }
 
     /**
@@ -384,8 +449,23 @@ public abstract class CommandManager<C> {
      * Get the caption registry
      *
      * @return Caption registry
+     * @deprecated for removal since 1.7.0. Use the non-prefixed getter {@link #captionRegistry()} instead.
      */
+    @Deprecated
+    @API(status = API.Status.DEPRECATED, since = "1.7.0")
     public final @NonNull CaptionRegistry<C> getCaptionRegistry() {
+        return this.captionRegistry();
+    }
+
+    /**
+     * Returns the caption registry.
+     *
+     * @return the caption registry
+     * @since 1.7.0
+     * @see #captionRegistry(CaptionRegistry)
+     */
+    @API(status = API.Status.STABLE, since = "1.7.0")
+    public final @NonNull CaptionRegistry<C> captionRegistry() {
         return this.captionRegistry;
     }
 
@@ -394,8 +474,26 @@ public abstract class CommandManager<C> {
      * and so you may need to insert these captions yourself if you do decide to replace the caption registry.
      *
      * @param captionRegistry New caption registry
+     * @deprecated for removal since 1.7.0. Use the non-prefixed setter {@link #captionRegistry(CaptionRegistry)} instead.
      */
+    @Deprecated
+    @API(status = API.Status.DEPRECATED, since = "1.7.0")
     public final void setCaptionRegistry(final @NonNull CaptionRegistry<C> captionRegistry) {
+        this.captionRegistry(captionRegistry);
+    }
+
+    /**
+     * Replaces the caption registry.
+     * <p>
+     * Some platforms may inject their own captions into the default caption registry,
+     * and so you may need to insert these captions yourself, if you do decide to replace the caption registry.
+     *
+     * @param captionRegistry new caption registry.
+     * @see #captionRegistry()
+     * @since 1.7.0
+     */
+    @API(status = API.Status.STABLE, since = "1.7.0")
+    public final void captionRegistry(final @NonNull CaptionRegistry<C> captionRegistry) {
         this.captionRegistry = captionRegistry;
     }
 
@@ -403,7 +501,7 @@ public abstract class CommandManager<C> {
      * Replace the default caption registry
      *
      * @param captionRegistry Caption registry to use
-     * @deprecated Use {@link #setCaptionRegistry(CaptionRegistry)} These methods are identical.
+     * @deprecated Use {@link #captionRegistry(CaptionRegistry)} These methods are identical.
      */
     @Deprecated
     @API(status = API.Status.DEPRECATED)
@@ -782,8 +880,25 @@ public abstract class CommandManager<C> {
      * are doing
      *
      * @return Command tree
+     * @deprecated for removal since 1.7.0. Use the non-prefixed getter {@link #commandTree()} instead.
      */
+    @Deprecated
+    @API(status = API.Status.DEPRECATED, since = "1.7.0")
     public @NonNull CommandTree<C> getCommandTree() {
+        return this.commandTree();
+    }
+
+    /**
+     * Returns the internal command tree.
+     * <p>
+     * Be careful when accessing the command tree. Do not interact with it, unless you
+     * absolutely know what you're doing.
+     *
+     * @return the command tree
+     * @since 1.7.0
+     */
+    @API(status = API.Status.STABLE, since = "1.7.0")
+    public @NonNull CommandTree<C> commandTree() {
         return this.commandTree;
     }
 
@@ -871,9 +986,24 @@ public abstract class CommandManager<C> {
      * Get the command suggestions processor instance currently used in this command manager
      *
      * @return Command suggestions processor
-     * @see #setCommandSuggestionProcessor(CommandSuggestionProcessor) Setting the suggestion processor
+     * @see #commandSuggestionProcessor(CommandSuggestionProcessor) Setting the suggestion processor
+     * @deprecated for removal since 1.7.0. Use the non-prefixed getter {@link #commandSuggestionProcessor()} instead.
      */
+    @Deprecated
+    @API(status = API.Status.DEPRECATED, since = "1.7.0")
     public @NonNull CommandSuggestionProcessor<C> getCommandSuggestionProcessor() {
+        return this.commandSuggestionProcessor();
+    }
+
+    /**
+     * Returns the command suggestion processor used in this command manager.
+     *
+     * @return the command suggestion processor
+     * @since 1.7.0
+     * @see #commandSuggestionProcessor(CommandSuggestionProcessor)
+     */
+    @API(status = API.Status.STABLE, since = "1.7.0")
+    public @NonNull CommandSuggestionProcessor<C> commandSuggestionProcessor() {
         return this.commandSuggestionProcessor;
     }
 
@@ -883,8 +1013,27 @@ public abstract class CommandManager<C> {
      * before it's returned to the caller
      *
      * @param commandSuggestionProcessor New command suggestions processor
+     * @deprecated for removal since 1.7.0. Use the non-prefixed setter
+     * {@link #commandSuggestionProcessor(CommandSuggestionProcessor)} instead.
      */
+    @Deprecated
+    @API(status = API.Status.DEPRECATED, since = "1.7.0")
     public void setCommandSuggestionProcessor(final @NonNull CommandSuggestionProcessor<C> commandSuggestionProcessor) {
+        this.commandSuggestionProcessor(commandSuggestionProcessor);
+    }
+
+    /**
+     * Sets the command suggestion processor.
+     * <p>
+     * This will be called ever time {@link #suggest(Object, String)} is called, in order to process the list
+     * of suggestions before it's returned to the caller.
+     *
+     * @param commandSuggestionProcessor the new command sugesstion processor
+     * @since 1.7.0
+     * @see #commandSuggestionProcessor()
+     */
+    @API(status = API.Status.STABLE, since = "1.7.0")
+    public void commandSuggestionProcessor(final @NonNull CommandSuggestionProcessor<C> commandSuggestionProcessor) {
         this.commandSuggestionProcessor = commandSuggestionProcessor;
     }
 
@@ -900,8 +1049,31 @@ public abstract class CommandManager<C> {
      * should be registered in the constructor of the platform {@link CommandManager}
      *
      * @return Parser registry instance
+     * @deprecated for removal since 1.7.0. Use the non-prefixed getter {@link #parserRegistry()} instead.
      */
-    public ParserRegistry<C> getParserRegistry() {
+    @Deprecated
+    @API(status = API.Status.STABLE, since = "1.7.0")
+    public @NonNull ParserRegistry<C> getParserRegistry() {
+        return this.parserRegistry();
+    }
+
+    /**
+     * Returns the parser registry intance.
+     * <p>
+     * The parser registry contains default mappings to {@link ArgumentParser argument parsers} and
+     * allows for the registryion of custom mappings. The parser registry also contains mappings between
+     * annotations and {@link ParserParameter}, which allows for the customization of parser settings by
+     * using annotations.
+     * <p>
+     * When creating a new parser type, it is highly recommended to register it in the parser registry.
+     * In particular, default parser types (shipped with cloud implementations) should be registered in the
+     * constructor of the platform {@link CommandManager}.
+     *
+     * @return the parser registry instance
+     * @since 1.7.0
+     */
+    @API(status = API.Status.STABLE, since = "1.7.0")
+    public @NonNull ParserRegistry<C> parserRegistry() {
         return this.parserRegistry;
     }
 
@@ -914,7 +1086,6 @@ public abstract class CommandManager<C> {
     public final @NonNull ParameterInjectorRegistry<C> parameterInjectorRegistry() {
         return this.parameterInjectorRegistry;
     }
-
 
     /**
      * Get the exception handler for an exception type, if one has been registered
@@ -974,8 +1145,22 @@ public abstract class CommandManager<C> {
      * Get a collection containing all registered commands.
      *
      * @return Unmodifiable view of all registered commands
+     * @deprecated for removal since 1.7.0. Use the non-prefixed getter {@link #commands()} instead.
      */
+    @Deprecated
+    @API(status = API.Status.DEPRECATED, since = "1.7.0")
     public final @NonNull Collection<@NonNull Command<C>> getCommands() {
+        return this.commands();
+    }
+
+    /**
+     * Returns an unmodifiable view of all registered commands.
+     *
+     * @return unmodifiable view of all registered commands
+     * @since 1.7.0
+     */
+    @API(status = API.Status.STABLE, since = "1.7.0")
+    public final @NonNull Collection<@NonNull Command<C>> commands() {
         return Collections.unmodifiableCollection(this.commands);
     }
 
@@ -986,8 +1171,26 @@ public abstract class CommandManager<C> {
      *
      * @return Command help handler. A new instance will be created
      *         each time this method is called.
+     * @deprecated for removal since 1.7.0. Use {@link #createCommandHelpHandler()} instead.
      */
+    @Deprecated
+    @API(status = API.Status.DEPRECATED, since = "1.7.0")
     public final @NonNull CommandHelpHandler<C> getCommandHelpHandler() {
+        return this.createCommandHelpHandler();
+    }
+
+    /**
+     * Creates a new command help handler instance.
+     * <p>
+     * The command helper handler can be used to assist in the production of commad help menus, etc.
+     * <p>
+     * This command help handler instance will display all commands registered in this command manager.
+     *
+     * @return a new command helper handler instance
+     * @since 1.7.0
+     */
+    @API(status = API.Status.STABLE, since = "1.7.0")
+    public final @NonNull CommandHelpHandler<C> createCommandHelpHandler() {
         return new CommandHelpHandler<>(this, cmd -> true);
     }
 
@@ -1000,8 +1203,31 @@ public abstract class CommandManager<C> {
      *                         the help menu.
      * @return Command help handler. A new instance will be created
      *         each time this method is called.
+     * @deprecated for removal since 1.7.0. Use {@link #createCommandHelpHandler(Predicate)} instead.
      */
+    @Deprecated
+    @API(status = API.Status.DEPRECATED, since = "1.7.0")
     public final @NonNull CommandHelpHandler<C> getCommandHelpHandler(
+            final @NonNull Predicate<Command<C>> commandPredicate
+    ) {
+        return this.createCommandHelpHandler(commandPredicate);
+    }
+
+    /**
+     * Creates a new command help handler instance.
+     * <p>
+     * The command helper handler can be used to assist in the production of commad help menus, etc.
+     * <p>
+     * A predicate can be specified to filter what commands
+     * registered in this command manager are visible in the help menu.
+     *
+     * @param commandPredicate predicate that filters what commands are displayed in
+     *                         the help menu.
+     * @return a new command helper handler instance
+     * @since 1.7.0
+     */
+    @API(status = API.Status.STABLE, since = "1.7.0")
+    public final @NonNull CommandHelpHandler<C> createCommandHelpHandler(
             final @NonNull Predicate<Command<C>> commandPredicate
     ) {
         return new CommandHelpHandler<>(this, commandPredicate);
@@ -1102,7 +1328,7 @@ public abstract class CommandManager<C> {
      */
     @API(status = API.Status.STABLE, since = "1.4.0")
     protected final void lockRegistration() {
-        if (this.getRegistrationState() == RegistrationState.BEFORE_REGISTRATION) {
+        if (this.registrationState() == RegistrationState.BEFORE_REGISTRATION) {
             this.transitionOrThrow(RegistrationState.BEFORE_REGISTRATION, RegistrationState.AFTER_REGISTRATION);
             return;
         }
@@ -1116,9 +1342,24 @@ public abstract class CommandManager<C> {
      *
      * @return The current state
      * @since 1.2.0
+     * @deprecated for removal since 1.7.0. Use the non-prefixed getter {@link #registrationState()} instead.
      */
-    @API(status = API.Status.STABLE, since = "1.2.0")
+    @Deprecated
+    @API(status = API.Status.DEPRECATED, since = "1.7.0")
     public final @NonNull RegistrationState getRegistrationState() {
+        return this.registrationState();
+    }
+
+    /**
+     * Returns the active registration state for this manager.
+     * <p>
+     * If the state is {@link RegistrationState#AFTER_REGISTRATION}, commands can no longer be registered.
+     *
+     * @return the current state
+     * @since 1.7.0
+     */
+    @API(status = API.Status.STABLE, since = "1.7.0")
+    public final @NonNull RegistrationState registrationState() {
         return this.state.get();
     }
 

--- a/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
@@ -207,7 +207,7 @@ public final class CommandTree<C> {
                 } else {
                     /* Too many arguments. We have a unique path, so we can send the entire context */
                     return Pair.of(null, new InvalidSyntaxException(
-                            this.commandManager.getCommandSyntaxFormatter()
+                            this.commandManager.commandSyntaxFormatter()
                                     .apply(parsedArguments, root),
                             commandContext.getSender(), this.getChain(root)
                             .stream()
@@ -219,7 +219,7 @@ public final class CommandTree<C> {
             } else {
                 /* Too many arguments. We have a unique path, so we can send the entire context */
                 return Pair.of(null, new InvalidSyntaxException(
-                        this.commandManager.getCommandSyntaxFormatter()
+                        this.commandManager.commandSyntaxFormatter()
                                 .apply(parsedArguments, root),
                         commandContext.getSender(), this.getChain(root)
                         .stream()
@@ -278,7 +278,7 @@ public final class CommandTree<C> {
             }
             /* We know that there's no command and we also cannot match any of the children */
             return Pair.of(null, new InvalidSyntaxException(
-                    this.commandManager.getCommandSyntaxFormatter()
+                    this.commandManager.commandSyntaxFormatter()
                             .apply(parsedArguments, root),
                     commandContext.getSender(), this.getChain(root)
                     .stream()
@@ -378,7 +378,7 @@ public final class CommandTree<C> {
                         }
                         /* Not enough arguments */
                         return Pair.of(null, new InvalidSyntaxException(
-                                this.commandManager.getCommandSyntaxFormatter()
+                                this.commandManager.commandSyntaxFormatter()
                                         .apply(Objects.requireNonNull(
                                                         child.getValue()
                                                                 .getOwningCommand())
@@ -411,7 +411,7 @@ public final class CommandTree<C> {
                         }
                         /* Child does not have a command and so we cannot proceed */
                         return Pair.of(null, new InvalidSyntaxException(
-                                this.commandManager.getCommandSyntaxFormatter()
+                                this.commandManager.commandSyntaxFormatter()
                                         .apply(parsedArguments, root),
                                 commandContext.getSender(), this.getChain(root)
                                 .stream()
@@ -449,7 +449,7 @@ public final class CommandTree<C> {
                         } else {
                             /* Too many arguments. We have a unique path, so we can send the entire context */
                             return Pair.of(null, new InvalidSyntaxException(
-                                    this.commandManager.getCommandSyntaxFormatter()
+                                    this.commandManager.commandSyntaxFormatter()
                                             .apply(parsedArguments, child),
                                     commandContext.getSender(), this.getChain(root)
                                     .stream()
@@ -778,7 +778,7 @@ public final class CommandTree<C> {
                 throw new NoCommandInLeafException(leaf);
             } else {
                 final Command<C> owningCommand = leaf.getOwningCommand();
-                this.commandManager.getCommandRegistrationHandler().registerCommand(owningCommand);
+                this.commandManager.commandRegistrationHandler().registerCommand(owningCommand);
             }
         });
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/CommandArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/CommandArgument.java
@@ -699,7 +699,7 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
          */
         public @NonNull CommandArgument<@NonNull C, @NonNull T> build() {
             if (this.parser == null && this.manager != null) {
-                this.parser = this.manager.getParserRegistry().createParser(this.valueType, ParserParameters.empty())
+                this.parser = this.manager.parserRegistry().createParser(this.valueType, ParserParameters.empty())
                         .orElse(null);
             }
             if (this.parser == null) {

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/DelegatingCommandSuggestionEngine.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/DelegatingCommandSuggestionEngine.java
@@ -72,7 +72,7 @@ public final class DelegatingCommandSuggestionEngine<C> implements CommandSugges
         context.store("__raw_input__", new LinkedList<>(inputQueue));
         final List<String> suggestions;
         if (this.commandManager.preprocessContext(context, inputQueue) == State.ACCEPTED) {
-            suggestions = this.commandManager.getCommandSuggestionProcessor().apply(
+            suggestions = this.commandManager.commandSuggestionProcessor().apply(
                     new CommandPreprocessingContext<>(context, inputQueue),
                     this.commandTree.getSuggestions(
                             context,

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/DelegatingCommandSuggestionEngineFactory.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/DelegatingCommandSuggestionEngineFactory.java
@@ -46,7 +46,7 @@ public final class DelegatingCommandSuggestionEngineFactory<C> {
      */
     public DelegatingCommandSuggestionEngineFactory(final @NonNull CommandManager<C> commandManager) {
         this.commandManager = commandManager;
-        this.commandTree = commandManager.getCommandTree();
+        this.commandTree = commandManager.commandTree();
     }
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/compound/ArgumentPair.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/compound/ArgumentPair.java
@@ -90,7 +90,7 @@ public class ArgumentPair<C, U, V, O> extends CompoundArgument<Pair<U, V>, C, O>
             final @NonNull Pair<@NonNull Class<U>,
                     @NonNull Class<V>> types
     ) {
-        final ParserRegistry<C> parserRegistry = manager.getParserRegistry();
+        final ParserRegistry<C> parserRegistry = manager.parserRegistry();
         final ArgumentParser<C, U> firstParser = parserRegistry.createParser(
                 TypeToken.get(types.getFirst()),
                 ParserParameters.empty()

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/compound/ArgumentTriplet.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/compound/ArgumentTriplet.java
@@ -93,7 +93,7 @@ public class ArgumentTriplet<C, U, V, W, O> extends CompoundArgument<Triplet<U, 
             final @NonNull Triplet<@NonNull String, @NonNull String, @NonNull String> names,
             final @NonNull Triplet<@NonNull Class<U>, @NonNull Class<V>, @NonNull Class<W>> types
     ) {
-        final ParserRegistry<C> parserRegistry = manager.getParserRegistry();
+        final ParserRegistry<C> parserRegistry = manager.parserRegistry();
         final ArgumentParser<C, U> firstParser = parserRegistry.createParser(
                 TypeToken.get(types.getFirst()),
                 ParserParameters.empty()

--- a/cloud-core/src/main/java/cloud/commandframework/context/CommandContext.java
+++ b/cloud-core/src/main/java/cloud/commandframework/context/CommandContext.java
@@ -129,7 +129,7 @@ public class CommandContext<C> {
         this.commandSender = commandSender;
         this.suggestions = suggestions;
         this.commandManager = commandManager;
-        this.captionRegistry = commandManager.getCaptionRegistry();
+        this.captionRegistry = commandManager.captionRegistry();
         this.captionVariableReplacementHandler = commandManager.captionVariableReplacementHandler();
     }
 

--- a/cloud-core/src/test/java/cloud/commandframework/CommandDeletionTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandDeletionTest.java
@@ -87,7 +87,7 @@ class CommandDeletionTest {
         assertThat(completionException).hasCauseThat().isInstanceOf(NoSuchCommandException.class);
 
         assertThat(this.commandManager.suggest(new TestCommandSender(), "")).isEmpty();
-        assertThat(this.commandManager.getCommandTree().getRootNodes()).isEmpty();
+        assertThat(this.commandManager.commandTree().getRootNodes()).isEmpty();
     }
 
     @Test
@@ -144,6 +144,6 @@ class CommandDeletionTest {
         verifyNoMoreInteractions(handler2);
         verifyNoMoreInteractions(handler3);
 
-        assertThat(this.commandManager.getCommandTree().getRootNodes()).isEmpty();
+        assertThat(this.commandManager.commandTree().getRootNodes()).isEmpty();
     }
 }

--- a/cloud-core/src/test/java/cloud/commandframework/CommandHelpHandlerTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandHelpHandlerTest.java
@@ -73,7 +73,7 @@ class CommandHelpHandlerTest {
     @Test
     void testVerboseHelp() {
         final List<CommandHelpHandler.VerboseHelpEntry<TestCommandSender>> syntaxHints
-                = manager.getCommandHelpHandler().getAllCommands();
+                = manager.createCommandHelpHandler().getAllCommands();
         final CommandHelpHandler.VerboseHelpEntry<TestCommandSender> entry0 = syntaxHints.get(0);
         Assertions.assertEquals("test <potato>", entry0.getSyntaxString());
         final CommandHelpHandler.VerboseHelpEntry<TestCommandSender> entry1 = syntaxHints.get(1);
@@ -84,22 +84,22 @@ class CommandHelpHandlerTest {
 
     @Test
     void testLongestChains() {
-        final List<String> longestChains = manager.getCommandHelpHandler().getLongestSharedChains();
+        final List<String> longestChains = manager.createCommandHelpHandler().getLongestSharedChains();
         Assertions.assertEquals(Arrays.asList("test int|this|<potato>", "vec <<x> <y>>"), longestChains);
     }
 
     @Test
     void testHelpQuery() {
-        final CommandHelpHandler.HelpTopic<TestCommandSender> query1 = manager.getCommandHelpHandler().queryHelp("");
+        final CommandHelpHandler.HelpTopic<TestCommandSender> query1 = manager.createCommandHelpHandler().queryHelp("");
         Assertions.assertTrue(query1 instanceof CommandHelpHandler.IndexHelpTopic);
         this.printTopic("", query1);
-        final CommandHelpHandler.HelpTopic<TestCommandSender> query2 = manager.getCommandHelpHandler().queryHelp("test");
+        final CommandHelpHandler.HelpTopic<TestCommandSender> query2 = manager.createCommandHelpHandler().queryHelp("test");
         Assertions.assertTrue(query2 instanceof CommandHelpHandler.MultiHelpTopic);
         this.printTopic("test", query2);
-        final CommandHelpHandler.HelpTopic<TestCommandSender> query3 = manager.getCommandHelpHandler().queryHelp("test int");
+        final CommandHelpHandler.HelpTopic<TestCommandSender> query3 = manager.createCommandHelpHandler().queryHelp("test int");
         Assertions.assertTrue(query3 instanceof CommandHelpHandler.VerboseHelpTopic);
         this.printTopic("test int", query3);
-        final CommandHelpHandler.HelpTopic<TestCommandSender> query4 = manager.getCommandHelpHandler().queryHelp("vec");
+        final CommandHelpHandler.HelpTopic<TestCommandSender> query4 = manager.createCommandHelpHandler().queryHelp("vec");
         Assertions.assertTrue(query4 instanceof CommandHelpHandler.VerboseHelpTopic);
         this.printTopic("vec", query4);
     }
@@ -118,7 +118,7 @@ class CommandHelpHandlerTest {
          * - /test <potato>
          * - /test int <int>
          */
-        final CommandHelpHandler.HelpTopic<TestCommandSender> query1 = manager.getCommandHelpHandler(predicate).queryHelp("");
+        final CommandHelpHandler.HelpTopic<TestCommandSender> query1 = manager.createCommandHelpHandler(predicate).queryHelp("");
         Assertions.assertTrue(query1 instanceof CommandHelpHandler.IndexHelpTopic);
         Assertions.assertEquals(Arrays.asList("test <potato>", "test int <int>"), getSortedSyntaxStrings(query1));
 
@@ -127,7 +127,7 @@ class CommandHelpHandlerTest {
          * - /test <potato>
          * - /test int <int>
          */
-        final CommandHelpHandler.HelpTopic<TestCommandSender> query2 = manager.getCommandHelpHandler(predicate).queryHelp("test");
+        final CommandHelpHandler.HelpTopic<TestCommandSender> query2 = manager.createCommandHelpHandler(predicate).queryHelp("test");
         Assertions.assertTrue(query2 instanceof CommandHelpHandler.MultiHelpTopic);
         Assertions.assertEquals(Arrays.asList("test <potato>", "test int <int>"), getSortedSyntaxStrings(query2));
 
@@ -135,7 +135,7 @@ class CommandHelpHandlerTest {
          * List all commands from /test int, which should show only:
          * - /test int <int>
          */
-        final CommandHelpHandler.HelpTopic<TestCommandSender> query3 = manager.getCommandHelpHandler(predicate).queryHelp(
+        final CommandHelpHandler.HelpTopic<TestCommandSender> query3 = manager.createCommandHelpHandler(predicate).queryHelp(
                 "test int");
         Assertions.assertTrue(query3 instanceof CommandHelpHandler.VerboseHelpTopic);
         Assertions.assertEquals(Collections.singletonList("test int <int>"), getSortedSyntaxStrings(query3));
@@ -143,7 +143,7 @@ class CommandHelpHandlerTest {
         /*
          * List all commands from /vec, which should show none
          */
-        final CommandHelpHandler.HelpTopic<TestCommandSender> query4 = manager.getCommandHelpHandler(predicate).queryHelp("vec");
+        final CommandHelpHandler.HelpTopic<TestCommandSender> query4 = manager.createCommandHelpHandler(predicate).queryHelp("vec");
         Assertions.assertTrue(query4 instanceof CommandHelpHandler.IndexHelpTopic);
         Assertions.assertEquals(Collections.emptyList(), getSortedSyntaxStrings(query4));
     }
@@ -239,7 +239,7 @@ class CommandHelpHandlerTest {
     }
 
     private void printVerboseHelpTopic(final CommandHelpHandler.VerboseHelpTopic<TestCommandSender> helpTopic) {
-        System.out.printf("└── Command: /%s\n", manager.getCommandSyntaxFormatter()
+        System.out.printf("└── Command: /%s\n", manager.commandSyntaxFormatter()
                 .apply(helpTopic.getCommand().getArguments(), null));
         System.out.printf("    ├── Description: %s\n", helpTopic.getDescription());
         System.out.println("    └── Args: ");
@@ -252,7 +252,7 @@ class CommandHelpHandlerTest {
                 description = ": " + description;
             }
 
-            System.out.printf("        %s %s%s\n", iterator.hasNext() ? "├──" : "└──", manager.getCommandSyntaxFormatter().apply(
+            System.out.printf("        %s %s%s\n", iterator.hasNext() ? "├──" : "└──", manager.commandSyntaxFormatter().apply(
                     Collections.singletonList(component.getArgument()), null), description);
         }
     }

--- a/cloud-core/src/test/java/cloud/commandframework/CommandPermissionTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandPermissionTest.java
@@ -155,7 +155,7 @@ class CommandPermissionTest {
         @Override
         public boolean hasPermission(
                 final @NonNull TestCommandSender sender,
-                final String permission
+                final @NonNull String permission
         ) {
             if (permission.equalsIgnoreCase("first")) {
                 return true;

--- a/cloud-core/src/test/java/cloud/commandframework/CommandRegistrationStateTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandRegistrationStateTest.java
@@ -35,7 +35,7 @@ public class CommandRegistrationStateTest {
     @Test
     void testInitialState() {
         final CommandManager<TestCommandSender> manager = createManager();
-        assertEquals(CommandManager.RegistrationState.BEFORE_REGISTRATION, manager.getRegistrationState());
+        assertEquals(CommandManager.RegistrationState.BEFORE_REGISTRATION, manager.registrationState());
     }
 
     @Test
@@ -45,7 +45,7 @@ public class CommandRegistrationStateTest {
         manager.command(manager.commandBuilder("test").handler(ctx -> {
         }));
 
-        assertEquals(CommandManager.RegistrationState.REGISTERING, manager.getRegistrationState());
+        assertEquals(CommandManager.RegistrationState.REGISTERING, manager.registrationState());
     }
 
     @Test
@@ -57,7 +57,7 @@ public class CommandRegistrationStateTest {
         manager.command(manager.commandBuilder("test2").handler(ctx -> {
         }));
 
-        assertEquals(CommandManager.RegistrationState.REGISTERING, manager.getRegistrationState());
+        assertEquals(CommandManager.RegistrationState.REGISTERING, manager.registrationState());
     }
 
     @Test
@@ -67,7 +67,7 @@ public class CommandRegistrationStateTest {
         }));
         assertThrows(
                 IllegalStateException.class,
-                () -> manager.setCommandRegistrationHandler(CommandRegistrationHandler.nullCommandRegistrationHandler())
+                () -> manager.commandRegistrationHandler(CommandRegistrationHandler.nullCommandRegistrationHandler())
         );
     }
 

--- a/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
@@ -94,19 +94,19 @@ class CommandTreeTest {
         );
 
         // Act
-        final Pair<Command<TestCommandSender>, Exception> command1 = this.commandManager.getCommandTree().parse(
+        final Pair<Command<TestCommandSender>, Exception> command1 = this.commandManager.commandTree().parse(
                 new CommandContext<>(new TestCommandSender(), this.commandManager),
                 new LinkedList<>(Arrays.asList("test", "one"))
         );
-        final Pair<Command<TestCommandSender>, Exception> command2 = this.commandManager.getCommandTree().parse(
+        final Pair<Command<TestCommandSender>, Exception> command2 = this.commandManager.commandTree().parse(
                 new CommandContext<>(new TestCommandSender(), this.commandManager),
                 new LinkedList<>(Arrays.asList("test", "two"))
         );
-        final Pair<Command<TestCommandSender>, Exception> command3 = this.commandManager.getCommandTree().parse(
+        final Pair<Command<TestCommandSender>, Exception> command3 = this.commandManager.commandTree().parse(
                 new CommandContext<>(new TestCommandSender(), this.commandManager),
                 new LinkedList<>(Arrays.asList("test", "opt"))
         );
-        final Pair<Command<TestCommandSender>, Exception> command4 = this.commandManager.getCommandTree().parse(
+        final Pair<Command<TestCommandSender>, Exception> command4 = this.commandManager.commandTree().parse(
                 new CommandContext<>(new TestCommandSender(), this.commandManager),
                 new LinkedList<>(Arrays.asList("test", "opt", "12"))
         );
@@ -139,7 +139,7 @@ class CommandTreeTest {
         this.commandManager.command(command);
 
         // Act
-        final Command<TestCommandSender> result = this.commandManager.getCommandTree().parse(
+        final Command<TestCommandSender> result = this.commandManager.commandTree().parse(
                 new CommandContext<>(new TestCommandSender(), this.commandManager),
                 new LinkedList<>(Arrays.asList("other", "öpt", "12"))
         ).getFirst();
@@ -161,7 +161,7 @@ class CommandTreeTest {
         );
 
         // Act
-        final List<String> results = this.commandManager.getCommandTree().getSuggestions(
+        final List<String> results = this.commandManager.commandTree().getSuggestions(
                 new CommandContext<>(new TestCommandSender(), this.commandManager),
                 new LinkedList<>(Arrays.asList("test", ""))
         );
@@ -492,7 +492,7 @@ class CommandTreeTest {
         );
 
         /* Try parsing as a variable, which should match the variable command */
-        final Pair<Command<TestCommandSender>, Exception> variableResult = this.commandManager.getCommandTree().parse(
+        final Pair<Command<TestCommandSender>, Exception> variableResult = this.commandManager.commandTree().parse(
                 new CommandContext<>(new TestCommandSender(), this.commandManager),
                 new LinkedList<>(Arrays.asList("literalwithvariable", "argthatdoesnotmatch"))
         );
@@ -503,7 +503,7 @@ class CommandTreeTest {
         ;
 
         /* Try parsing with the main name literal, which should match the literal command */
-        final Pair<Command<TestCommandSender>, Exception> literalResult = this.commandManager.getCommandTree().parse(
+        final Pair<Command<TestCommandSender>, Exception> literalResult = this.commandManager.commandTree().parse(
                 new CommandContext<>(new TestCommandSender(), this.commandManager),
                 new LinkedList<>(Arrays.asList("literalwithvariable", "literal"))
         );
@@ -514,7 +514,7 @@ class CommandTreeTest {
         ;
 
         /* Try parsing with the alias of the literal, which should match the literal command */
-        final Pair<Command<TestCommandSender>, Exception> literalAliasResult = this.commandManager.getCommandTree().parse(
+        final Pair<Command<TestCommandSender>, Exception> literalAliasResult = this.commandManager.commandTree().parse(
                 new CommandContext<>(new TestCommandSender(), this.commandManager),
                 new LinkedList<>(Arrays.asList("literalwithvariable", "literalalias"))
         );

--- a/cloud-core/src/test/java/cloud/commandframework/issue/Issue281.java
+++ b/cloud-core/src/test/java/cloud/commandframework/issue/Issue281.java
@@ -52,8 +52,8 @@ class Issue281 {
         ) {
             @Override
             public boolean hasPermission(
-                    @NonNull final TestCommandSender sender,
-                    @NonNull final String permission
+                    final @NonNull TestCommandSender sender,
+                    final @NonNull String permission
             ) {
                 return true;
             }

--- a/cloud-discord/cloud-javacord/src/main/java/cloud/commandframework/javacord/JavacordCommandManager.java
+++ b/cloud-discord/cloud-javacord/src/main/java/cloud/commandframework/javacord/JavacordCommandManager.java
@@ -71,7 +71,7 @@ public class JavacordCommandManager<C> extends CommandManager<C> {
                     @NonNull String, @NonNull Boolean> commandPermissionMapper
     ) {
         super(commandExecutionCoordinator, new JavacordRegistrationHandler<>());
-        ((JavacordRegistrationHandler<C>) this.getCommandRegistrationHandler()).initialize(this);
+        ((JavacordRegistrationHandler<C>) this.commandRegistrationHandler()).initialize(this);
         this.discordApi = discordApi;
         this.commandSenderMapper = commandSenderMapper;
         this.backwardsCommandSenderMapper = backwardsCommandSenderMapper;

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/JDACommandManager.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/JDACommandManager.java
@@ -105,16 +105,16 @@ public class JDACommandManager<C> extends CommandManager<C> {
         this.registerCommandPreProcessor(new JDACommandPreprocessor<>(this));
 
         /* Register JDA Parsers */
-        this.getParserRegistry().registerParserSupplier(TypeToken.get(User.class), parserParameters ->
+        this.parserRegistry().registerParserSupplier(TypeToken.get(User.class), parserParameters ->
                 new UserArgument.UserParser<>(
                         new HashSet<>(Arrays.asList(UserArgument.ParserMode.values())),
                         UserArgument.Isolation.GLOBAL
                 ));
-        this.getParserRegistry().registerParserSupplier(TypeToken.get(MessageChannel.class), parserParameters ->
+        this.parserRegistry().registerParserSupplier(TypeToken.get(MessageChannel.class), parserParameters ->
                 new ChannelArgument.MessageParser<>(
                         new HashSet<>(Arrays.asList(ChannelArgument.ParserMode.values()))
                 ));
-        this.getParserRegistry().registerParserSupplier(TypeToken.get(Role.class), parserParameters ->
+        this.parserRegistry().registerParserSupplier(TypeToken.get(Role.class), parserParameters ->
                 new RoleArgument.RoleParser<>(
                         new HashSet<>(Arrays.asList(RoleArgument.ParserMode.values()))
                 ));

--- a/cloud-irc/cloud-pircbotx/src/main/java/cloud/commandframework/pircbotx/PircBotXCommandManager.java
+++ b/cloud-irc/cloud-pircbotx/src/main/java/cloud/commandframework/pircbotx/PircBotXCommandManager.java
@@ -104,14 +104,14 @@ public class PircBotXCommandManager<C> extends CommandManager<C> {
         this.commandPrefix = commandPrefix;
         this.userMapper = userMapper;
         this.pircBotX.getConfiguration().getListenerManager().addListener(new CloudListenerAdapter<>(this));
-        if (this.getCaptionRegistry() instanceof FactoryDelegatingCaptionRegistry) {
-            ((FactoryDelegatingCaptionRegistry<C>) this.getCaptionRegistry()).registerMessageFactory(
+        if (this.captionRegistry() instanceof FactoryDelegatingCaptionRegistry) {
+            ((FactoryDelegatingCaptionRegistry<C>) this.captionRegistry()).registerMessageFactory(
                     ARGUMENT_PARSE_FAILURE_USER_KEY,
                     (caption, user) -> ARGUMENT_PARSE_FAILURE_USER
             );
         }
         this.registerCommandPreProcessor(context -> context.getCommandContext().store(PIRCBOTX_META_KEY, pircBotX));
-        this.getParserRegistry().registerParserSupplier(
+        this.parserRegistry().registerParserSupplier(
                 TypeToken.get(User.class),
                 parameters -> new UserArgument.UserArgumentParser<>()
         );

--- a/cloud-kotlin/cloud-kotlin-extensions/src/test/kotlin/cloud/commandframework/kotlin/CommandBuildingDSLTest.kt
+++ b/cloud-kotlin/cloud-kotlin-extensions/src/test/kotlin/cloud/commandframework/kotlin/CommandBuildingDSLTest.kt
@@ -88,7 +88,7 @@ class CommandBuildingDSLTest {
         manager.executeCommand(SpecificCommandSender(), "kotlin dsl time bruh_moment")
 
         Assertions.assertEquals(
-            manager.commandHelpHandler.allCommands.map { it.syntaxString }.sorted(),
+            manager.createCommandHelpHandler().allCommands.map { it.syntaxString }.sorted(),
             setOf(
                 "kotlin dsl <moment>",
                 "kotlin dsl <moment> bruh_moment",

--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/CloudBrigadierManager.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/CloudBrigadierManager.java
@@ -430,7 +430,7 @@ public final class CloudBrigadierManager<C, S> {
             final com.mojang.brigadier.@NonNull Command<S> executor
     ) {
         final CommandTree.Node<CommandArgument<C, ?>> node = this.commandManager
-                .getCommandTree().getNamedNode(cloudCommand.getArguments().get(0).getName());
+                .commandTree().getNamedNode(cloudCommand.getArguments().get(0).getName());
         final SuggestionProvider<S> provider = (context, builder) -> this.buildSuggestions(
                 context,
                 null, /* parent node, null for the literal command node root */

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommand.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommand.java
@@ -196,7 +196,7 @@ final class BukkitCommand<C> extends org.bukkit.command.Command implements Plugi
 
     @Override
     public @NonNull String getUsage() {
-        return this.manager.getCommandSyntaxFormatter().apply(
+        return this.manager.commandSyntaxFormatter().apply(
                 Collections.singletonList(Objects.requireNonNull(this.namedNode().getValue())),
                 this.namedNode()
         );
@@ -229,6 +229,6 @@ final class BukkitCommand<C> extends org.bukkit.command.Command implements Plugi
     }
 
     private CommandTree.@Nullable Node<CommandArgument<C, ?>> namedNode() {
-        return this.manager.getCommandTree().getNamedNode(this.command.getName());
+        return this.manager.commandTree().getNamedNode(this.command.getName());
     }
 }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandManager.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandManager.java
@@ -125,7 +125,7 @@ public class BukkitCommandManager<C> extends CommandManager<C> implements Brigad
     )
             throws Exception {
         super(commandExecutionCoordinator, new BukkitPluginRegistrationHandler<>());
-        ((BukkitPluginRegistrationHandler<C>) this.getCommandRegistrationHandler()).initialize(this);
+        ((BukkitPluginRegistrationHandler<C>) this.commandRegistrationHandler()).initialize(this);
         this.owningPlugin = owningPlugin;
         this.commandSenderMapper = commandSenderMapper;
         this.backwardsCommandSenderMapper = backwardsCommandSenderMapper;
@@ -141,39 +141,39 @@ public class BukkitCommandManager<C> extends CommandManager<C> implements Brigad
         this.registerCommandPreProcessor(new BukkitCommandPreprocessor<>(this));
 
         /* Register Bukkit Parsers */
-        this.getParserRegistry().registerParserSupplier(TypeToken.get(World.class), parserParameters ->
+        this.parserRegistry().registerParserSupplier(TypeToken.get(World.class), parserParameters ->
                 new WorldArgument.WorldParser<>());
-        this.getParserRegistry().registerParserSupplier(TypeToken.get(Material.class), parserParameters ->
+        this.parserRegistry().registerParserSupplier(TypeToken.get(Material.class), parserParameters ->
                 new MaterialArgument.MaterialParser<>());
-        this.getParserRegistry().registerParserSupplier(TypeToken.get(Player.class), parserParameters ->
+        this.parserRegistry().registerParserSupplier(TypeToken.get(Player.class), parserParameters ->
                 new PlayerArgument.PlayerParser<>());
-        this.getParserRegistry().registerParserSupplier(TypeToken.get(OfflinePlayer.class), parserParameters ->
+        this.parserRegistry().registerParserSupplier(TypeToken.get(OfflinePlayer.class), parserParameters ->
                 new OfflinePlayerArgument.OfflinePlayerParser<>());
-        this.getParserRegistry().registerParserSupplier(TypeToken.get(Enchantment.class), parserParameters ->
+        this.parserRegistry().registerParserSupplier(TypeToken.get(Enchantment.class), parserParameters ->
                 new EnchantmentArgument.EnchantmentParser<>());
-        this.getParserRegistry().registerParserSupplier(TypeToken.get(Location.class), parserParameters ->
+        this.parserRegistry().registerParserSupplier(TypeToken.get(Location.class), parserParameters ->
                 new LocationArgument.LocationParser<>());
-        this.getParserRegistry().registerParserSupplier(TypeToken.get(Location2D.class), parserParameters ->
+        this.parserRegistry().registerParserSupplier(TypeToken.get(Location2D.class), parserParameters ->
                 new Location2DArgument.Location2DParser<>());
-        this.getParserRegistry().registerParserSupplier(TypeToken.get(ProtoItemStack.class), parserParameters ->
+        this.parserRegistry().registerParserSupplier(TypeToken.get(ProtoItemStack.class), parserParameters ->
                 new ItemStackArgument.Parser<>());
         /* Register Entity Selector Parsers */
-        this.getParserRegistry().registerParserSupplier(TypeToken.get(SingleEntitySelector.class), parserParameters ->
+        this.parserRegistry().registerParserSupplier(TypeToken.get(SingleEntitySelector.class), parserParameters ->
                 new SingleEntitySelectorArgument.SingleEntitySelectorParser<>());
-        this.getParserRegistry().registerParserSupplier(TypeToken.get(SinglePlayerSelector.class), parserParameters ->
+        this.parserRegistry().registerParserSupplier(TypeToken.get(SinglePlayerSelector.class), parserParameters ->
                 new SinglePlayerSelectorArgument.SinglePlayerSelectorParser<>());
-        this.getParserRegistry().registerParserSupplier(TypeToken.get(MultipleEntitySelector.class), parserParameters ->
+        this.parserRegistry().registerParserSupplier(TypeToken.get(MultipleEntitySelector.class), parserParameters ->
                 new MultipleEntitySelectorArgument.MultipleEntitySelectorParser<>());
-        this.getParserRegistry().registerParserSupplier(TypeToken.get(MultiplePlayerSelector.class), parserParameters ->
+        this.parserRegistry().registerParserSupplier(TypeToken.get(MultiplePlayerSelector.class), parserParameters ->
                 new MultiplePlayerSelectorArgument.MultiplePlayerSelectorParser<>());
 
         if (CraftBukkitReflection.classExists("org.bukkit.NamespacedKey")) {
             this.registerParserSupplierFor(NamespacedKeyArgument.class);
-            this.getParserRegistry().registerAnnotationMapper(
+            this.parserRegistry().registerAnnotationMapper(
                     RequireExplicitNamespace.class,
                     (annotation, type) -> ParserParameters.single(BukkitParserParameters.REQUIRE_EXPLICIT_NAMESPACE, true)
             );
-            this.getParserRegistry().registerAnnotationMapper(
+            this.parserRegistry().registerAnnotationMapper(
                     DefaultNamespace.class,
                     (annotation, type) -> ParserParameters.single(BukkitParserParameters.DEFAULT_NAMESPACE, annotation.value())
             );
@@ -191,7 +191,7 @@ public class BukkitCommandManager<C> extends CommandManager<C> implements Brigad
                 this.owningPlugin
         );
 
-        this.setCaptionRegistry(new BukkitCaptionRegistryFactory<C>().create());
+        this.captionRegistry(new BukkitCaptionRegistryFactory<C>().create());
     }
 
     /**
@@ -323,7 +323,7 @@ public class BukkitCommandManager<C> extends CommandManager<C> implements Brigad
         try {
             final CloudCommodoreManager<C> cloudCommodoreManager = new CloudCommodoreManager<>(this);
             cloudCommodoreManager.initialize(this);
-            this.setCommandRegistrationHandler(cloudCommodoreManager);
+            this.commandRegistrationHandler(cloudCommodoreManager);
             this.setSplitAliases(true);
         } catch (final Throwable e) {
             throw new BrigadierFailureException(BrigadierFailureReason.COMMODORE_NOT_PRESENT, e);
@@ -337,8 +337,8 @@ public class BukkitCommandManager<C> extends CommandManager<C> implements Brigad
      */
     @Override
     public @Nullable CloudBrigadierManager<C, ?> brigadierManager() {
-        if (this.getCommandRegistrationHandler() instanceof CloudCommodoreManager) {
-            return ((CloudCommodoreManager<C>) this.getCommandRegistrationHandler()).brigadierManager();
+        if (this.commandRegistrationHandler() instanceof CloudCommodoreManager) {
+            return ((CloudCommodoreManager<C>) this.commandRegistrationHandler()).brigadierManager();
         }
         return null;
     }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitPluginRegistrationHandler.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitPluginRegistrationHandler.java
@@ -75,7 +75,7 @@ public class BukkitPluginRegistrationHandler<C> implements CommandRegistrationHa
     public final boolean registerCommand(final @NonNull Command<?> command) {
         /* We only care about the root command argument */
         final CommandArgument<?, ?> commandArgument = command.getArguments().get(0);
-        if (!(this.bukkitCommandManager.getCommandRegistrationHandler() instanceof CloudCommodoreManager)
+        if (!(this.bukkitCommandManager.commandRegistrationHandler() instanceof CloudCommodoreManager)
                 && this.registeredCommands.containsKey(commandArgument)) {
             return false;
         }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/CloudCommodoreManager.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/CloudCommodoreManager.java
@@ -97,7 +97,7 @@ class CloudCommodoreManager<C> extends BukkitPluginRegistrationHandler<C> {
         final LiteralCommandNode<?> literalCommandNode = this.brigadierManager
                 .createLiteralCommandNode(label, command, (commandSourceStack, commandPermission) -> {
                     // We need to check that the command still exists...
-                    if (this.commandManager.getCommandTree().getNamedNode(label) == null) {
+                    if (this.commandManager.commandTree().getNamedNode(label) == null) {
                         return false;
                     }
 

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/argument/NamespacedKeyArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/argument/NamespacedKeyArgument.java
@@ -356,7 +356,7 @@ public final class NamespacedKeyArgument<C> extends CommandArgument<C, Namespace
      */
     @SuppressWarnings("unused")
     private static <C> void registerParserSupplier(final @NonNull BukkitCommandManager<C> commandManager) {
-        commandManager.getParserRegistry()
+        commandManager.parserRegistry()
                 .registerParserSupplier(TypeToken.get(NamespacedKey.class), params -> new Parser<>(
                         params.has(BukkitParserParameters.REQUIRE_EXPLICIT_NAMESPACE),
                         params.get(BukkitParserParameters.DEFAULT_NAMESPACE, NamespacedKey.MINECRAFT)

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/BlockPredicateArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/BlockPredicateArgument.java
@@ -335,7 +335,7 @@ public final class BlockPredicateArgument<C> extends CommandArgument<C, BlockPre
      */
     @SuppressWarnings("unused")
     private static <C> void registerParserSupplier(final @NonNull BukkitCommandManager<C> commandManager) {
-        commandManager.getParserRegistry()
+        commandManager.parserRegistry()
                 .registerParserSupplier(TypeToken.get(BlockPredicate.class), params -> new BlockPredicateArgument.Parser<>());
     }
 }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/ItemStackPredicateArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/ItemStackPredicateArgument.java
@@ -271,7 +271,7 @@ public final class ItemStackPredicateArgument<C> extends CommandArgument<C, Item
      */
     @SuppressWarnings("unused")
     private static <C> void registerParserSupplier(final @NonNull BukkitCommandManager<C> commandManager) {
-        commandManager.getParserRegistry().registerParserSupplier(
+        commandManager.parserRegistry().registerParserSupplier(
                 TypeToken.get(ItemStackPredicate.class),
                 params -> new ItemStackPredicateArgument.Parser<>()
         );

--- a/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/BungeeCommandManager.java
+++ b/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/BungeeCommandManager.java
@@ -71,7 +71,7 @@ public class BungeeCommandManager<C> extends CommandManager<C> {
             final @NonNull Function<@NonNull C, @NonNull CommandSender> backwardsCommandSenderMapper
     ) {
         super(commandExecutionCoordinator, new BungeePluginRegistrationHandler<>());
-        ((BungeePluginRegistrationHandler<C>) this.getCommandRegistrationHandler()).initialize(this);
+        ((BungeePluginRegistrationHandler<C>) this.commandRegistrationHandler()).initialize(this);
         this.owningPlugin = owningPlugin;
         this.commandSenderMapper = commandSenderMapper;
         this.backwardsCommandSenderMapper = backwardsCommandSenderMapper;
@@ -80,15 +80,15 @@ public class BungeeCommandManager<C> extends CommandManager<C> {
         this.registerCommandPreProcessor(new BungeeCommandPreprocessor<>(this));
 
         /* Register Bungee Parsers */
-        this.getParserRegistry().registerParserSupplier(TypeToken.get(ProxiedPlayer.class), parserParameters ->
+        this.parserRegistry().registerParserSupplier(TypeToken.get(ProxiedPlayer.class), parserParameters ->
                 new PlayerArgument.PlayerParser<>());
-        this.getParserRegistry().registerParserSupplier(TypeToken.get(ServerInfo.class), parserParameters ->
+        this.parserRegistry().registerParserSupplier(TypeToken.get(ServerInfo.class), parserParameters ->
                 new ServerArgument.ServerParser<>());
 
         /* Register default captions */
-        if (this.getCaptionRegistry() instanceof FactoryDelegatingCaptionRegistry) {
+        if (this.captionRegistry() instanceof FactoryDelegatingCaptionRegistry) {
             final FactoryDelegatingCaptionRegistry<C> factoryDelegatingCaptionRegistry = (FactoryDelegatingCaptionRegistry<C>)
-                    this.getCaptionRegistry();
+                    this.captionRegistry();
             factoryDelegatingCaptionRegistry.registerMessageFactory(
                     BungeeCaptionKeys.ARGUMENT_PARSE_FAILURE_PLAYER,
                     (context, key) -> ARGUMENT_PARSE_FAILURE_PLAYER

--- a/cloud-minecraft/cloud-cloudburst/src/main/java/cloud/commandframework/cloudburst/CloudburstCommandManager.java
+++ b/cloud-minecraft/cloud-cloudburst/src/main/java/cloud/commandframework/cloudburst/CloudburstCommandManager.java
@@ -65,7 +65,7 @@ public class CloudburstCommandManager<C> extends CommandManager<C> {
             final @NonNull Function<@NonNull C, @NonNull CommandSender> backwardsCommandSenderMapper
     ) {
         super(commandExecutionCoordinator, new CloudburstPluginRegistrationHandler<>());
-        ((CloudburstPluginRegistrationHandler<C>) this.getCommandRegistrationHandler()).initialize(this);
+        ((CloudburstPluginRegistrationHandler<C>) this.commandRegistrationHandler()).initialize(this);
         this.commandSenderMapper = commandSenderMapper;
         this.backwardsCommandSenderMapper = backwardsCommandSenderMapper;
         this.owningPlugin = owningPlugin;
@@ -95,7 +95,7 @@ public class CloudburstCommandManager<C> extends CommandManager<C> {
 
     @Override
     public final boolean isCommandRegistrationAllowed() {
-        return this.getRegistrationState() != RegistrationState.AFTER_REGISTRATION;
+        return this.registrationState() != RegistrationState.AFTER_REGISTRATION;
     }
 
     final @NonNull Function<@NonNull CommandSender, @NonNull C> getCommandSenderMapper() {

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/FabricCommandManager.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/FabricCommandManager.java
@@ -152,10 +152,10 @@ public abstract class FabricCommandManager<C, S extends SharedSuggestionProvider
         this.brigadierManager.backwardsBrigadierSenderMapper(this.backwardsCommandSourceMapper);
         this.brigadierManager.brigadierSenderMapper(this.commandSourceMapper);
         this.registerNativeBrigadierMappings(this.brigadierManager);
-        this.setCaptionRegistry(new FabricCaptionRegistry<>());
+        this.captionRegistry(new FabricCaptionRegistry<>());
         this.registerCommandPreProcessor(new FabricCommandPreprocessor<>(this));
 
-        ((FabricCommandRegistrationHandler<C, S>) this.getCommandRegistrationHandler()).initialize(this);
+        ((FabricCommandRegistrationHandler<C, S>) this.commandRegistrationHandler()).initialize(this);
     }
 
     private void registerNativeBrigadierMappings(final @NonNull CloudBrigadierManager<C, S> brigadier) {
@@ -165,7 +165,7 @@ public abstract class FabricCommandManager<C, S extends SharedSuggestionProvider
         this.registerRegistryEntryMappings();
         brigadier.registerMapping(new TypeToken<TeamArgument.TeamParser<C>>() {
         }, builder -> builder.toConstant(net.minecraft.commands.arguments.TeamArgument.team()));
-        this.getParserRegistry().registerParserSupplier(
+        this.parserRegistry().registerParserSupplier(
                 TypeToken.get(PlayerTeam.class),
                 params -> new TeamArgument.TeamParser<>()
         );
@@ -190,7 +190,7 @@ public abstract class FabricCommandManager<C, S extends SharedSuggestionProvider
 
         /* Wrapped/Constant Brigadier types, mapped value type */
         this.registerConstantNativeParserSupplier(MessageArgument.Message.class, MessageArgument.message());
-        this.getParserRegistry().registerParserSupplier(
+        this.parserRegistry().registerParserSupplier(
                 TypeToken.get(MinecraftTime.class),
                 params -> FabricArgumentParsers.time()
         );
@@ -251,7 +251,7 @@ public abstract class FabricCommandManager<C, S extends SharedSuggestionProvider
             seenClasses.add(GenericTypeReflector.erase(valueType));
 
             /* and now, finally, we can register */
-            this.getParserRegistry().registerParserSupplier(
+            this.parserRegistry().registerParserSupplier(
                     TypeToken.get(valueType),
                     params -> new RegistryEntryArgument.Parser(key)
             );
@@ -270,7 +270,7 @@ public abstract class FabricCommandManager<C, S extends SharedSuggestionProvider
             final @NonNull Class<T> type,
             final @NonNull Function<CommandBuildContext, @NonNull ArgumentType<T>> argument
     ) {
-        this.getParserRegistry().registerParserSupplier(
+        this.parserRegistry().registerParserSupplier(
                 TypeToken.get(type),
                 params -> FabricArgumentParsers.contextual(argument)
         );
@@ -300,7 +300,7 @@ public abstract class FabricCommandManager<C, S extends SharedSuggestionProvider
             final @NonNull TypeToken<T> type,
             final @NonNull ArgumentType<T> argument
     ) {
-        this.getParserRegistry().registerParserSupplier(type, params -> new WrappedBrigadierParser<>(argument));
+        this.parserRegistry().registerParserSupplier(type, params -> new WrappedBrigadierParser<>(argument));
     }
 
     @Override

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/FabricServerCommandManager.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/FabricServerCommandManager.java
@@ -136,50 +136,50 @@ public final class FabricServerCommandManager<C> extends FabricCommandManager<C,
     }
 
     private void registerParsers() {
-        this.getParserRegistry().registerParserSupplier(TypeToken.get(Message.class), params -> FabricArgumentParsers.message());
+        this.parserRegistry().registerParserSupplier(TypeToken.get(Message.class), params -> FabricArgumentParsers.message());
 
         // Location arguments
-        this.getParserRegistry().registerAnnotationMapper(
+        this.parserRegistry().registerAnnotationMapper(
                 Center.class,
                 (annotation, type) -> ParserParameters.single(FabricParserParameters.CENTER_INTEGERS, true)
         );
-        this.getParserRegistry().registerParserSupplier(
+        this.parserRegistry().registerParserSupplier(
                 TypeToken.get(Coordinates.class),
                 params -> FabricArgumentParsers.vec3(params.get(
                         FabricParserParameters.CENTER_INTEGERS,
                         false
                 ))
         );
-        this.getParserRegistry().registerParserSupplier(
+        this.parserRegistry().registerParserSupplier(
                 TypeToken.get(Coordinates.CoordinatesXZ.class),
                 params -> FabricArgumentParsers.vec2(params.get(
                         FabricParserParameters.CENTER_INTEGERS,
                         false
                 ))
         );
-        this.getParserRegistry().registerParserSupplier(
+        this.parserRegistry().registerParserSupplier(
                 TypeToken.get(Coordinates.BlockCoordinates.class),
                 params -> FabricArgumentParsers.blockPos()
         );
-        this.getParserRegistry().registerParserSupplier(
+        this.parserRegistry().registerParserSupplier(
                 TypeToken.get(Coordinates.ColumnCoordinates.class),
                 params -> FabricArgumentParsers.columnPos()
         );
 
         // Entity selectors
-        this.getParserRegistry().registerParserSupplier(
+        this.parserRegistry().registerParserSupplier(
                 TypeToken.get(SinglePlayerSelector.class),
                 params -> FabricArgumentParsers.singlePlayerSelector()
         );
-        this.getParserRegistry().registerParserSupplier(
+        this.parserRegistry().registerParserSupplier(
                 TypeToken.get(MultiplePlayerSelector.class),
                 params -> FabricArgumentParsers.multiplePlayerSelector()
         );
-        this.getParserRegistry().registerParserSupplier(
+        this.parserRegistry().registerParserSupplier(
                 TypeToken.get(SingleEntitySelector.class),
                 params -> FabricArgumentParsers.singleEntitySelector()
         );
-        this.getParserRegistry().registerParserSupplier(
+        this.parserRegistry().registerParserSupplier(
                 TypeToken.get(MultipleEntitySelector.class),
                 params -> FabricArgumentParsers.multipleEntitySelector()
         );

--- a/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/MinecraftHelp.java
+++ b/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/MinecraftHelp.java
@@ -326,7 +326,7 @@ public final class MinecraftHelp<C> {
                 recipient,
                 query,
                 page,
-                this.commandManager.getCommandHelpHandler(this.commandFilter).queryHelp(recipient, query)
+                this.commandManager.createCommandHelpHandler(this.commandFilter).queryHelp(recipient, query)
         );
     }
 
@@ -471,7 +471,7 @@ public final class MinecraftHelp<C> {
         final Audience audience = this.getAudience(sender);
         audience.sendMessage(this.basicHeader(sender));
         audience.sendMessage(this.showingResults(sender, query));
-        final String command = this.commandManager.getCommandSyntaxFormatter()
+        final String command = this.commandManager.commandSyntaxFormatter()
                 .apply(helpTopic.getCommand().getArguments(), null);
         audience.sendMessage(text()
                 .append(this.lastBranch())
@@ -521,7 +521,7 @@ public final class MinecraftHelp<C> {
                 final CommandComponent<C> component = iterator.next();
                 final CommandArgument<C, ?> argument = component.getArgument();
 
-                final String syntax = this.commandManager.getCommandSyntaxFormatter()
+                final String syntax = this.commandManager.commandSyntaxFormatter()
                         .apply(Collections.singletonList(argument), null);
 
                 final TextComponent.Builder textComponent = text()

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/AsyncCommandSuggestionsListener.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/AsyncCommandSuggestionsListener.java
@@ -52,7 +52,7 @@ final class AsyncCommandSuggestionsListener<C> implements Listener {
 
         @SuppressWarnings("unchecked")
         final BukkitPluginRegistrationHandler<C> bukkitPluginRegistrationHandler =
-                (BukkitPluginRegistrationHandler<C>) this.paperCommandManager.getCommandRegistrationHandler();
+                (BukkitPluginRegistrationHandler<C>) this.paperCommandManager.commandRegistrationHandler();
 
         /* Turn 'plugin:command arg1 arg2 ...' into 'plugin:command' */
         final String commandLabel = strippedBuffer.split(" ")[0];

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperBrigadierListener.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperBrigadierListener.java
@@ -77,7 +77,7 @@ class PaperBrigadierListener<C> implements Listener {
             return;
         }
 
-        final CommandTree<C> commandTree = this.paperCommandManager.getCommandTree();
+        final CommandTree<C> commandTree = this.paperCommandManager.commandTree();
 
         final String label;
         if (event.getCommandLabel().contains(":")) {

--- a/cloud-minecraft/cloud-sponge7/src/main/java/cloud/commandframework/sponge7/CloudCommandCallable.java
+++ b/cloud-minecraft/cloud-sponge7/src/main/java/cloud/commandframework/sponge7/CloudCommandCallable.java
@@ -210,9 +210,9 @@ final class CloudCommandCallable<C> implements CommandCallable {
 
     @Override
     public Text getUsage(final @NonNull CommandSource source) {
-        return Text.of(this.manager.getCommandSyntaxFormatter().apply(
+        return Text.of(this.manager.commandSyntaxFormatter().apply(
                 Collections.emptyList(),
-                this.manager.getCommandTree().getNamedNode(this.command.getName())
+                this.manager.commandTree().getNamedNode(this.command.getName())
         ));
     }
 }

--- a/cloud-minecraft/cloud-sponge7/src/main/java/cloud/commandframework/sponge7/SpongeCommandManager.java
+++ b/cloud-minecraft/cloud-sponge7/src/main/java/cloud/commandframework/sponge7/SpongeCommandManager.java
@@ -78,7 +78,7 @@ public class SpongeCommandManager<C> extends CommandManager<C> {
         this.owningPlugin = requireNonNull(container, "container");
         this.forwardMapper = requireNonNull(forwardMapper, "forwardMapper");
         this.reverseMapper = requireNonNull(reverseMapper, "reverseMapper");
-        ((SpongePluginRegistrationHandler<C>) this.getCommandRegistrationHandler()).initialize(this);
+        ((SpongePluginRegistrationHandler<C>) this.commandRegistrationHandler()).initialize(this);
     }
 
     @Override

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/VelocityCommandManager.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/VelocityCommandManager.java
@@ -109,7 +109,7 @@ public class VelocityCommandManager<C> extends CommandManager<C> implements Brig
             final @NonNull Function<@NonNull C, @NonNull CommandSource> backwardsCommandSenderMapper
     ) {
         super(commandExecutionCoordinator, new VelocityPluginRegistrationHandler<>());
-        ((VelocityPluginRegistrationHandler<C>) this.getCommandRegistrationHandler()).initialize(this);
+        ((VelocityPluginRegistrationHandler<C>) this.commandRegistrationHandler()).initialize(this);
         this.proxyServer = proxyServer;
         this.commandSenderMapper = commandSenderMapper;
         this.backwardsCommandSenderMapper = backwardsCommandSenderMapper;
@@ -118,15 +118,15 @@ public class VelocityCommandManager<C> extends CommandManager<C> implements Brig
         this.registerCommandPreProcessor(new VelocityCommandPreprocessor<>(this));
 
         /* Register Velocity Parsers */
-        this.getParserRegistry().registerParserSupplier(TypeToken.get(Player.class), parserParameters ->
+        this.parserRegistry().registerParserSupplier(TypeToken.get(Player.class), parserParameters ->
                 new PlayerArgument.PlayerParser<>());
-        this.getParserRegistry().registerParserSupplier(TypeToken.get(RegisteredServer.class), parserParameters ->
+        this.parserRegistry().registerParserSupplier(TypeToken.get(RegisteredServer.class), parserParameters ->
                 new ServerArgument.ServerParser<>());
 
         /* Register default captions */
-        if (this.getCaptionRegistry() instanceof FactoryDelegatingCaptionRegistry) {
+        if (this.captionRegistry() instanceof FactoryDelegatingCaptionRegistry) {
             final FactoryDelegatingCaptionRegistry<C> factoryDelegatingCaptionRegistry = (FactoryDelegatingCaptionRegistry<C>)
-                    this.getCaptionRegistry();
+                    this.captionRegistry();
             factoryDelegatingCaptionRegistry.registerMessageFactory(
                     VelocityCaptionKeys.ARGUMENT_PARSE_FAILURE_PLAYER,
                     (context, key) -> ARGUMENT_PARSE_FAILURE_PLAYER
@@ -163,7 +163,7 @@ public class VelocityCommandManager<C> extends CommandManager<C> implements Brig
     @SuppressWarnings("unchecked")
     @Override
     public @NonNull CloudBrigadierManager<C, CommandSource> brigadierManager() {
-        return ((VelocityPluginRegistrationHandler<C>) this.getCommandRegistrationHandler()).brigadierManager();
+        return ((VelocityPluginRegistrationHandler<C>) this.commandRegistrationHandler()).brigadierManager();
     }
 
     final @NonNull ProxyServer proxyServer() {

--- a/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/ExamplePlugin.java
+++ b/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/ExamplePlugin.java
@@ -424,8 +424,8 @@ public final class ExamplePlugin extends JavaPlugin {
 
         /* Register a custom regex caption */
         final Caption moneyCaption = Caption.of("regex.money");
-        if (this.manager.getCaptionRegistry() instanceof SimpleCaptionRegistry) {
-            ((SimpleCaptionRegistry<CommandSender>) this.manager.getCaptionRegistry()).registerMessageFactory(
+        if (this.manager.captionRegistry() instanceof SimpleCaptionRegistry) {
+            ((SimpleCaptionRegistry<CommandSender>) this.manager.captionRegistry()).registerMessageFactory(
                     moneyCaption,
                     (sender, key) -> "'{input}' is not very cash money of you"
             );


### PR DESCRIPTION
All prefixed (actual) getters/setters in CommandManager have been deprecated, and non-prefixed alternatives have been introduced. I've also put some effort into improving the JavaDocs of these methods.