### PR TITLE
Make injection order predictable

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/annotations/injection/ParameterInjectorRegistry.java
+++ b/cloud-core/src/main/java/cloud/commandframework/annotations/injection/ParameterInjectorRegistry.java
@@ -31,7 +31,7 @@ import io.leangen.geantyref.TypeToken;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +51,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class ParameterInjectorRegistry<C> implements InjectionService<C> {
 
     private volatile int injectorCount = 0;
-    private final Map<Class<?>, List<ParameterInjector<C, ?>>> injectors = new HashMap<>();
+    private final Map<Class<?>, List<ParameterInjector<C, ?>>> injectors = new LinkedHashMap<>();
     private final ServicePipeline servicePipeline = ServicePipeline.builder().build();
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/annotations/injection/ParameterInjectorRegistry.java
+++ b/cloud-core/src/main/java/cloud/commandframework/annotations/injection/ParameterInjectorRegistry.java
@@ -64,7 +64,7 @@ public final class ParameterInjectorRegistry<C> implements InjectionService<C> {
     }
 
     /**
-     * Register an injector for a particular type or any of it's assignable supertypes
+     * Register an injector for a particular type or any of it's assignable supertypes.
      *
      * @param clazz    Type that the injector should inject for. This type will matched using
      *                 {@link Class#isAssignableFrom(Class)}
@@ -79,12 +79,14 @@ public final class ParameterInjectorRegistry<C> implements InjectionService<C> {
     }
 
     /**
-     * Register an injector for a particular type predicate
+     * Register an injector for a particular type predicate.
      *
-     * @param predicate A predicate that matches if the injector should be used for a type.
+     * @param predicate A predicate that matches if the injector should be used for a type
      * @param injector The injector that should inject the value into the command method
      * @param <T>      Injected type
+     * @since 1.8.0
      */
+    @API(status = API.Status.STABLE, since = "1.8.0")
     public synchronized <T> void registerInjector(
             final @NonNull Predicate<Class<?>> predicate,
             final @NonNull ParameterInjector<C, T> injector
@@ -108,7 +110,7 @@ public final class ParameterInjectorRegistry<C> implements InjectionService<C> {
     ) {
         return Collections.unmodifiableCollection(this.injectors.stream()
                 .filter(pair -> pair.getFirst().test(clazz))
-                .map(pair -> pair.getSecond())
+                .map(Pair::getSecond)
                 .collect(Collectors.toList()));
     }
 

--- a/cloud-core/src/main/java/cloud/commandframework/annotations/injection/ParameterInjectorRegistry.java
+++ b/cloud-core/src/main/java/cloud/commandframework/annotations/injection/ParameterInjectorRegistry.java
@@ -26,22 +26,24 @@ package cloud.commandframework.annotations.injection;
 import cloud.commandframework.annotations.AnnotationAccessor;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.services.ServicePipeline;
+import cloud.commandframework.types.tuples.Pair;
 import cloud.commandframework.types.tuples.Triplet;
 import io.leangen.geantyref.TypeToken;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Registry containing mappings between {@link Class classes} and {@link ParameterInjector injectors}
+ *
+ * The order injectors are tested is the same order they were registered in.
  *
  * @param <C> Command sender type
  * @since 1.2.0
@@ -50,8 +52,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 @API(status = API.Status.STABLE, since = "1.2.0")
 public final class ParameterInjectorRegistry<C> implements InjectionService<C> {
 
-    private volatile int injectorCount = 0;
-    private final Map<Class<?>, List<ParameterInjector<C, ?>>> injectors = new LinkedHashMap<>();
+    private final List<Pair<Predicate<Class<?>>, ParameterInjector<C, ?>>> injectors = new ArrayList<>();
     private final ServicePipeline servicePipeline = ServicePipeline.builder().build();
 
     /**
@@ -63,7 +64,7 @@ public final class ParameterInjectorRegistry<C> implements InjectionService<C> {
     }
 
     /**
-     * Register an injector for a particular type
+     * Register an injector for a particular type or any of it's assignable supertypes
      *
      * @param clazz    Type that the injector should inject for. This type will matched using
      *                 {@link Class#isAssignableFrom(Class)}
@@ -74,8 +75,21 @@ public final class ParameterInjectorRegistry<C> implements InjectionService<C> {
             final @NonNull Class<T> clazz,
             final @NonNull ParameterInjector<C, T> injector
     ) {
-        this.injectors.computeIfAbsent(clazz, missingClass -> new LinkedList<>()).add(injector);
-        this.injectorCount++;
+        this.registerInjector(cl -> clazz.isAssignableFrom(cl), injector);
+    }
+
+    /**
+     * Register an injector for a particular type predicate
+     *
+     * @param predicate A predicate that matches if the injector should be used for a type.
+     * @param injector The injector that should inject the value into the command method
+     * @param <T>      Injected type
+     */
+    public synchronized <T> void registerInjector(
+            final @NonNull Predicate<Class<?>> predicate,
+            final @NonNull ParameterInjector<C, T> injector
+    ) {
+        this.injectors.add(Pair.of(predicate, injector));
     }
 
     /**
@@ -92,13 +106,10 @@ public final class ParameterInjectorRegistry<C> implements InjectionService<C> {
     public synchronized <T> @NonNull Collection<@NonNull ParameterInjector<C, ?>> injectors(
             final @NonNull Class<T> clazz
     ) {
-        final List<@NonNull ParameterInjector<C, ?>> injectors = new ArrayList<>(this.injectorCount);
-        for (final Map.Entry<Class<?>, List<ParameterInjector<C, ?>>> entry : this.injectors.entrySet()) {
-            if (clazz.isAssignableFrom(entry.getKey())) {
-                injectors.addAll(entry.getValue());
-            }
-        }
-        return Collections.unmodifiableCollection(injectors);
+        return Collections.unmodifiableCollection(this.injectors.stream()
+                .filter(pair -> pair.getFirst().test(clazz))
+                .map(pair -> pair.getSecond())
+                .collect(Collectors.toList()));
     }
 
     @Override


### PR DESCRIPTION
Very simple change that makes it so the order injectors are called in is the one they were registered in, instead of being arbitrary.

This is relevant when the injectors overlap on classes, eg: CommandSender vs Player injectors, if your command wants to be injected a "CommandSender", it could randomly first attempt the player one (as player is compatible) and if player isn't available (eg: console) then it would go to the other injector for the actual CommandSender.

While this is probably a minor change it otherwise becomes impossible to make required injectors that will throw exceptions (later handled by the exception handler) when the necessary context isn't available when classes overlap. In the previous example, if the injector for Player threw an exception when the caller isn't a player, then randomly no command would be able to run from console (if you're unlucky enough that the player injector is called first).

With this change, as long as you register CommandSender's injector first, and then Player, such behavior works reliably.