### PR TITLE
Rewrite Bukkit entity selector arguments using WrappedBrigadierParser instead of Bukkit API

### DIFF
--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/CloudBrigadierManager.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/CloudBrigadierManager.java
@@ -214,6 +214,7 @@ public final class CloudBrigadierManager<C, S> {
                 case QUOTED:
                     return StringArgumentType.string();
                 case GREEDY:
+                case GREEDY_FLAG_YIELDING:
                     return StringArgumentType.greedyString();
                 default:
                     return StringArgumentType.word();

--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/CloudBrigadierManager.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/CloudBrigadierManager.java
@@ -703,7 +703,7 @@ public final class CloudBrigadierManager<C, S> {
         private ParsedCommandNodeHandler() {
         }
 
-        private static <S> List<Pair<CommandNode<S>, StringRange>> toPairList(List<?> nodes) {
+        private static <S> List<Pair<CommandNode<S>, StringRange>> toPairList(final List<?> nodes) {
             return ((List<ParsedCommandNode<S>>) nodes).stream()
                     .map(n -> Pair.of(n.getNode(), n.getRange()))
                     .collect(Collectors.toList());

--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/CloudBrigadierManager.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/CloudBrigadierManager.java
@@ -684,9 +684,7 @@ public final class CloudBrigadierManager<C, S> {
             final Method getNodesMethod = commandContext.getClass().getDeclaredMethod("getNodes");
             final Object nodes = getNodesMethod.invoke(commandContext);
             if (nodes instanceof List) {
-                return ((List<ParsedCommandNode<S>>) nodes).stream()
-                        .map(n -> Pair.of(n.getNode(), n.getRange()))
-                        .collect(Collectors.toList());
+                return ParsedCommandNodeHandler.toPairList((List) nodes);
             } else if (nodes instanceof Map) {
                 return ((Map<CommandNode<S>, StringRange>) nodes).entrySet().stream()
                         .map(entry -> Pair.of(entry.getKey(), entry.getValue()))
@@ -697,5 +695,18 @@ public final class CloudBrigadierManager<C, S> {
         } catch (final ReflectiveOperationException ex) {
             throw new RuntimeException(ex);
         }
+    }
+
+    // Inner class to prevent attempting to load ParsedCommandNode when it doesn't exist
+    private static final class ParsedCommandNodeHandler {
+        private ParsedCommandNodeHandler() {
+        }
+
+        private static <S> List<Pair<CommandNode<S>, StringRange>> toPairList(List<?> nodes) {
+            return ((List<ParsedCommandNode<S>>) nodes).stream()
+                    .map(n -> Pair.of(n.getNode(), n.getRange()))
+                    .collect(Collectors.toList());
+        }
+
     }
 }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCaptionKeys.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCaptionKeys.java
@@ -27,6 +27,7 @@ import cloud.commandframework.captions.Caption;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
+import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -58,7 +59,11 @@ public final class BukkitCaptionKeys {
     public static final Caption ARGUMENT_PARSE_FAILURE_WORLD = of("argument.parse.failure.world");
     /**
      * Variables: {input}
+     *
+     * @deprecated parsing is now handled by Brigadier and will throw {@link com.mojang.brigadier.exceptions.CommandSyntaxException} instead.
      */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
     public static final Caption ARGUMENT_PARSE_FAILURE_SELECTOR_MALFORMED = of("argument.parse.failure.selector.malformed");
     /**
      * Variables: None
@@ -66,17 +71,29 @@ public final class BukkitCaptionKeys {
     public static final Caption ARGUMENT_PARSE_FAILURE_SELECTOR_UNSUPPORTED = of("argument.parse.failure.selector.unsupported");
     /**
      * Variables: None
+     *
+     * @deprecated parsing is now handled by Brigadier and will throw {@link com.mojang.brigadier.exceptions.CommandSyntaxException} instead.
      */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
     public static final Caption ARGUMENT_PARSE_FAILURE_SELECTOR_TOO_MANY_PLAYERS = of(
             "argument.parse.failure.selector.too_many_players");
     /**
      * Variables: None
+     *
+     * @deprecated parsing is now handled by Brigadier and will throw {@link com.mojang.brigadier.exceptions.CommandSyntaxException} instead.
      */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
     public static final Caption ARGUMENT_PARSE_FAILURE_SELECTOR_TOO_MANY_ENTITIES = of(
             "argument.parse.failure.selector.too_many_entities");
     /**
      * Variables: None
+     *
+     * @deprecated parsing is now handled by Brigadier and will throw {@link com.mojang.brigadier.exceptions.CommandSyntaxException} instead.
      */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
     public static final Caption ARGUMENT_PARSE_FAILURE_SELECTOR_NON_PLAYER = of(
             "argument.parse.failure.selector.non_player_in_player_selector");
     /**

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCaptionRegistry.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCaptionRegistry.java
@@ -24,6 +24,7 @@
 package cloud.commandframework.bukkit;
 
 import cloud.commandframework.captions.SimpleCaptionRegistry;
+import org.apiguardian.api.API;
 
 /**
  * Caption registry that uses bi-functions to produce messages
@@ -54,7 +55,11 @@ public class BukkitCaptionRegistry<C> extends SimpleCaptionRegistry<C> {
     public static final String ARGUMENT_PARSE_FAILURE_WORLD = "'{input}' is not a valid Minecraft world";
     /**
      * Default caption for {@link BukkitCaptionKeys#ARGUMENT_PARSE_FAILURE_SELECTOR_MALFORMED}
+     *
+     * @deprecated parsing is now handled by Brigadier and will throw {@link com.mojang.brigadier.exceptions.CommandSyntaxException} instead.
      */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
     public static final String ARGUMENT_PARSE_FAILURE_SELECTOR_MALFORMED = "Selector '{input}' is malformed.";
     /**
      * Default caption for {@link BukkitCaptionKeys#ARGUMENT_PARSE_FAILURE_SELECTOR_UNSUPPORTED}
@@ -63,15 +68,27 @@ public class BukkitCaptionRegistry<C> extends SimpleCaptionRegistry<C> {
             "Entity selector argument type not supported below Minecraft 1.13.";
     /**
      * Default caption for {@link BukkitCaptionKeys#ARGUMENT_PARSE_FAILURE_SELECTOR_TOO_MANY_PLAYERS}
+     *
+     * @deprecated parsing is now handled by Brigadier and will throw {@link com.mojang.brigadier.exceptions.CommandSyntaxException} instead.
      */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
     public static final String ARGUMENT_PARSE_FAILURE_SELECTOR_TOO_MANY_PLAYERS = "More than 1 player selected in single player selector";
     /**
      * Default caption for {@link BukkitCaptionKeys#ARGUMENT_PARSE_FAILURE_SELECTOR_TOO_MANY_ENTITIES}
+     *
+     * @deprecated parsing is now handled by Brigadier and will throw {@link com.mojang.brigadier.exceptions.CommandSyntaxException} instead.
      */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
     public static final String ARGUMENT_PARSE_FAILURE_SELECTOR_TOO_MANY_ENTITIES = "More than 1 entity selected in single entity selector.";
     /**
      * Default caption for {@link BukkitCaptionKeys#ARGUMENT_PARSE_FAILURE_SELECTOR_NON_PLAYER}
+     *
+     * @deprecated parsing is now handled by Brigadier and will throw {@link com.mojang.brigadier.exceptions.CommandSyntaxException} instead.
      */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
     public static final String ARGUMENT_PARSE_FAILURE_SELECTOR_NON_PLAYER = "Non-player(s) selected in player selector.";
     /**
      * Default caption for {@link BukkitCaptionKeys#ARGUMENT_PARSE_FAILURE_LOCATION_INVALID_FORMAT}
@@ -106,6 +123,7 @@ public class BukkitCaptionRegistry<C> extends SimpleCaptionRegistry<C> {
             "Invalid input '{input}', requires an explicit namespace.";
 
 
+    @SuppressWarnings("deprecation")
     protected BukkitCaptionRegistry() {
         super();
         this.registerMessageFactory(

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandManager.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandManager.java
@@ -29,6 +29,7 @@ import cloud.commandframework.CommandTree;
 import cloud.commandframework.arguments.parser.ParserParameters;
 import cloud.commandframework.brigadier.BrigadierManagerHolder;
 import cloud.commandframework.brigadier.CloudBrigadierManager;
+import cloud.commandframework.bukkit.annotation.specifier.AllowEmptySelection;
 import cloud.commandframework.bukkit.annotation.specifier.DefaultNamespace;
 import cloud.commandframework.bukkit.annotation.specifier.RequireExplicitNamespace;
 import cloud.commandframework.bukkit.argument.NamespacedKeyArgument;
@@ -157,15 +158,28 @@ public class BukkitCommandManager<C> extends CommandManager<C> implements Brigad
                 new Location2DArgument.Location2DParser<>());
         this.parserRegistry().registerParserSupplier(TypeToken.get(ProtoItemStack.class), parserParameters ->
                 new ItemStackArgument.Parser<>());
+
         /* Register Entity Selector Parsers */
         this.parserRegistry().registerParserSupplier(TypeToken.get(SingleEntitySelector.class), parserParameters ->
                 new SingleEntitySelectorArgument.SingleEntitySelectorParser<>());
         this.parserRegistry().registerParserSupplier(TypeToken.get(SinglePlayerSelector.class), parserParameters ->
                 new SinglePlayerSelectorArgument.SinglePlayerSelectorParser<>());
-        this.parserRegistry().registerParserSupplier(TypeToken.get(MultipleEntitySelector.class), parserParameters ->
-                new MultipleEntitySelectorArgument.MultipleEntitySelectorParser<>());
-        this.parserRegistry().registerParserSupplier(TypeToken.get(MultiplePlayerSelector.class), parserParameters ->
-                new MultiplePlayerSelectorArgument.MultiplePlayerSelectorParser<>());
+        this.parserRegistry().registerAnnotationMapper(
+                AllowEmptySelection.class,
+                (annotation, type) -> ParserParameters.single(BukkitParserParameters.ALLOW_EMPTY_SELECTOR_RESULT, annotation.value())
+        );
+        this.parserRegistry().registerParserSupplier(
+                TypeToken.get(MultipleEntitySelector.class),
+                parserParameters -> new MultipleEntitySelectorArgument.MultipleEntitySelectorParser<>(
+                        parserParameters.get(BukkitParserParameters.ALLOW_EMPTY_SELECTOR_RESULT, true)
+                )
+        );
+        this.parserRegistry().registerParserSupplier(
+                TypeToken.get(MultiplePlayerSelector.class),
+                parserParameters -> new MultiplePlayerSelectorArgument.MultiplePlayerSelectorParser<>(
+                        parserParameters.get(BukkitParserParameters.ALLOW_EMPTY_SELECTOR_RESULT, true)
+                )
+        );
 
         if (CraftBukkitReflection.classExists("org.bukkit.NamespacedKey")) {
             this.registerParserSupplierFor(NamespacedKeyArgument.class);

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitParserParameters.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitParserParameters.java
@@ -25,6 +25,7 @@ package cloud.commandframework.bukkit;
 
 import cloud.commandframework.arguments.parser.ParserParameter;
 import io.leangen.geantyref.TypeToken;
+import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -32,10 +33,22 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  *
  * @since 1.7.0
  */
+@API(status = API.Status.STABLE, since = "1.7.0")
 public final class BukkitParserParameters {
 
     private BukkitParserParameters() {
     }
+
+    /**
+     * Used to specify if an empty result is allowed for
+     * {@link cloud.commandframework.bukkit.parsers.selector.MultiplePlayerSelectorArgument} and
+     * {@link cloud.commandframework.bukkit.parsers.selector.MultipleEntitySelectorArgument}.
+     *
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static final ParserParameter<Boolean> ALLOW_EMPTY_SELECTOR_RESULT =
+            create("allow_empty_selector_result", TypeToken.get(Boolean.class));
 
     /**
      * Sets to require explicit namespaces for {@link cloud.commandframework.bukkit.argument.NamespacedKeyArgument}

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/annotation/specifier/AllowEmptySelection.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/annotation/specifier/AllowEmptySelection.java
@@ -1,0 +1,28 @@
+package cloud.commandframework.bukkit.annotation.specifier;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.apiguardian.api.API;
+
+/**
+ * Annotation used to specify if an empty result is allowed for
+ * {@link cloud.commandframework.bukkit.parsers.selector.MultiplePlayerSelectorArgument} and
+ * {@link cloud.commandframework.bukkit.parsers.selector.MultipleEntitySelectorArgument}.
+ *
+ * @since 1.8.0
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@API(status = API.Status.STABLE, since = "1.8.0")
+public @interface AllowEmptySelection {
+
+    /**
+     * Whether to allow empty results.
+     *
+     * @return value
+     */
+    boolean value() default true;
+
+}

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/annotation/specifier/AllowEmptySelection.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/annotation/specifier/AllowEmptySelection.java
@@ -1,3 +1,26 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
 package cloud.commandframework.bukkit.annotation.specifier;
 
 import java.lang.annotation.ElementType;

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultipleEntitySelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultipleEntitySelectorArgument.java
@@ -27,7 +27,6 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.bukkit.arguments.selector.MultipleEntitySelector;
 import cloud.commandframework.context.CommandContext;
-import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import java.util.List;
 import java.util.function.BiFunction;
 import org.apiguardian.api.API;
@@ -191,10 +190,10 @@ public final class MultipleEntitySelectorArgument<C> extends CommandArgument<C, 
         public MultipleEntitySelector mapResult(
                 final @NonNull String input,
                 final SelectorUtils.@NonNull EntitySelectorWrapper wrapper
-        ) throws Exception {
+        ) {
             final List<Entity> entities = wrapper.entities();
             if (entities.isEmpty() && !this.allowEmpty) {
-                throw ((SimpleCommandExceptionType) NO_ENTITIES_EXCEPTION_TYPE.get()).create();
+                new Thrower(NO_ENTITIES_EXCEPTION_TYPE.get()).throwIt();
             }
             return new MultipleEntitySelector(input, entities);
         }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultipleEntitySelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultipleEntitySelectorArgument.java
@@ -35,6 +35,14 @@ import org.bukkit.entity.Entity;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+/**
+ * Argument type for parsing {@link MultipleEntitySelector}. On Minecraft 1.13+
+ * this argument uses Minecraft's built-in entity selector argument for parsing
+ * and suggestions. On prior versions, this argument will suggest nothing and
+ * always fail parsing with {@link SelectorParseException.FailureReason#UNSUPPORTED_VERSION}.
+ *
+ * @param <C> sender type
+ */
 public final class MultipleEntitySelectorArgument<C> extends CommandArgument<C, MultipleEntitySelector> {
 
     private MultipleEntitySelectorArgument(

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultiplePlayerSelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultiplePlayerSelectorArgument.java
@@ -30,7 +30,6 @@ import cloud.commandframework.bukkit.arguments.selector.MultiplePlayerSelector;
 import cloud.commandframework.bukkit.parsers.PlayerArgument;
 import cloud.commandframework.context.CommandContext;
 import com.google.common.collect.ImmutableList;
-import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
@@ -197,10 +196,10 @@ public final class MultiplePlayerSelectorArgument<C> extends CommandArgument<C, 
         public MultiplePlayerSelector mapResult(
                 final @NonNull String input,
                 final SelectorUtils.@NonNull EntitySelectorWrapper wrapper
-        ) throws Exception {
+        ) {
             final List<Player> players = wrapper.players();
             if (players.isEmpty() && !this.allowEmpty) {
-                throw ((SimpleCommandExceptionType) NO_PLAYERS_EXCEPTION_TYPE.get()).create();
+                new Thrower(NO_PLAYERS_EXCEPTION_TYPE.get()).throwIt();
             }
             return new MultiplePlayerSelector(input, new ArrayList<>(players));
         }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultiplePlayerSelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultiplePlayerSelectorArgument.java
@@ -41,6 +41,14 @@ import org.bukkit.entity.Player;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+/**
+ * Argument type for parsing {@link MultiplePlayerSelector}. On Minecraft 1.13+
+ * this argument uses Minecraft's built-in entity selector argument for parsing
+ * and suggestions. On prior versions, this argument behaves similarly to
+ * {@link PlayerArgument}.
+ *
+ * @param <C> sender type
+ */
 public final class MultiplePlayerSelectorArgument<C> extends CommandArgument<C, MultiplePlayerSelector> {
 
     private MultiplePlayerSelectorArgument(

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SelectorParseException.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SelectorParseException.java
@@ -28,6 +28,7 @@ import cloud.commandframework.captions.Caption;
 import cloud.commandframework.captions.CaptionVariable;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.ParserException;
+import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -73,7 +74,10 @@ public final class SelectorParseException extends ParserException {
     }
 
     /**
-     * Get the reason of failure for the selector parser
+     * Get the reason of failure for the selector parser.
+     *
+     * <p>Note: The only type currently used is {@link FailureReason#UNSUPPORTED_VERSION}, other exceptions
+     * are now handled by Brigadier in the form of {@link com.mojang.brigadier.exceptions.CommandSyntaxException}.</p>
      *
      * @return Failure reason
      * @since 1.2.0
@@ -90,9 +94,29 @@ public final class SelectorParseException extends ParserException {
     public enum FailureReason {
 
         UNSUPPORTED_VERSION(BukkitCaptionKeys.ARGUMENT_PARSE_FAILURE_SELECTOR_UNSUPPORTED),
+        /**
+         * @deprecated parsing is now handled by Brigadier and will throw {@link com.mojang.brigadier.exceptions.CommandSyntaxException} instead.
+         */
+        @API(status = API.Status.DEPRECATED, since = "1.8.0")
+        @Deprecated
         MALFORMED_SELECTOR(BukkitCaptionKeys.ARGUMENT_PARSE_FAILURE_SELECTOR_MALFORMED),
+        /**
+         * @deprecated parsing is now handled by Brigadier and will throw {@link com.mojang.brigadier.exceptions.CommandSyntaxException} instead.
+         */
+        @API(status = API.Status.DEPRECATED, since = "1.8.0")
+        @Deprecated
         TOO_MANY_PLAYERS(BukkitCaptionKeys.ARGUMENT_PARSE_FAILURE_SELECTOR_TOO_MANY_PLAYERS),
+        /**
+         * @deprecated parsing is now handled by Brigadier and will throw {@link com.mojang.brigadier.exceptions.CommandSyntaxException} instead.
+         */
+        @API(status = API.Status.DEPRECATED, since = "1.8.0")
+        @Deprecated
         TOO_MANY_ENTITIES(BukkitCaptionKeys.ARGUMENT_PARSE_FAILURE_SELECTOR_TOO_MANY_ENTITIES),
+        /**
+         * @deprecated parsing is now handled by Brigadier and will throw {@link com.mojang.brigadier.exceptions.CommandSyntaxException} instead.
+         */
+        @API(status = API.Status.DEPRECATED, since = "1.8.0")
+        @Deprecated
         NON_PLAYER_IN_PLAYER_SELECTOR(BukkitCaptionKeys.ARGUMENT_PARSE_FAILURE_SELECTOR_NON_PLAYER);
 
 

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SelectorUtils.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SelectorUtils.java
@@ -139,6 +139,19 @@ final class SelectorUtils {
 
         private final @Nullable ArgumentParser<C, T> modernParser;
 
+        // Hide brigadier references in inner class
+        protected static final class Thrower {
+            private final Object type;
+
+            Thrower(final Object simpleCommandExceptionType) {
+                this.type = simpleCommandExceptionType;
+            }
+
+            void throwIt() {
+                throw rethrow(((SimpleCommandExceptionType) this.type).create());
+            }
+        }
+
         protected SelectorParser(
                 final boolean single,
                 final boolean playersOnly

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SelectorUtils.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SelectorUtils.java
@@ -1,0 +1,472 @@
+//
+// MIT License
+//
+// Copyright (c) 2021 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.bukkit.parsers.selector;
+
+import cloud.commandframework.arguments.parser.ArgumentParseResult;
+import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.brigadier.argument.WrappedBrigadierParser;
+import cloud.commandframework.bukkit.BukkitCommandContextKeys;
+import cloud.commandframework.bukkit.internal.CraftBukkitReflection;
+import cloud.commandframework.bukkit.internal.MinecraftArgumentTypes;
+import cloud.commandframework.context.CommandContext;
+import com.google.common.base.Suppliers;
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import io.leangen.geantyref.GenericTypeReflector;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.DefaultQualifier;
+
+@DefaultQualifier(NonNull.class)
+final class SelectorUtils {
+
+    private SelectorUtils() {
+    }
+
+    private static <C, T> @Nullable ArgumentParser<C, T> createModernParser(
+            final boolean single,
+            final boolean playersOnly,
+            final SelectorMapper<T> mapper
+    ) {
+        if (CraftBukkitReflection.MAJOR_REVISION < 13) {
+            return null;
+        }
+        final ArgumentParser<C, Object> wrappedBrigParser = new WrappedBrigadierParser<>(
+                () -> createEntityArgument(single, playersOnly),
+                ArgumentParser.DEFAULT_ARGUMENT_COUNT,
+                EntityArgumentParseFunction.INSTANCE
+        );
+        return new ModernSelectorParser<>(wrappedBrigParser, mapper);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ArgumentType<Object> createEntityArgument(final boolean single, final boolean playersOnly) {
+        final Constructor<?> constructor =
+                MinecraftArgumentTypes.getClassByKey(NamespacedKey.minecraft("entity")).getDeclaredConstructors()[0];
+        constructor.setAccessible(true);
+        try {
+            return (ArgumentType<Object>) constructor.newInstance(single, playersOnly);
+        } catch (final ReflectiveOperationException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private static final class EntityArgumentParseFunction implements WrappedBrigadierParser.ParseFunction<Object> {
+        static final EntityArgumentParseFunction INSTANCE = new EntityArgumentParseFunction();
+
+        @Override
+        public Object apply(
+                final ArgumentType<Object> type,
+                final StringReader reader
+        ) throws CommandSyntaxException {
+            final @Nullable Method specialParse = CraftBukkitReflection.findMethod(
+                    type.getClass(),
+                    "parse",
+                    StringReader.class,
+                    boolean.class
+            );
+            if (specialParse == null) {
+                return type.parse(reader);
+            }
+            try {
+                return specialParse.invoke(
+                        type,
+                        reader,
+                        true // CraftBukkit overridePermissions param
+                );
+            } catch (final InvocationTargetException ex) {
+                final Throwable cause = ex.getCause();
+                if (cause instanceof CommandSyntaxException) {
+                    throw (CommandSyntaxException) cause;
+                }
+                throw new RuntimeException(ex);
+            } catch (final ReflectiveOperationException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+
+    private abstract static class SelectorParser<C, T> implements ArgumentParser<C, T>, SelectorMapper<T> {
+        protected static final Supplier<Object> NO_PLAYERS_EXCEPTION_TYPE =
+                Suppliers.memoize(() -> findExceptionType("argument.entity.notfound.player"));
+        protected static final Supplier<Object> NO_ENTITIES_EXCEPTION_TYPE =
+                Suppliers.memoize(() -> findExceptionType("argument.entity.notfound.entity"));
+
+        private final @Nullable ArgumentParser<C, T> modernParser;
+
+        protected SelectorParser(
+                final boolean single,
+                final boolean playersOnly
+        ) {
+            this.modernParser = createModernParser(single, playersOnly, this);
+        }
+
+        protected ArgumentParseResult<T> legacyParse(
+                final CommandContext<C> commandContext,
+                final Queue<String> inputQueue
+        ) {
+            return ArgumentParseResult.failure(new SelectorParseException(
+                    "",
+                    commandContext,
+                    SelectorParseException.FailureReason.UNSUPPORTED_VERSION,
+                    this.getClass()
+            ));
+        }
+
+        protected List<String> legacySuggestions(
+                final CommandContext<C> commandContext,
+                final String input
+        ) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public ArgumentParseResult<T> parse(
+                final CommandContext<C> commandContext,
+                final Queue<String> inputQueue
+        ) {
+            if (this.modernParser != null) {
+                return this.modernParser.parse(commandContext, inputQueue);
+            }
+            return this.legacyParse(commandContext, inputQueue);
+        }
+
+        @Override
+        public List<String> suggestions(
+                final CommandContext<C> commandContext,
+                final String input
+        ) {
+            if (this.modernParser != null) {
+                return this.modernParser.suggestions(commandContext, input);
+            }
+            return this.legacySuggestions(commandContext, input);
+        }
+
+        // returns SimpleCommandExceptionType, does not reference in signature for ABI with pre-1.13
+        private static Object findExceptionType(final String type) {
+            final Field[] fields = MinecraftArgumentTypes.getClassByKey(NamespacedKey.minecraft("entity")).getDeclaredFields();
+            return Arrays.stream(fields)
+                    .filter(field -> Modifier.isStatic(field.getModifiers()) && field.getType() == SimpleCommandExceptionType.class)
+                    .map(field -> {
+                        try {
+                            final @Nullable Object fieldValue = field.get(null);
+                            if (fieldValue == null) {
+                                return null;
+                            }
+                            final Field messageField = SimpleCommandExceptionType.class.getDeclaredField("message");
+                            messageField.setAccessible(true);
+                            if (messageField.get(fieldValue).toString().contains(type)) {
+                                return fieldValue;
+                            }
+                        } catch (final ReflectiveOperationException ex) {
+                            throw new RuntimeException(ex);
+                        }
+                        return null;
+                    })
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException("Could not find exception type '" + type + "'"));
+        }
+    }
+
+    abstract static class EntitySelectorParser<C, T> extends SelectorParser<C, T> {
+        protected EntitySelectorParser(final boolean single) {
+            super(single, false);
+        }
+    }
+
+    abstract static class PlayerSelectorParser<C, T> extends SelectorParser<C, T> {
+        protected PlayerSelectorParser(final boolean single) {
+            super(single, true);
+        }
+
+        @Override
+        protected List<String> legacySuggestions(
+                final CommandContext<C> commandContext,
+                final String input
+        ) {
+            final List<String> suggestions = new ArrayList<>();
+
+            for (final Player player : Bukkit.getOnlinePlayers()) {
+                final CommandSender bukkit = commandContext.get(BukkitCommandContextKeys.BUKKIT_COMMAND_SENDER);
+                if (bukkit instanceof Player && !((Player) bukkit).canSee(player)) {
+                    continue;
+                }
+                suggestions.add(player.getName());
+            }
+
+            return suggestions;
+        }
+    }
+
+    private static class ModernSelectorParser<C, T> implements ArgumentParser<C, T> {
+        private final ArgumentParser<C, Object> wrappedBrigadierParser;
+        private final SelectorMapper<T> mapper;
+
+        ModernSelectorParser(
+                final ArgumentParser<C, Object> wrapperBrigParser,
+                final SelectorMapper<T> mapper
+        ) {
+            this.wrappedBrigadierParser = wrapperBrigParser;
+            this.mapper = mapper;
+        }
+
+        @Override
+        public ArgumentParseResult<T> parse(
+                final CommandContext<C> commandContext,
+                final Queue<String> inputQueue
+        ) {
+            final List<String> originalInputQueue = new ArrayList<>(inputQueue);
+
+            final ArgumentParseResult<Object> result = this.wrappedBrigadierParser.parse(commandContext, inputQueue);
+            if (result.getFailure().isPresent()) {
+                return ArgumentParseResult.failure(result.getFailure().get());
+            } else if (result.getParsedValue().isPresent()) {
+                try {
+                    final int consumed = originalInputQueue.size() - inputQueue.size();
+                    final String input = String.join(" ", originalInputQueue.subList(0, consumed));
+                    return ArgumentParseResult.success(this.mapper.mapResult(
+                            input,
+                            new EntitySelectorWrapper(commandContext, result.getParsedValue().get())
+                    ));
+                } catch (final CommandSyntaxException ex) {
+                    inputQueue.clear();
+                    inputQueue.addAll(originalInputQueue);
+                    return ArgumentParseResult.failure(ex);
+                } catch (final Exception ex) {
+                    throw rethrow(ex);
+                }
+            }
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public List<String> suggestions(
+                final CommandContext<C> commandContext,
+                final String input
+        ) {
+            return this.wrappedBrigadierParser.suggestions(commandContext, input);
+        }
+    }
+
+    static final class EntitySelectorWrapper {
+        private static volatile @Nullable Methods methods;
+
+        private final CommandContext<?> commandContext;
+        private final Object selector;
+
+        private static final class Methods {
+            private Method getBukkitEntity;
+            private Method entity;
+            private Method player;
+            private Method entities;
+            private Method players;
+
+            Methods(final CommandContext<?> commandContext, final Object selector) {
+                final Object nativeSender = commandContext.get(WrappedBrigadierParser.COMMAND_CONTEXT_BRIGADIER_NATIVE_SENDER);
+                final Class<?> nativeSenderClass = nativeSender.getClass();
+                for (final Method method : selector.getClass().getDeclaredMethods()) {
+                    if (method.getParameterCount() != 1 || !method.getParameterTypes()[0].equals(nativeSenderClass)) {
+                        continue;
+                    }
+
+                    final Class<?> returnType = method.getReturnType();
+                    if (List.class.isAssignableFrom(returnType)) {
+                        final ParameterizedType stringListType = (ParameterizedType) method.getGenericReturnType();
+                        Type listType = stringListType.getActualTypeArguments()[0];
+                        while (listType instanceof WildcardType) {
+                            listType = ((WildcardType) listType).getUpperBounds()[0];
+                        }
+                        final Class<?> clazz = listType instanceof Class
+                                ? (Class<?>) listType
+                                : GenericTypeReflector.erase(listType);
+                        final @Nullable Method getBukkitEntity = findGetBukkitEntityMethod(clazz);
+                        if (getBukkitEntity == null) {
+                            continue;
+                        }
+                        final Class<?> bukkitType = getBukkitEntity.getReturnType();
+                        if (Player.class.isAssignableFrom(bukkitType)) {
+                            if (this.players != null) {
+                                throw new IllegalStateException();
+                            }
+                            this.players = method;
+                        } else {
+                            if (this.entities != null) {
+                                throw new IllegalStateException();
+                            }
+                            this.entities = method;
+                        }
+                    } else if (returnType != Void.TYPE) {
+                        final @Nullable Method getBukkitEntity = findGetBukkitEntityMethod(returnType);
+                        if (getBukkitEntity == null) {
+                            continue;
+                        }
+                        final Class<?> bukkitType = getBukkitEntity.getReturnType();
+                        if (Player.class.isAssignableFrom(bukkitType)) {
+                            if (this.player != null) {
+                                throw new IllegalStateException();
+                            }
+                            this.player = method;
+                        } else {
+                            if (this.entity != null || this.getBukkitEntity != null) {
+                                throw new IllegalStateException();
+                            }
+                            this.entity = method;
+                            this.getBukkitEntity = getBukkitEntity;
+                        }
+                    }
+                }
+                Objects.requireNonNull(this.getBukkitEntity);
+                Objects.requireNonNull(this.player);
+                Objects.requireNonNull(this.entity);
+                Objects.requireNonNull(this.players);
+                Objects.requireNonNull(this.entities);
+            }
+
+            private static @Nullable Method findGetBukkitEntityMethod(final Class<?> returnType) {
+                @Nullable Method getBukkitEntity;
+                try {
+                    getBukkitEntity = returnType.getDeclaredMethod("getBukkitEntity");
+                } catch (final ReflectiveOperationException ex) {
+                    try {
+                        getBukkitEntity = returnType.getMethod("getBukkitEntity");
+                    } catch (final ReflectiveOperationException ex0) {
+                        getBukkitEntity = null;
+                    }
+                }
+                return getBukkitEntity;
+            }
+        }
+
+        EntitySelectorWrapper(
+                final CommandContext<?> commandContext,
+                final Object selector
+        ) {
+            this.commandContext = commandContext;
+            this.selector = selector;
+        }
+
+        private static Methods methods(final CommandContext<?> commandContext, final Object selector) {
+            if (methods == null) {
+                synchronized (Methods.class) {
+                    if (methods == null) {
+                        methods = new Methods(commandContext, selector);
+                    }
+                }
+            }
+            return methods;
+        }
+
+        private Methods methods() {
+            return methods(this.commandContext, this.selector);
+        }
+
+        Entity singleEntity() {
+            return reflectiveOperation(() -> (Entity) this.methods().getBukkitEntity.invoke(this.methods().entity.invoke(
+                    this.selector,
+                    this.commandContext.<Object>get(WrappedBrigadierParser.COMMAND_CONTEXT_BRIGADIER_NATIVE_SENDER)
+            )));
+        }
+
+        Player singlePlayer() {
+            return reflectiveOperation(() -> (Player) this.methods().getBukkitEntity.invoke(this.methods().player.invoke(
+                    this.selector,
+                    this.commandContext.<Object>get(WrappedBrigadierParser.COMMAND_CONTEXT_BRIGADIER_NATIVE_SENDER)
+            )));
+        }
+
+        @SuppressWarnings("unchecked")
+        List<Entity> entities() {
+            return reflectiveOperation(() -> ((List<Object>) this.methods().entities.invoke(
+                    this.selector,
+                    this.commandContext.<Object>get(WrappedBrigadierParser.COMMAND_CONTEXT_BRIGADIER_NATIVE_SENDER)
+            ))
+                    .stream()
+                    .map(o -> reflectiveOperation(() -> (Entity) this.methods().getBukkitEntity.invoke(o)))
+                    .collect(Collectors.toList()));
+        }
+
+        @SuppressWarnings("unchecked")
+        List<Player> players() {
+            return reflectiveOperation(() -> ((List<Object>) this.methods().players.invoke(
+                    this.selector,
+                    this.commandContext.<Object>get(WrappedBrigadierParser.COMMAND_CONTEXT_BRIGADIER_NATIVE_SENDER)
+            ))
+                    .stream()
+                    .map(o -> reflectiveOperation(() -> (Player) this.methods().getBukkitEntity.invoke(o)))
+                    .collect(Collectors.toList()));
+        }
+
+        @FunctionalInterface
+        interface ReflectiveOperation<T> {
+            T run() throws ReflectiveOperationException;
+        }
+
+        private static <T> T reflectiveOperation(final ReflectiveOperation<T> op) {
+            try {
+                return op.run();
+            } catch (final InvocationTargetException ex) {
+                if (ex.getCause() instanceof CommandSyntaxException) {
+                    throw rethrow(ex.getCause());
+                }
+                throw new RuntimeException(ex);
+            } catch (final ReflectiveOperationException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+
+    @FunctionalInterface
+    interface SelectorMapper<T> {
+        T mapResult(String input, EntitySelectorWrapper wrapper) throws Exception; // throws CommandSyntaxException
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <X extends Throwable> RuntimeException rethrow(final Throwable t) throws X {
+        throw (X) t;
+    }
+}

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SelectorUtils.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SelectorUtils.java
@@ -57,6 +57,7 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.DefaultQualifier;
@@ -294,17 +295,17 @@ final class SelectorUtils {
     }
 
     static final class EntitySelectorWrapper {
-        private static volatile @Nullable Methods methods;
+        private static volatile @MonotonicNonNull Methods methods;
 
         private final CommandContext<?> commandContext;
         private final Object selector;
 
         private static final class Methods {
-            private Method getBukkitEntity;
-            private Method entity;
-            private Method player;
-            private Method entities;
-            private Method players;
+            private @MonotonicNonNull Method getBukkitEntity;
+            private @MonotonicNonNull Method entity;
+            private @MonotonicNonNull Method player;
+            private @MonotonicNonNull Method entities;
+            private @MonotonicNonNull Method players;
 
             Methods(final CommandContext<?> commandContext, final Object selector) {
                 final Object nativeSender = commandContext.get(WrappedBrigadierParser.COMMAND_CONTEXT_BRIGADIER_NATIVE_SENDER);
@@ -360,11 +361,11 @@ final class SelectorUtils {
                         }
                     }
                 }
-                Objects.requireNonNull(this.getBukkitEntity);
-                Objects.requireNonNull(this.player);
-                Objects.requireNonNull(this.entity);
-                Objects.requireNonNull(this.players);
-                Objects.requireNonNull(this.entities);
+                Objects.requireNonNull(this.getBukkitEntity, "Failed to locate getBukkitEntity method");
+                Objects.requireNonNull(this.player, "Failed to locate findPlayer method");
+                Objects.requireNonNull(this.entity, "Failed to locate findEntity method");
+                Objects.requireNonNull(this.players, "Failed to locate findPlayers method");
+                Objects.requireNonNull(this.entities, "Failed to locate findEntities method");
             }
 
             private static @Nullable Method findGetBukkitEntityMethod(final Class<?> returnType) {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SingleEntitySelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SingleEntitySelectorArgument.java
@@ -34,6 +34,14 @@ import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+/**
+ * Argument type for parsing {@link SingleEntitySelector}. On Minecraft 1.13+
+ * this argument uses Minecraft's built-in entity selector argument for parsing
+ * and suggestions. On prior versions, this argument will suggest nothing and
+ * always fail parsing with {@link SelectorParseException.FailureReason#UNSUPPORTED_VERSION}.
+ *
+ * @param <C> sender type
+ */
 public final class SingleEntitySelectorArgument<C> extends CommandArgument<C, SingleEntitySelector> {
 
     private SingleEntitySelectorArgument(

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SinglePlayerSelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SinglePlayerSelectorArgument.java
@@ -40,6 +40,14 @@ import org.bukkit.entity.Player;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+/**
+ * Argument type for parsing {@link SinglePlayerSelector}. On Minecraft 1.13+
+ * this argument uses Minecraft's built-in entity selector argument for parsing
+ * and suggestions. On prior versions, this argument behaves similarly to
+ * {@link PlayerArgument}.
+ *
+ * @param <C> sender type
+ */
 public final class SinglePlayerSelectorArgument<C> extends CommandArgument<C, SinglePlayerSelector> {
 
     private SinglePlayerSelectorArgument(


### PR DESCRIPTION
- Proper handling of spaces
- Possible to use built-in minecraft translations for brigadier exceptions
- Fixes suggestions on Paper in combination with their option to fix tag selector suggestions
- Added option to fail parse when the result collection is empty

Tested to work on 1.8.8, 1.13.2, 1.16.5, 1.19.2 Paper