### PR TITLE
Add option to allow flags anywhere after last literal argument

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/Command.java
+++ b/cloud-core/src/main/java/cloud/commandframework/Command.java
@@ -62,6 +62,7 @@ public class Command<C> {
 
     private final List<@NonNull CommandComponent<C>> components;
     private final List<@NonNull CommandArgument<C, ?>> arguments;
+    private final @Nullable FlagArgument<C> flagArgument;
     private final CommandExecutionHandler<C> commandExecutionHandler;
     private final Class<? extends C> senderType;
     private final CommandPermission commandPermission;
@@ -78,6 +79,7 @@ public class Command<C> {
      * @since 1.3.0
      */
     @API(status = API.Status.STABLE, since = "1.3.0")
+    @SuppressWarnings("unchecked")
     public Command(
             final @NonNull List<@NonNull CommandComponent<C>> commandComponents,
             final @NonNull CommandExecutionHandler<@NonNull C> commandExecutionHandler,
@@ -90,6 +92,14 @@ public class Command<C> {
         if (this.components.isEmpty()) {
             throw new IllegalArgumentException("At least one command component is required");
         }
+
+        this.flagArgument =
+                this.arguments.stream()
+                        .filter(ca -> ca instanceof FlagArgument)
+                        .map(ca -> (FlagArgument<C>) ca)
+                        .findFirst()
+                        .orElse(null);
+
         // Enforce ordering of command arguments
         boolean foundOptional = false;
         for (final CommandArgument<C, ?> argument : this.arguments) {
@@ -316,6 +326,32 @@ public class Command<C> {
      */
     public @NonNull List<CommandArgument<@NonNull C, @NonNull ?>> getArguments() {
         return new ArrayList<>(this.arguments);
+    }
+
+    /**
+     * Return a mutable copy of the command arguments, ignoring flag arguments.
+     *
+     * @return argument list
+     * @since 1.8.0
+     */
+    @API(status = API.Status.EXPERIMENTAL, since = "1.8.0")
+    public @NonNull List<CommandArgument<@NonNull C, @NonNull ?>> nonFlagArguments() {
+        List<CommandArgument<C, ?>> arguments = new ArrayList<>(this.arguments);
+        if (this.flagArgument != null) {
+            arguments.remove(this.flagArgument);
+        }
+        return arguments;
+    }
+
+    /**
+     * Returns the flag argument for this command, or null if no flags are supported.
+     *
+     * @return flag argument or null
+     * @since 1.8.0
+     */
+    @API(status = API.Status.EXPERIMENTAL, since = "1.8.0")
+    public @Nullable FlagArgument<@NonNull C> flagArgument() {
+        return this.flagArgument;
     }
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
@@ -1420,14 +1420,14 @@ public abstract class CommandManager<C> {
         OVERRIDE_EXISTING_COMMANDS,
 
         /**
-         * Allows parsing flags at any position by appending flag argument nodes between each command node.
+         * Allows parsing flags at any position after the last literal by appending flag argument nodes between each command node.
          * It can have some conflicts when integrating with other command systems like Brigadier,
          * and code inspecting the command tree may need to be adjusted.
          *
          * @since 1.8.0
          */
         @API(status = API.Status.EXPERIMENTAL, since = "1.8.0")
-        ALLOW_FLAGS_EVERYWHERE
+        LIBERAL_FLAG_PARSING
     }
 
 

--- a/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
@@ -1417,7 +1417,17 @@ public abstract class CommandManager<C> {
          * @since 1.2.0
          */
         @API(status = API.Status.STABLE, since = "1.2.0")
-        OVERRIDE_EXISTING_COMMANDS
+        OVERRIDE_EXISTING_COMMANDS,
+
+        /**
+         * Allows parsing flags at any position by appending flag argument nodes between each command node.
+         * It can have some conflicts when integrating with other command systems like Brigadier,
+         * and code inspecting the command tree may need to be adjusted.
+         *
+         * @since 1.8.0
+         */
+        @API(status = API.Status.EXPERIMENTAL, since = "1.8.0")
+        ALLOW_FLAGS_EVERYWHERE
     }
 
 

--- a/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
@@ -761,11 +761,11 @@ public final class CommandTree<C> {
             return Integer.MAX_VALUE;
         }
 
-        // Append flags before the first non-static argument
-        if (this.commandManager.getSetting(CommandManager.ManagerSettings.ALLOW_FLAGS_EVERYWHERE)) {
-            for (int i = 1; i < arguments.size(); i++) {
-                if (!(arguments.get(i) instanceof StaticArgument)) {
-                    return i - 1;
+        // Append flags after the last static argument
+        if (this.commandManager.getSetting(CommandManager.ManagerSettings.LIBERAL_FLAG_PARSING)) {
+            for (int i = arguments.size() - 1; i >= 0; i--) {
+                if (arguments.get(i) instanceof StaticArgument) {
+                    return i;
                 }
             }
         }

--- a/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
@@ -755,7 +755,7 @@ public final class CommandTree<C> {
         }
     }
 
-    private int flagStartIndex(final List<CommandArgument<C, ?>> arguments, final FlagArgument<C> flags) {
+    private int flagStartIndex(final @NonNull List<CommandArgument<C, ?>> arguments, final @Nullable FlagArgument<C> flags) {
         // Do not append flags
         if (flags == null) {
             return Integer.MAX_VALUE;

--- a/cloud-core/src/main/java/cloud/commandframework/context/CommandContext.java
+++ b/cloud-core/src/main/java/cloud/commandframework/context/CommandContext.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -495,9 +496,9 @@ public class CommandContext<C> {
     /**
      * Get a value if it exists, else return the provided default value
      *
-     * @param key          Argument key
+     * @param key          Cloud key
      * @param defaultValue Default value
-     * @param <T>          Argument type
+     * @param <T>          Value type
      * @return Argument, or supplied default value
      */
     public <T> @Nullable T getOrDefault(
@@ -510,9 +511,9 @@ public class CommandContext<C> {
     /**
      * Get a value if it exists, else return the provided default value
      *
-     * @param key          Argument key
+     * @param key          Cloud key
      * @param defaultValue Default value
-     * @param <T>          Argument type
+     * @param <T>          Value type
      * @return Argument, or supplied default value
      * @since 1.4.0
      */
@@ -527,9 +528,9 @@ public class CommandContext<C> {
     /**
      * Get a value if it exists, else return the value supplied by the given supplier
      *
-     * @param key             Argument key
+     * @param key             Cloud key
      * @param defaultSupplier Supplier of default value
-     * @param <T>             Argument type
+     * @param <T>             Value type
      * @return Argument, or supplied default value
      * @since 1.2.0
      */
@@ -544,9 +545,9 @@ public class CommandContext<C> {
     /**
      * Get a value if it exists, else return the value supplied by the given supplier
      *
-     * @param key             Argument key
+     * @param key             Cloud key
      * @param defaultSupplier Supplier of default value
-     * @param <T>             Argument type
+     * @param <T>             Value type
      * @return Argument, or supplied default value
      * @since 1.4.0
      */
@@ -556,6 +557,25 @@ public class CommandContext<C> {
             final @NonNull Supplier<@Nullable T> defaultSupplier
     ) {
         return this.getOptional(key).orElseGet(defaultSupplier);
+    }
+
+    /**
+     * Get a value if it exists, else compute and store the value returned by the function and return it.
+     *
+     * @param key             Cloud key
+     * @param defaultFunction Default value function
+     * @param <T>             Value type
+     * @return present or computed value
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public <T> T computeIfAbsent(
+            final @NonNull CloudKey<T> key,
+            final @NonNull Function<CloudKey<T>, T> defaultFunction
+    ) {
+        @SuppressWarnings("unchecked")
+        final T castedValue = (T) this.internalStorage.computeIfAbsent(key, k -> defaultFunction.apply((CloudKey<T>) k));
+        return castedValue;
     }
 
     /**

--- a/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
@@ -403,6 +403,7 @@ public class CommandSuggestionsTest {
     void testFlagYieldingGreedyStringFollowedByFlagArgument() {
         // Arrange
         final CommandManager<TestCommandSender> manager = createManager();
+        manager.setSetting(CommandManager.ManagerSettings.ALLOW_FLAGS_EVERYWHERE, true);
         manager.command(
                 manager.commandBuilder("command")
                         .argument(
@@ -441,7 +442,7 @@ public class CommandSuggestionsTest {
         );
 
         // Assert
-        assertThat(suggestions1).containsExactly("hello");
+        assertThat(suggestions1).containsExactly("hello", "--flag", "--flag2", "-f");
         assertThat(suggestions2).containsExactly("hello");
         assertThat(suggestions3).containsExactly("--flag", "--flag2");
         assertThat(suggestions4).containsExactly("--flag", "--flag2");
@@ -453,6 +454,7 @@ public class CommandSuggestionsTest {
     void testFlagYieldingStringArrayFollowedByFlagArgument() {
         // Arrange
         final CommandManager<TestCommandSender> manager = createManager();
+        manager.setSetting(CommandManager.ManagerSettings.ALLOW_FLAGS_EVERYWHERE, true);
         manager.command(
                 manager.commandBuilder("command")
                         .argument(
@@ -492,7 +494,7 @@ public class CommandSuggestionsTest {
         );
 
         // Assert
-        assertThat(suggestions1).isEmpty();
+        assertThat(suggestions1).containsExactly("--flag", "--flag2", "-f");
         assertThat(suggestions2).isEmpty();
         assertThat(suggestions3).containsExactly("--flag", "--flag2");
         assertThat(suggestions4).containsExactly("--flag", "--flag2");

--- a/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
@@ -403,7 +403,7 @@ public class CommandSuggestionsTest {
     void testFlagYieldingGreedyStringFollowedByFlagArgument() {
         // Arrange
         final CommandManager<TestCommandSender> manager = createManager();
-        manager.setSetting(CommandManager.ManagerSettings.ALLOW_FLAGS_EVERYWHERE, true);
+        manager.setSetting(CommandManager.ManagerSettings.LIBERAL_FLAG_PARSING, true);
         manager.command(
                 manager.commandBuilder("command")
                         .argument(
@@ -454,7 +454,7 @@ public class CommandSuggestionsTest {
     void testFlagYieldingStringArrayFollowedByFlagArgument() {
         // Arrange
         final CommandManager<TestCommandSender> manager = createManager();
-        manager.setSetting(CommandManager.ManagerSettings.ALLOW_FLAGS_EVERYWHERE, true);
+        manager.setSetting(CommandManager.ManagerSettings.LIBERAL_FLAG_PARSING, true);
         manager.command(
                 manager.commandBuilder("command")
                         .argument(

--- a/cloud-core/src/test/java/cloud/commandframework/feature/ArbitraryPositionFlagTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/feature/ArbitraryPositionFlagTest.java
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2021 Alexander Söderberg & Contributors
+// Copyright (c) 2022 Alexander Söderberg & Contributors
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/cloud-core/src/test/java/cloud/commandframework/feature/ArbitraryPositionFlagTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/feature/ArbitraryPositionFlagTest.java
@@ -1,0 +1,100 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.feature;
+
+import cloud.commandframework.CommandManager;
+import cloud.commandframework.TestCommandSender;
+import cloud.commandframework.arguments.compound.FlagArgument;
+import cloud.commandframework.arguments.standard.StringArgument;
+import cloud.commandframework.exceptions.ArgumentParseException;
+import cloud.commandframework.execution.CommandResult;
+import com.google.common.truth.ThrowableSubject;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import static cloud.commandframework.util.TestUtils.createManager;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ArbitraryPositionFlagTest {
+
+    private CommandManager<TestCommandSender> commandManager;
+
+    @BeforeEach
+    void setup() {
+        this.commandManager = createManager();
+        this.commandManager.setSetting(CommandManager.ManagerSettings.ALLOW_FLAGS_EVERYWHERE, true);
+
+        this.commandManager.command(
+                this.commandManager.commandBuilder("test")
+                        .literal("literal")
+                        .argument(StringArgument.greedyFlagYielding("text"))
+                        .flag(this.commandManager.flagBuilder("flag").withAliases("f")));
+    }
+
+    @Test
+    void testParsingAllLocations() {
+        List<String> passing = Arrays.asList(
+                "test literal -f foo bar",
+                "test literal foo bar -f",
+                "test literal --flag foo bar",
+                "test literal foo bar --flag");
+
+        for (String cmd : passing) {
+            CommandResult<TestCommandSender> result = this.commandManager.executeCommand(new TestCommandSender(), cmd).join();
+            assertThat(result.getCommandContext().flags().isPresent("flag")).isEqualTo(true);
+        }
+    }
+
+    @Test
+    void testFailBeforeLiterals() {
+        List<String> failing = Arrays.asList(
+                "test -f literal foo bar",
+                "test --flag literal foo bar");
+
+        for (String cmd : failing) {
+            assertThrows(CompletionException.class, commandExecutable(cmd));
+        }
+    }
+
+    @Test
+    void testMultiFlagThrows() {
+        final CompletionException completionException = assertThrows(CompletionException.class,
+                commandExecutable("test literal -f foo bar -f"));
+
+
+        ThrowableSubject argParse = assertThat(completionException).hasCauseThat();
+        argParse.isInstanceOf(ArgumentParseException.class);
+        argParse.hasCauseThat().isInstanceOf(FlagArgument.FlagParseException.class);
+    }
+
+    private Executable commandExecutable(String cmd) {
+        return () -> this.commandManager.executeCommand(new TestCommandSender(), cmd).join();
+    }
+
+}

--- a/cloud-core/src/test/java/cloud/commandframework/feature/ArbitraryPositionFlagTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/feature/ArbitraryPositionFlagTest.java
@@ -48,7 +48,7 @@ class ArbitraryPositionFlagTest {
     @BeforeEach
     void setup() {
         this.commandManager = createManager();
-        this.commandManager.setSetting(CommandManager.ManagerSettings.ALLOW_FLAGS_EVERYWHERE, true);
+        this.commandManager.setSetting(CommandManager.ManagerSettings.LIBERAL_FLAG_PARSING, true);
 
         this.commandManager.command(
                 this.commandManager.commandBuilder("test")

--- a/cloud-minecraft/cloud-fabric/src/testmod/java/cloud/commandframework/fabric/testmod/FabricClientExample.java
+++ b/cloud-minecraft/cloud-fabric/src/testmod/java/cloud/commandframework/fabric/testmod/FabricClientExample.java
@@ -24,6 +24,7 @@
 package cloud.commandframework.fabric.testmod;
 
 import cloud.commandframework.Command;
+import cloud.commandframework.arguments.flags.CommandFlag;
 import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.execution.CommandExecutionCoordinator;
 import cloud.commandframework.fabric.FabricClientCommandManager;
@@ -125,6 +126,11 @@ public final class FabricClientExample implements ClientModInitializer {
                         ctx.getSender().sendError(ComponentUtils.fromMessage(ex.getRawMessage()));
                     }
                 }));
+
+        commandManager.command(base.literal("flag_test")
+                .argument(StringArgument.optional("parameter"))
+                .flag(CommandFlag.newBuilder("flag").withAliases("f"))
+                .handler(ctx -> ctx.getSender().sendFeedback(Component.literal("Had flag: " + ctx.flags().isPresent("flag")))));
     }
 
     private static void disconnectClient(final @NonNull Minecraft client) {


### PR DESCRIPTION
This is a proof-of-concept of how the library could support flags being located anywhere in the command, instead of just at the very end.

The code at this time is dirty just but the main point is to open up discussion about do's and don'ts since i'm new to the library, tests are passing (including the newly added ones) and the changes seem to be working as intended, although i'm sure there's missing corners).

Solves #230