### PR TITLE
Fix regex exception occuring on some prefixes in the javacord module

### DIFF
--- a/cloud-discord/cloud-javacord/src/main/java/cloud/commandframework/javacord/JavacordCommand.java
+++ b/cloud-discord/cloud-javacord/src/main/java/cloud/commandframework/javacord/JavacordCommand.java
@@ -81,7 +81,7 @@ public class JavacordCommand<C> implements MessageCreateListener {
         if (!messageContent.startsWith(commandPrefix)) {
             return;
         }
-        messageContent = messageContent.replaceFirst(commandPrefix, "");
+        messageContent = messageContent.substring(commandPrefix.length());
 
         final String finalContent = messageContent;
         if (((StaticArgument<C>) this.command).getAliases()


### PR DESCRIPTION
An exception occurs if you use a regex meta character as a prefix in the javacord implementation. This fix uses the trick I found in the JDA implementation where the prefix length is used to cut the command input.