### PR TITLE
Fix parameter injection default predicate

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/annotations/injection/ParameterInjectorRegistry.java
+++ b/cloud-core/src/main/java/cloud/commandframework/annotations/injection/ParameterInjectorRegistry.java
@@ -75,7 +75,7 @@ public final class ParameterInjectorRegistry<C> implements InjectionService<C> {
             final @NonNull Class<T> clazz,
             final @NonNull ParameterInjector<C, T> injector
     ) {
-        this.registerInjector(cl -> clazz.isAssignableFrom(cl), injector);
+        this.registerInjector(cl -> cl.isAssignableFrom(clazz), injector);
     }
 
     /**


### PR DESCRIPTION
Bug introduced in #402, causes ClassCastExceptions when trying to inject, eg: request a Player but receive a CommandSender (console)