### PR TITLE
Don't show commands the sender can't use in invalid syntax messages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
             echo "STATUS=release" >> $GITHUB_ENV
           fi
       - name: Publish Snapshot
-        if: "${{ env.STATUS != 'release' && github.event_name == 'push' && github.ref == 'refs/heads/1.7.0-dev' }}"
+        if: "${{ env.STATUS != 'release' && github.event_name == 'push' && github.ref == 'refs/heads/1.8.0-dev' }}"
         run: ./gradlew publish
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: "${{ secrets.SONATYPE_USERNAME }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Core: Expose failure reason when flag parsing fails ([#380](https://github.com/Incendo/cloud/pull/380))
+
 ## [1.7.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [1.7.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Snapshot builds of Cloud are available through the [Sonatype OSS Snapshot reposi
 <dependency>  
  <groupId>cloud.commandframework</groupId>
  <artifactId>cloud-PLATFORM</artifactId>
- <version>1.7.0</version>
+ <version>1.8.0-SNAPSHOT</version>
 </dependency>
 <!-- 
 ~    Optional: Allows you to use annotated methods
@@ -126,7 +126,7 @@ Snapshot builds of Cloud are available through the [Sonatype OSS Snapshot reposi
 <dependency>  
  <groupId>cloud.commandframework</groupId>
  <artifactId>cloud-annotations</artifactId>
- <version>1.7.0</version>
+ <version>1.8.0-SNAPSHOT</version>
 </dependency>
 ``` 
 
@@ -187,7 +187,7 @@ repositories {
 
 ```kotlin
 dependencies {
-    implementation("cloud.commandframework", "cloud-PLATFORM", "1.7.0")
+    implementation("cloud.commandframework", "cloud-PLATFORM", "1.8.0-SNAPSHOT")
 }
 ```
 

--- a/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
@@ -24,6 +24,7 @@
 package cloud.commandframework;
 
 import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.CommandSyntaxFormatter;
 import cloud.commandframework.arguments.StaticArgument;
 import cloud.commandframework.arguments.compound.CompoundArgument;
 import cloud.commandframework.arguments.compound.FlagArgument;
@@ -207,8 +208,8 @@ public final class CommandTree<C> {
                 } else {
                     /* Too many arguments. We have a unique path, so we can send the entire context */
                     return Pair.of(null, new InvalidSyntaxException(
-                            this.commandManager.commandSyntaxFormatter()
-                                    .apply(parsedArguments, root),
+                            ((CommandSyntaxFormatter.SenderAware<C>) this.commandManager.commandSyntaxFormatter())
+                                    .apply(commandContext.getSender(), parsedArguments, root),
                             commandContext.getSender(), this.getChain(root)
                             .stream()
                             .filter(node -> node.getValue() != null)
@@ -219,8 +220,8 @@ public final class CommandTree<C> {
             } else {
                 /* Too many arguments. We have a unique path, so we can send the entire context */
                 return Pair.of(null, new InvalidSyntaxException(
-                        this.commandManager.commandSyntaxFormatter()
-                                .apply(parsedArguments, root),
+                        ((CommandSyntaxFormatter.SenderAware<C>) this.commandManager.commandSyntaxFormatter())
+                                .apply(commandContext.getSender(), parsedArguments, root),
                         commandContext.getSender(), this.getChain(root)
                         .stream()
                         .filter(node -> node.getValue() != null)
@@ -278,8 +279,8 @@ public final class CommandTree<C> {
             }
             /* We know that there's no command and we also cannot match any of the children */
             return Pair.of(null, new InvalidSyntaxException(
-                    this.commandManager.commandSyntaxFormatter()
-                            .apply(parsedArguments, root),
+                    ((CommandSyntaxFormatter.SenderAware<C>) this.commandManager.commandSyntaxFormatter())
+                            .apply(commandContext.getSender(), parsedArguments, root),
                     commandContext.getSender(), this.getChain(root)
                     .stream()
                     .filter(node -> node.getValue() != null)
@@ -378,8 +379,8 @@ public final class CommandTree<C> {
                         }
                         /* Not enough arguments */
                         return Pair.of(null, new InvalidSyntaxException(
-                                this.commandManager.commandSyntaxFormatter()
-                                        .apply(Objects.requireNonNull(
+                                ((CommandSyntaxFormatter.SenderAware<C>) this.commandManager.commandSyntaxFormatter())
+                                        .apply(commandContext.getSender(), Objects.requireNonNull(
                                                         child.getValue()
                                                                 .getOwningCommand())
                                                 .getArguments(), child),
@@ -411,8 +412,8 @@ public final class CommandTree<C> {
                         }
                         /* Child does not have a command and so we cannot proceed */
                         return Pair.of(null, new InvalidSyntaxException(
-                                this.commandManager.commandSyntaxFormatter()
-                                        .apply(parsedArguments, root),
+                                ((CommandSyntaxFormatter.SenderAware<C>) this.commandManager.commandSyntaxFormatter())
+                                        .apply(commandContext.getSender(), parsedArguments, root),
                                 commandContext.getSender(), this.getChain(root)
                                 .stream()
                                 .filter(node -> node.getValue() != null)
@@ -449,8 +450,8 @@ public final class CommandTree<C> {
                         } else {
                             /* Too many arguments. We have a unique path, so we can send the entire context */
                             return Pair.of(null, new InvalidSyntaxException(
-                                    this.commandManager.commandSyntaxFormatter()
-                                            .apply(parsedArguments, child),
+                                    ((CommandSyntaxFormatter.SenderAware<C>) this.commandManager.commandSyntaxFormatter())
+                                            .apply(commandContext.getSender(), parsedArguments, child),
                                     commandContext.getSender(), this.getChain(root)
                                     .stream()
                                     .filter(node -> node.getValue() != null)
@@ -719,7 +720,15 @@ public final class CommandTree<C> {
         }
     }
 
-    private @Nullable CommandPermission isPermitted(
+
+    /**
+     * Todo this probably shouldn't be public.
+     *
+     * @param sender sender
+     * @param node node
+     * @return permission
+     */
+    public @Nullable CommandPermission isPermitted(
             final @NonNull C sender,
             final @NonNull Node<@Nullable CommandArgument<C, ?>> node
     ) {

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/CommandSyntaxFormatter.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/CommandSyntaxFormatter.java
@@ -53,4 +53,38 @@ public interface CommandSyntaxFormatter<C> {
             @NonNull List<@NonNull CommandArgument<C, ?>> commandArguments,
             CommandTree.@Nullable Node<@Nullable CommandArgument<C, ?>> node
     );
+
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    @SuppressWarnings("FunctionalInterfaceMethodChanged")
+    @FunctionalInterface
+    interface SenderAware<C> extends CommandSyntaxFormatter<C> {
+
+        @Override
+        default @NonNull String apply(
+                final @NonNull List<@NonNull CommandArgument<C, ?>> commandArguments,
+                final CommandTree.@Nullable Node<@Nullable CommandArgument<C, ?>> node
+        ) {
+            return this.apply(null, commandArguments, node);
+        }
+
+        /**
+         * Format the command arguments into a syntax string.
+         *
+         * @param sender           Command sender
+         * @param commandArguments Command arguments that have been unambiguously specified up until this point. This
+         *                         should include the "current" command, if such a command exists.
+         * @param node             The current command node. The children of this node will be appended onto the
+         *                         command syntax string, as long as an unambiguous path can be identified. The node
+         *                         itself will not be appended onto the syntax string. This can be set to {@code null} if
+         *                         no node is relevant at the point of formatting.
+         * @return formatted syntax string
+         * @since 1.8.0
+         */
+        @API(status = API.Status.STABLE, since = "1.8.0")
+        @NonNull String apply(
+                @Nullable C sender,
+                @NonNull List<@NonNull CommandArgument<C, ?>> commandArguments,
+                CommandTree.@Nullable Node<@Nullable CommandArgument<C, ?>> node
+        );
+    }
 }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/LegacyAdapterCommandSyntaxFormatter.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/LegacyAdapterCommandSyntaxFormatter.java
@@ -1,0 +1,71 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.arguments;
+
+import cloud.commandframework.CommandTree;
+import java.util.List;
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Adapter from {@link CommandSyntaxFormatter} to {@link cloud.commandframework.arguments.CommandSyntaxFormatter.SenderAware}.
+ *
+ * @param <C> sender type
+ * @since 1.8.0
+ */
+@API(status = API.Status.STABLE, since = "1.8.0")
+public final class LegacyAdapterCommandSyntaxFormatter<C> implements CommandSyntaxFormatter.SenderAware<C> {
+
+    private final CommandSyntaxFormatter<C> wrapped;
+
+    /**
+     * Create a new {@link LegacyAdapterCommandSyntaxFormatter}.
+     *
+     * @param wrapped legacy formatter to wrap
+     */
+    public LegacyAdapterCommandSyntaxFormatter(final @NonNull CommandSyntaxFormatter<C> wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public @NonNull String apply(
+            final @NonNull C sender,
+            final @NonNull List<@NonNull CommandArgument<C, ?>> commandArguments,
+            final CommandTree.@Nullable Node<@Nullable CommandArgument<C, ?>> node
+    ) {
+        return this.wrapped.apply(commandArguments, node);
+    }
+
+    /**
+     * Get the wrapped formatter.
+     *
+     * @return wrapped formatter
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public @NonNull CommandSyntaxFormatter<C> wrapped() {
+        return this.wrapped;
+    }
+}

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/compound/FlagArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/compound/FlagArgument.java
@@ -483,6 +483,7 @@ public final class FlagArgument<C> extends CommandArgument<C, Object> {
 
         private static final long serialVersionUID = -7725389394142868549L;
         private final String input;
+        private final FailureReason failureReason;
 
         /**
          * Construct a new flag parse exception
@@ -504,6 +505,7 @@ public final class FlagArgument<C> extends CommandArgument<C, Object> {
                     CaptionVariable.of("flag", input)
             );
             this.input = input;
+            this.failureReason = failureReason;
         }
 
         /**
@@ -513,6 +515,17 @@ public final class FlagArgument<C> extends CommandArgument<C, Object> {
          */
         public String getInput() {
             return this.input;
+        }
+
+        /**
+         * Returns the reason why the flag parsing failed.
+         *
+         * @return the failure reason
+         * @since 1.8.0
+         */
+        @API(status = API.Status.STABLE, since = "1.8.0")
+        public @NonNull FailureReason failureReason() {
+            return this.failureReason;
         }
     }
 

--- a/cloud-minecraft/README.md
+++ b/cloud-minecraft/README.md
@@ -24,14 +24,14 @@ mappings will be available.
 <dependency>
     <groupId>cloud.commandframework</groupId>
     <artifactId>cloud-bukkit</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0-SNAPSHOT</version>
 </dependency>
 ```
 
 **gradle**:
 ```groovy
 dependencies {
-    implementation 'cloud.commandframework:cloud-bukkit:1.7.0'
+    implementation 'cloud.commandframework:cloud-bukkit:1.8.0-SNAPSHOT'
 }
 ```
 
@@ -93,14 +93,14 @@ mappings are available even without commodore present.
 <dependency>
     <groupId>cloud.commandframework</groupId>
     <artifactId>cloud-paper</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0-SNAPSHOT</version>
 </dependency>
 ```
 
 **gradle**:
 ```groovy
 dependencies {
-    implementation 'cloud.commandframework:cloud-paper:1.7.0'
+    implementation 'cloud.commandframework:cloud-paper:1.8.0-SNAPSHOT'
 }
 ```
 
@@ -118,14 +118,14 @@ BungeeCord mappings for cloud.
 <dependency>
     <groupId>cloud.commandframework</groupId>
     <artifactId>cloud-bungee</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0-SNAPSHOT</version>
 </dependency>
 ```
 
 **gradle**:
 ```groovy
 dependencies {
-    implementation 'cloud.commandframework:cloud-bungee:1.7.0'
+    implementation 'cloud.commandframework:cloud-bungee:1.8.0-SNAPSHOT'
 }
 ```
 
@@ -150,14 +150,14 @@ cloud mappings for Velocity 1.1.0.
 <dependency>
     <groupId>cloud.commandframework</groupId>
     <artifactId>cloud-velocity</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0-SNAPSHOT</version>
 </dependency>
 ```
 
 **gradle**:
 ```groovy
 dependencies {
-    implementation 'cloud.commandframework:cloud-velocity:1.7.0'
+    implementation 'cloud.commandframework:cloud-velocity:1.8.0-SNAPSHOT'
 }
 ```
 
@@ -181,14 +181,14 @@ cloud mappings for CloudBurst 1.0.0-SNAPSHOT.
 <dependency>
     <groupId>cloud.commandframework</groupId>
     <artifactId>cloud-cloudburst</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0-SNAPSHOT</version>
 </dependency>
 ```
 
 **gradle**:
 ```groovy
 dependencies {
-    implementation 'cloud.commandframework:cloud-velocity:1.7.0'
+    implementation 'cloud.commandframework:cloud-velocity:1.8.0-SNAPSHOT'
 }
 ```
 
@@ -212,7 +212,7 @@ cloud mappings for the Fabric mod loader for Minecraft 1.16+
 **gradle**:
 ```groovy
 dependencies {
-    modImplementation 'cloud.commandframework:cloud-fabric:1.7.0'
+    modImplementation 'cloud.commandframework:cloud-fabric:1.8.0-SNAPSHOT'
 }
 ```
 

--- a/cloud-minecraft/cloud-sponge7/src/main/java/cloud/commandframework/sponge7/CloudCommandCallable.java
+++ b/cloud-minecraft/cloud-sponge7/src/main/java/cloud/commandframework/sponge7/CloudCommandCallable.java
@@ -25,6 +25,7 @@ package cloud.commandframework.sponge7;
 
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.CommandSyntaxFormatter;
 import cloud.commandframework.exceptions.ArgumentParseException;
 import cloud.commandframework.exceptions.CommandExecutionException;
 import cloud.commandframework.exceptions.InvalidCommandSenderException;
@@ -210,7 +211,8 @@ final class CloudCommandCallable<C> implements CommandCallable {
 
     @Override
     public Text getUsage(final @NonNull CommandSource source) {
-        return Text.of(this.manager.commandSyntaxFormatter().apply(
+        return Text.of(((CommandSyntaxFormatter.SenderAware<C>) this.manager.commandSyntaxFormatter()).apply(
+                this.manager.getCommandSourceMapper().apply(source),
                 Collections.emptyList(),
                 this.manager.commandTree().getNamedNode(this.command.getName())
         ));

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=cloud.commandframework
-version=1.7.0
+version=1.8.0-SNAPSHOT
 description=Command framework and dispatcher for the JVM
 
 org.gradle.caching=true


### PR DESCRIPTION
Needs clean up but this is something we should fix.
Should we also check sender type possibly?