### PR TITLE
fix root command unregister

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
@@ -545,7 +545,7 @@ public abstract class CommandManager<C> {
         this.commandRegistrationHandler.unregisterRootCommand((StaticArgument<?>) node.getValue());
 
         // We then delete it from the tree.
-        this.commandTree.deleteRecursively(node);
+        this.commandTree.deleteRecursively(node, true);
 
         // And lastly we re-build the entire tree.
         this.commandTree.verifyAndRegister();

--- a/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
@@ -952,23 +952,22 @@ public final class CommandTree<C> {
         return null;
     }
 
-    void deleteRecursively(final @NonNull Node<@Nullable CommandArgument<C, ?>> node) {
+    void deleteRecursively(final @NonNull Node<@Nullable CommandArgument<C, ?>> node, final boolean root) {
         for (final Node<@Nullable CommandArgument<C, ?>> child : new ArrayList<>(node.children)) {
-            this.deleteRecursively(child);
+            this.deleteRecursively(child, false);
         }
 
-        // We need to remove it from the tree.
-        this.removeNode(node);
+        this.removeNode(node, root);
     }
 
-    private boolean removeNode(final @NonNull Node<@Nullable CommandArgument<C, ?>> node) {
-        if (this.getRootNodes().contains(node)) {
-            this.internalTree.removeChild(node);
+    private boolean removeNode(final @NonNull Node<@Nullable CommandArgument<C, ?>> node, final boolean root) {
+        if (root) {
+            // root command node - remove it from the root tree
+            return this.internalTree.removeChild(node);
         } else {
+            // child node - remove it from the parent node
             return node.getParent().removeChild(node);
         }
-
-        return false;
     }
 
     /**


### PR DESCRIPTION
The command unregistration process unregisters all command nodes from the backing tree based on all childs of a root command. As the Node#equals & Node#hashCode functions are only implemented based on the name of a node, unregistering a command which has (for example) the same literal argument name as a root node will cause the unregister process to remove the root node instead of the child from the parent node.

The root boolean which is now passed to the `deleteRecursively` method seems to be the safest way to check if the specified node should be unregistered from the root command tree, however checking if `node.getParent == internalTree` would do the job as well.