### PR TITLE
Make CommandMethod inheritable

### DIFF
--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/AnnotationParser.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/AnnotationParser.java
@@ -224,7 +224,18 @@ public final class AnnotationParser<C> {
     static @NonNull List<Method> getAllDeclaredMethods(final Class<?> clazz) {
         final List<Method> methods = new ArrayList<>();
         final Set<MethodSignature> signatures = new HashSet<>();
-        for (Class<?> current = clazz; current != null; current = current.getSuperclass()) {
+        final List<Class<?>> classes = new ArrayList<>();
+        classes.add(clazz);
+        for (int i = 0; i < classes.size(); i++) {
+            final Class<?> current = classes.get(i);
+            if (current.getSuperclass() != null) {
+                classes.add(current.getSuperclass());
+            }
+            for (final Class<?> inter : current.getInterfaces()) {
+                if (!classes.contains(inter)) {
+                    classes.add(inter);
+                }
+            }
             for (final Method method : current.getDeclaredMethods()) {
                 if (Modifier.isPrivate(method.getModifiers()) || signatures.add(new MethodSignature(method))) {
                     methods.add(method);

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/AnnotationParser.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/AnnotationParser.java
@@ -221,6 +221,19 @@ public final class AnnotationParser<C> {
         return getMethodOrClassAnnotation(method, clazz) != null;
     }
 
+    static @NonNull List<Method> getAllDeclaredMethods(final Class<?> clazz) {
+        final List<Method> methods = new ArrayList<>();
+        final Set<MethodSignature> signatures = new HashSet<>();
+        for (Class<?> current = clazz; current != null; current = current.getSuperclass()) {
+            for (final Method method : current.getDeclaredMethods()) {
+                if (Modifier.isPrivate(method.getModifiers()) || signatures.add(new MethodSignature(method))) {
+                    methods.add(method);
+                }
+            }
+        }
+        return methods;
+    }
+
     /**
      * Returns the command manager that was used to create this parser
      *
@@ -414,7 +427,7 @@ public final class AnnotationParser<C> {
         /* Then register all parsers */
         this.parseParsers(instance);
         /* Then construct commands from @CommandMethod annotated classes */
-        final Method[] methods = instance.getClass().getMethods();
+        final List<Method> methods = getAllDeclaredMethods(instance.getClass());
         final Collection<CommandMethodPair> commandMethodPairs = new ArrayList<>();
         for (final Method method : methods) {
             final CommandMethod commandMethod = method.getAnnotation(CommandMethod.class);

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/AnnotationParser.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/AnnotationParser.java
@@ -414,7 +414,7 @@ public final class AnnotationParser<C> {
         /* Then register all parsers */
         this.parseParsers(instance);
         /* Then construct commands from @CommandMethod annotated classes */
-        final Method[] methods = instance.getClass().getDeclaredMethods();
+        final Method[] methods = instance.getClass().getMethods();
         final Collection<CommandMethodPair> commandMethodPairs = new ArrayList<>();
         for (final Method method : methods) {
             final CommandMethod commandMethod = method.getAnnotation(CommandMethod.class);

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/CommandMethod.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/CommandMethod.java
@@ -24,6 +24,7 @@
 package cloud.commandframework.annotations;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -32,6 +33,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 /**
  * Used to declare a class method as a command method
  */
+@Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 public @interface CommandMethod {

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/MethodSignature.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/MethodSignature.java
@@ -1,0 +1,56 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.annotations;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Objects;
+
+final class MethodSignature {
+
+    private final String name;
+    private final Class<?>[] parameters;
+
+    MethodSignature(final Method method) {
+        this.name = method.getName();
+        this.parameters = method.getParameterTypes();
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj instanceof MethodSignature) {
+            final MethodSignature other = (MethodSignature) obj;
+            return this.name.equals(other.name) && Arrays.equals(this.parameters, other.parameters);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.name, Arrays.hashCode(this.parameters));
+    }
+}

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
@@ -113,6 +113,7 @@ class AnnotationParserTest {
         manager.executeCommand(new TestCommandSender(), "child-method").join();
         manager.executeCommand(new TestCommandSender(), "override-method").join();
         manager.executeCommand(new TestCommandSender(), "child-method-with-parent-signature").join();
+        manager.executeCommand(new TestCommandSender(), "default-interface-method").join();
     }
 
     @Test
@@ -285,33 +286,42 @@ class AnnotationParserTest {
 
         @SuppressWarnings("UnusedMethod")
         @CommandMethod("parent-method")
-        private void parent() {
+        private void parentMethod() {
             System.out.println("Hello from parent");
         }
 
         @CommandMethod("override-method")
-        public void override() {
+        public void overrideMethod() {
             throw new UnsupportedOperationException("Failed to use the override command method");
         }
     }
 
 
-    private static class ChildCommandMethod extends ParentCommandMethod {
+    private interface InterfaceCommandMethod {
+
+        @CommandMethod("default-interface-method")
+        default void defaultMethod() {
+            System.out.println("Hello from interface");
+        }
+    }
+
+
+    private static class ChildCommandMethod extends ParentCommandMethod implements InterfaceCommandMethod {
 
         @CommandMethod("child-method")
-        public void child() {
+        public void childMethod() {
             System.out.println("Hello from child");
         }
 
         @Override
         @CommandMethod("override-method")
-        public void override() {
+        public void overrideMethod() {
             System.out.println("Hello from override");
         }
 
         @SuppressWarnings("UnusedMethod")
         @CommandMethod("child-method-with-parent-signature")
-        private void parent() {
+        private void parentMethod() {
             System.out.println("Hello derklaro");
         }
     }

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
@@ -93,6 +93,7 @@ class AnnotationParserTest {
         commands = new ArrayList<>();
         commands.addAll(annotationParser.parse(this));
         commands.addAll(annotationParser.parse(new ClassCommandMethod()));
+        commands.addAll(annotationParser.parse(new ChildCommandMethod()));
     }
 
     @Test
@@ -108,6 +109,8 @@ class AnnotationParserTest {
         manager.executeCommand(new TestCommandSender(), "parserflagcommand -s \"Hello World\"").join();
         manager.executeCommand(new TestCommandSender(), "parserflagcommand -s \"Hello World\" -o This is a test").join();
         manager.executeCommand(new TestCommandSender(), "class method").join();
+        manager.executeCommand(new TestCommandSender(), "parent-method").join();
+        manager.executeCommand(new TestCommandSender(), "child-method").join();
     }
 
     @Test
@@ -272,6 +275,22 @@ class AnnotationParserTest {
         @CommandMethod("method")
         public void annotatedMethod() {
             System.out.println("kekw");
+        }
+    }
+
+    private static abstract class SuperCommandMethod {
+
+        @CommandMethod("parent-method")
+        public void parent() {
+            System.out.println("Hello");
+        }
+    }
+
+    private static class ChildCommandMethod extends SuperCommandMethod {
+
+        @CommandMethod("child-method")
+        public void child() {
+            System.out.println("Hello world");
         }
     }
 

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
@@ -111,6 +111,8 @@ class AnnotationParserTest {
         manager.executeCommand(new TestCommandSender(), "class method").join();
         manager.executeCommand(new TestCommandSender(), "parent-method").join();
         manager.executeCommand(new TestCommandSender(), "child-method").join();
+        manager.executeCommand(new TestCommandSender(), "override-method").join();
+        manager.executeCommand(new TestCommandSender(), "child-method-with-parent-signature").join();
     }
 
     @Test
@@ -278,21 +280,42 @@ class AnnotationParserTest {
         }
     }
 
-    private static abstract class SuperCommandMethod {
 
+    private static abstract class ParentCommandMethod {
+
+        @SuppressWarnings("UnusedMethod")
         @CommandMethod("parent-method")
-        public void parent() {
-            System.out.println("Hello");
+        private void parent() {
+            System.out.println("Hello from parent");
+        }
+
+        @CommandMethod("override-method")
+        public void override() {
+            throw new UnsupportedOperationException("Failed to use the override command method");
         }
     }
 
-    private static class ChildCommandMethod extends SuperCommandMethod {
+
+    private static class ChildCommandMethod extends ParentCommandMethod {
 
         @CommandMethod("child-method")
         public void child() {
-            System.out.println("Hello world");
+            System.out.println("Hello from child");
+        }
+
+        @Override
+        @CommandMethod("override-method")
+        public void override() {
+            System.out.println("Hello from override");
+        }
+
+        @SuppressWarnings("UnusedMethod")
+        @CommandMethod("child-method-with-parent-signature")
+        private void parent() {
+            System.out.println("Hello derklaro");
         }
     }
+
 
     @CommandPermission("some.permission")
     @Target(ElementType.METHOD)


### PR DESCRIPTION
It would be very helpful for command systems that acts on polymorfic objects.

Example: Permissions where you have users and groups. Both have permissions, names, etc... but a group may have a weight for permission resolution and the users may have an id.

This PR aims to reduce the amount of code needed to accomplish that kind of task.