### PR TITLE
Expose argument names to minecraft extras help message provider

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
             echo "STATUS=release" >> $GITHUB_ENV
           fi
       - name: Publish Snapshot
-        if: "${{ env.STATUS != 'release' && github.event_name == 'push' && github.ref == 'refs/heads/1.7.0-dev' }}"
+        if: "${{ env.STATUS != 'release' && github.event_name == 'push' && github.ref == 'refs/heads/1.8.0-dev' }}"
         run: ./gradlew publish
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: "${{ secrets.SONATYPE_USERNAME }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Core: Expose failure reason when flag parsing fails ([#380](https://github.com/Incendo/cloud/pull/380))
+
 ## [1.7.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [1.7.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Core: Expose failure reason when flag parsing fails ([#380](https://github.com/Incendo/cloud/pull/380))
+- Minecraft-Extras: Expose the name of arguments to the help message provider ([#381](https://github.com/Incendo/cloud/pull/381))
 
 ## [1.7.0]
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Snapshot builds of Cloud are available through the [Sonatype OSS Snapshot reposi
 <dependency>  
  <groupId>cloud.commandframework</groupId>
  <artifactId>cloud-PLATFORM</artifactId>
- <version>1.7.0</version>
+ <version>1.8.0-SNAPSHOT</version>
 </dependency>
 <!-- 
 ~    Optional: Allows you to use annotated methods
@@ -126,7 +126,7 @@ Snapshot builds of Cloud are available through the [Sonatype OSS Snapshot reposi
 <dependency>  
  <groupId>cloud.commandframework</groupId>
  <artifactId>cloud-annotations</artifactId>
- <version>1.7.0</version>
+ <version>1.8.0-SNAPSHOT</version>
 </dependency>
 ``` 
 
@@ -187,7 +187,7 @@ repositories {
 
 ```kotlin
 dependencies {
-    implementation("cloud.commandframework", "cloud-PLATFORM", "1.7.0")
+    implementation("cloud.commandframework", "cloud-PLATFORM", "1.8.0-SNAPSHOT")
 }
 ```
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/compound/FlagArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/compound/FlagArgument.java
@@ -483,6 +483,7 @@ public final class FlagArgument<C> extends CommandArgument<C, Object> {
 
         private static final long serialVersionUID = -7725389394142868549L;
         private final String input;
+        private final FailureReason failureReason;
 
         /**
          * Construct a new flag parse exception
@@ -504,6 +505,7 @@ public final class FlagArgument<C> extends CommandArgument<C, Object> {
                     CaptionVariable.of("flag", input)
             );
             this.input = input;
+            this.failureReason = failureReason;
         }
 
         /**
@@ -513,6 +515,17 @@ public final class FlagArgument<C> extends CommandArgument<C, Object> {
          */
         public String getInput() {
             return this.input;
+        }
+
+        /**
+         * Returns the reason why the flag parsing failed.
+         *
+         * @return the failure reason
+         * @since 1.8.0
+         */
+        @API(status = API.Status.STABLE, since = "1.8.0")
+        public @NonNull FailureReason failureReason() {
+            return this.failureReason;
         }
     }
 

--- a/cloud-minecraft/README.md
+++ b/cloud-minecraft/README.md
@@ -24,14 +24,14 @@ mappings will be available.
 <dependency>
     <groupId>cloud.commandframework</groupId>
     <artifactId>cloud-bukkit</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0-SNAPSHOT</version>
 </dependency>
 ```
 
 **gradle**:
 ```groovy
 dependencies {
-    implementation 'cloud.commandframework:cloud-bukkit:1.7.0'
+    implementation 'cloud.commandframework:cloud-bukkit:1.8.0-SNAPSHOT'
 }
 ```
 
@@ -93,14 +93,14 @@ mappings are available even without commodore present.
 <dependency>
     <groupId>cloud.commandframework</groupId>
     <artifactId>cloud-paper</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0-SNAPSHOT</version>
 </dependency>
 ```
 
 **gradle**:
 ```groovy
 dependencies {
-    implementation 'cloud.commandframework:cloud-paper:1.7.0'
+    implementation 'cloud.commandframework:cloud-paper:1.8.0-SNAPSHOT'
 }
 ```
 
@@ -118,14 +118,14 @@ BungeeCord mappings for cloud.
 <dependency>
     <groupId>cloud.commandframework</groupId>
     <artifactId>cloud-bungee</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0-SNAPSHOT</version>
 </dependency>
 ```
 
 **gradle**:
 ```groovy
 dependencies {
-    implementation 'cloud.commandframework:cloud-bungee:1.7.0'
+    implementation 'cloud.commandframework:cloud-bungee:1.8.0-SNAPSHOT'
 }
 ```
 
@@ -150,14 +150,14 @@ cloud mappings for Velocity 1.1.0.
 <dependency>
     <groupId>cloud.commandframework</groupId>
     <artifactId>cloud-velocity</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0-SNAPSHOT</version>
 </dependency>
 ```
 
 **gradle**:
 ```groovy
 dependencies {
-    implementation 'cloud.commandframework:cloud-velocity:1.7.0'
+    implementation 'cloud.commandframework:cloud-velocity:1.8.0-SNAPSHOT'
 }
 ```
 
@@ -181,14 +181,14 @@ cloud mappings for CloudBurst 1.0.0-SNAPSHOT.
 <dependency>
     <groupId>cloud.commandframework</groupId>
     <artifactId>cloud-cloudburst</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0-SNAPSHOT</version>
 </dependency>
 ```
 
 **gradle**:
 ```groovy
 dependencies {
-    implementation 'cloud.commandframework:cloud-velocity:1.7.0'
+    implementation 'cloud.commandframework:cloud-velocity:1.8.0-SNAPSHOT'
 }
 ```
 
@@ -212,7 +212,7 @@ cloud mappings for the Fabric mod loader for Minecraft 1.16+
 **gradle**:
 ```groovy
 dependencies {
-    modImplementation 'cloud.commandframework:cloud-fabric:1.7.0'
+    modImplementation 'cloud.commandframework:cloud-fabric:1.8.0-SNAPSHOT'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=cloud.commandframework
-version=1.7.0
+version=1.8.0-SNAPSHOT
 description=Command framework and dispatcher for the JVM
 
 org.gradle.caching=true


### PR DESCRIPTION
As noted this only properly works for arguments used a single time (as backwards compat uses arg index), however this works for all current arguments.