### PR TITLE
expose failure reason when flag parsing fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Core: Expose failure reason when flag parsing fails ([#380](https://github.com/Incendo/cloud/pull/380))
+
 ## [1.7.0]
 
 ### Added

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/compound/FlagArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/compound/FlagArgument.java
@@ -518,7 +518,7 @@ public final class FlagArgument<C> extends CommandArgument<C, Object> {
         }
 
         /**
-         * Get the reason why the flag parsing failed
+         * Returns the reason why the flag parsing failed.
          *
          * @return the failure reason
          * @since 1.8.0

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/compound/FlagArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/compound/FlagArgument.java
@@ -483,6 +483,7 @@ public final class FlagArgument<C> extends CommandArgument<C, Object> {
 
         private static final long serialVersionUID = -7725389394142868549L;
         private final String input;
+        private final FailureReason failureReason;
 
         /**
          * Construct a new flag parse exception
@@ -504,6 +505,7 @@ public final class FlagArgument<C> extends CommandArgument<C, Object> {
                     CaptionVariable.of("flag", input)
             );
             this.input = input;
+            this.failureReason = failureReason;
         }
 
         /**
@@ -513,6 +515,17 @@ public final class FlagArgument<C> extends CommandArgument<C, Object> {
          */
         public String getInput() {
             return this.input;
+        }
+
+        /**
+         * Get the reason why the flag parsing failed
+         *
+         * @return the failure reason
+         * @since 1.8.0
+         */
+        @API(status = API.Status.STABLE, since = "1.8.0")
+        public @NonNull FailureReason failureReason() {
+            return this.failureReason;
         }
     }
 


### PR DESCRIPTION
Makes it easier to find the issue when flag parsing fails, especially when using custom exception handling.