### PR TITLE
Deprecate argument `newBuilder` methods and add `builder` methods to align with newer arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Cloud allows for commands to be defined using builder patterns, like this:
 manager.command(
         manager.commandBuilder("command", Description.of("Test cloud command using a builder"), "alias")
                 .argument(StringArgument.of("input"))
-                .argument(IntegerArgument.<CommandSender>newBuilder("number").withMin(1).withMax(100).build())
+                .argument(IntegerArgument.<CommandSender>builder("number").withMin(1).withMax(100).build())
                 .handler(context -> {
                     String input = context.get("input");
                     int number = context.get("number");

--- a/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
@@ -873,7 +873,7 @@ public abstract class CommandManager<C> {
      * @return Flag builder
      */
     public CommandFlag.@NonNull Builder<Void> flagBuilder(final @NonNull String name) {
-        return CommandFlag.newBuilder(name);
+        return CommandFlag.builder(name);
     }
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/flags/CommandFlag.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/flags/CommandFlag.java
@@ -72,11 +72,26 @@ public final class CommandFlag<T> {
     }
 
     /**
+     * Create a new {@link Builder}.
+     *
+     * @param name flag name
+     * @return new {@link Builder}
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static @NonNull Builder<Void> builder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
      * Create a new flag builder
      *
      * @param name Flag name
      * @return Flag builder
+     * @deprecated prefer {@link #builder(String)}
      */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
     public static @NonNull Builder<Void> newBuilder(final @NonNull String name) {
         return new Builder<>(name);
     }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/BooleanArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/BooleanArgument.java
@@ -64,14 +64,30 @@ public final class BooleanArgument<C> extends CommandArgument<C, Boolean> {
     }
 
     /**
+     * Create a new {@link Builder}.
+     *
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
      * Create a new builder
      *
      * @param name Name of the argument
      * @param <C>  Command sender type
      * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
      */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
     public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
-        return new Builder<>(name);
+        return builder(name);
     }
 
     /**
@@ -82,7 +98,7 @@ public final class BooleanArgument<C> extends CommandArgument<C, Boolean> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Boolean> of(final @NonNull String name) {
-        return BooleanArgument.<C>newBuilder(name).asRequired().build();
+        return BooleanArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -93,7 +109,7 @@ public final class BooleanArgument<C> extends CommandArgument<C, Boolean> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Boolean> optional(final @NonNull String name) {
-        return BooleanArgument.<C>newBuilder(name).asOptional().build();
+        return BooleanArgument.<C>builder(name).asOptional().build();
     }
 
     /**
@@ -108,7 +124,7 @@ public final class BooleanArgument<C> extends CommandArgument<C, Boolean> {
             final @NonNull String name,
             final boolean defaultBoolean
     ) {
-        return BooleanArgument.<C>newBuilder(name).asOptionalWithDefault(Boolean.toString(defaultBoolean)).build();
+        return BooleanArgument.<C>builder(name).asOptionalWithDefault(Boolean.toString(defaultBoolean)).build();
     }
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ByteArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ByteArgument.java
@@ -64,12 +64,28 @@ public final class ByteArgument<C> extends CommandArgument<C, Byte> {
     /**
      * Create a new {@link Builder}.
      *
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
+     * Create a new builder
+     *
      * @param name Name of the argument
      * @param <C>  Command sender type
      * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
      */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
     public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
-        return new Builder<>(name);
+        return builder(name);
     }
 
     /**
@@ -80,7 +96,7 @@ public final class ByteArgument<C> extends CommandArgument<C, Byte> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Byte> of(final @NonNull String name) {
-        return ByteArgument.<C>newBuilder(name).asRequired().build();
+        return ByteArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -91,7 +107,7 @@ public final class ByteArgument<C> extends CommandArgument<C, Byte> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Byte> optional(final @NonNull String name) {
-        return ByteArgument.<C>newBuilder(name).asOptional().build();
+        return ByteArgument.<C>builder(name).asOptional().build();
     }
 
     /**
@@ -106,7 +122,7 @@ public final class ByteArgument<C> extends CommandArgument<C, Byte> {
             final @NonNull String name,
             final byte defaultNum
     ) {
-        return ByteArgument.<C>newBuilder(name).asOptionalWithDefault(defaultNum).build();
+        return ByteArgument.<C>builder(name).asOptionalWithDefault(defaultNum).build();
     }
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/CharArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/CharArgument.java
@@ -56,14 +56,30 @@ public final class CharArgument<C> extends CommandArgument<C, Character> {
     }
 
     /**
+     * Create a new {@link Builder}.
+     *
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
      * Create a new builder
      *
      * @param name Name of the argument
      * @param <C>  Command sender type
      * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
      */
-    public static <C> CharArgument.@NonNull Builder<C> newBuilder(final @NonNull String name) {
-        return new CharArgument.Builder<>(name);
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
+    public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
+        return builder(name);
     }
 
     /**
@@ -74,7 +90,7 @@ public final class CharArgument<C> extends CommandArgument<C, Character> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Character> of(final @NonNull String name) {
-        return CharArgument.<C>newBuilder(name).asRequired().build();
+        return CharArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -85,7 +101,7 @@ public final class CharArgument<C> extends CommandArgument<C, Character> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Character> optional(final @NonNull String name) {
-        return CharArgument.<C>newBuilder(name).asOptional().build();
+        return CharArgument.<C>builder(name).asOptional().build();
     }
 
     /**
@@ -100,7 +116,7 @@ public final class CharArgument<C> extends CommandArgument<C, Character> {
             final @NonNull String name,
             final @NonNull String defaultNum
     ) {
-        return CharArgument.<C>newBuilder(name).asOptionalWithDefault(defaultNum).build();
+        return CharArgument.<C>builder(name).asOptionalWithDefault(defaultNum).build();
     }
 
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DoubleArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DoubleArgument.java
@@ -64,12 +64,28 @@ public final class DoubleArgument<C> extends CommandArgument<C, Double> {
     /**
      * Create a new {@link Builder}.
      *
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
+     * Create a new builder
+     *
      * @param name Name of the argument
      * @param <C>  Command sender type
      * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
      */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
     public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
-        return new Builder<>(name);
+        return builder(name);
     }
 
     /**
@@ -80,7 +96,7 @@ public final class DoubleArgument<C> extends CommandArgument<C, Double> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Double> of(final @NonNull String name) {
-        return DoubleArgument.<C>newBuilder(name).asRequired().build();
+        return DoubleArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -91,7 +107,7 @@ public final class DoubleArgument<C> extends CommandArgument<C, Double> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Double> optional(final @NonNull String name) {
-        return DoubleArgument.<C>newBuilder(name).asOptional().build();
+        return DoubleArgument.<C>builder(name).asOptional().build();
     }
 
     /**
@@ -106,7 +122,7 @@ public final class DoubleArgument<C> extends CommandArgument<C, Double> {
             final @NonNull String name,
             final double defaultNum
     ) {
-        return DoubleArgument.<C>newBuilder(name).asOptionalWithDefault(defaultNum).build();
+        return DoubleArgument.<C>builder(name).asOptionalWithDefault(defaultNum).build();
     }
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/EnumArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/EnumArgument.java
@@ -65,19 +65,40 @@ public class EnumArgument<C, E extends Enum<E>> extends CommandArgument<C, E> {
     }
 
     /**
-     * Create a new builder
+     * Create a new {@link Builder}.
      *
-     * @param name      Name of the argument
-     * @param enumClass Enum class
-     * @param <C>       Command sender type
-     * @param <E>       Enum type
-     * @return Created builder
+     * @param enumClass enum class
+     * @param name      argument name
+     * @param <C>       sender type
+     * @param <E>       enum type
+     * @return new {@link Builder}
+     * @since 1.8.0
      */
-    public static <C, E extends Enum<E>> EnumArgument.@NonNull Builder<C, E> newBuilder(
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C, E extends Enum<E>> @NonNull Builder<C, E> builder(
             final @NonNull Class<E> enumClass,
             final @NonNull String name
     ) {
-        return new EnumArgument.Builder<>(name, enumClass);
+        return new Builder<>(name, enumClass);
+    }
+
+    /**
+     * Create a new builder
+     *
+     * @param enumClass enum class
+     * @param name      Name of the argument
+     * @param <C>       Command sender type
+     * @param <E>       enum type
+     * @return Created builder
+     * @deprecated prefer {@link #builder(Class, String)}
+     */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
+    public static <C, E extends Enum<E>> @NonNull Builder<C, E> newBuilder(
+            final @NonNull Class<E> enumClass,
+            final @NonNull String name
+    ) {
+        return builder(enumClass, name);
     }
 
     /**
@@ -93,7 +114,7 @@ public class EnumArgument<C, E extends Enum<E>> extends CommandArgument<C, E> {
             final @NonNull Class<E> enumClass,
             final @NonNull String name
     ) {
-        return EnumArgument.<C, E>newBuilder(enumClass, name).asRequired().build();
+        return EnumArgument.<C, E>builder(enumClass, name).asRequired().build();
     }
 
     /**
@@ -109,7 +130,7 @@ public class EnumArgument<C, E extends Enum<E>> extends CommandArgument<C, E> {
             final @NonNull Class<E> enumClass,
             final @NonNull String name
     ) {
-        return EnumArgument.<C, E>newBuilder(enumClass, name).asOptional().build();
+        return EnumArgument.<C, E>builder(enumClass, name).asOptional().build();
     }
 
     /**
@@ -127,7 +148,7 @@ public class EnumArgument<C, E extends Enum<E>> extends CommandArgument<C, E> {
             final @NonNull String name,
             final @NonNull E defaultValue
     ) {
-        return EnumArgument.<C, E>newBuilder(enumClass, name).asOptionalWithDefault(defaultValue.name().toLowerCase()).build();
+        return EnumArgument.<C, E>builder(enumClass, name).asOptionalWithDefault(defaultValue.name().toLowerCase()).build();
     }
 
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/FloatArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/FloatArgument.java
@@ -64,12 +64,28 @@ public final class FloatArgument<C> extends CommandArgument<C, Float> {
     /**
      * Create a new {@link Builder}.
      *
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
+     * Create a new builder
+     *
      * @param name Name of the argument
      * @param <C>  Command sender type
      * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
      */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
     public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
-        return new Builder<>(name);
+        return builder(name);
     }
 
     /**
@@ -80,7 +96,7 @@ public final class FloatArgument<C> extends CommandArgument<C, Float> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Float> of(final @NonNull String name) {
-        return FloatArgument.<C>newBuilder(name).asRequired().build();
+        return FloatArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -91,7 +107,7 @@ public final class FloatArgument<C> extends CommandArgument<C, Float> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Float> optional(final @NonNull String name) {
-        return FloatArgument.<C>newBuilder(name).asOptional().build();
+        return FloatArgument.<C>builder(name).asOptional().build();
     }
 
     /**
@@ -106,7 +122,7 @@ public final class FloatArgument<C> extends CommandArgument<C, Float> {
             final @NonNull String name,
             final float defaultNum
     ) {
-        return FloatArgument.<C>newBuilder(name).asOptionalWithDefault(defaultNum).build();
+        return FloatArgument.<C>builder(name).asOptionalWithDefault(defaultNum).build();
     }
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/IntegerArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/IntegerArgument.java
@@ -79,12 +79,28 @@ public final class IntegerArgument<C> extends CommandArgument<C, Integer> {
     /**
      * Create a new {@link Builder}.
      *
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
+     * Create a new builder
+     *
      * @param name Name of the argument
      * @param <C>  Command sender type
      * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
      */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
     public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
-        return new Builder<>(name);
+        return builder(name);
     }
 
     /**
@@ -95,7 +111,7 @@ public final class IntegerArgument<C> extends CommandArgument<C, Integer> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Integer> of(final @NonNull String name) {
-        return IntegerArgument.<C>newBuilder(name).asRequired().build();
+        return IntegerArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -106,7 +122,7 @@ public final class IntegerArgument<C> extends CommandArgument<C, Integer> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Integer> optional(final @NonNull String name) {
-        return IntegerArgument.<C>newBuilder(name).asOptional().build();
+        return IntegerArgument.<C>builder(name).asOptional().build();
     }
 
     /**
@@ -118,7 +134,7 @@ public final class IntegerArgument<C> extends CommandArgument<C, Integer> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Integer> optional(final @NonNull String name, final int defaultNum) {
-        return IntegerArgument.<C>newBuilder(name).asOptionalWithDefault(defaultNum).build();
+        return IntegerArgument.<C>builder(name).asOptionalWithDefault(defaultNum).build();
     }
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/LongArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/LongArgument.java
@@ -64,12 +64,28 @@ public final class LongArgument<C> extends CommandArgument<C, Long> {
     /**
      * Create a new {@link Builder}.
      *
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
+     * Create a new builder
+     *
      * @param name Name of the argument
      * @param <C>  Command sender type
      * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
      */
-    public static <C> LongArgument.@NonNull Builder<C> newBuilder(final @NonNull String name) {
-        return new Builder<>(name);
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
+    public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
+        return builder(name);
     }
 
     /**
@@ -80,7 +96,7 @@ public final class LongArgument<C> extends CommandArgument<C, Long> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Long> of(final @NonNull String name) {
-        return LongArgument.<C>newBuilder(name).asRequired().build();
+        return LongArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -91,7 +107,7 @@ public final class LongArgument<C> extends CommandArgument<C, Long> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Long> optional(final @NonNull String name) {
-        return LongArgument.<C>newBuilder(name).asOptional().build();
+        return LongArgument.<C>builder(name).asOptional().build();
     }
 
     /**
@@ -106,7 +122,7 @@ public final class LongArgument<C> extends CommandArgument<C, Long> {
             final @NonNull String name,
             final long defaultNum
     ) {
-        return LongArgument.<C>newBuilder(name).asOptionalWithDefault(defaultNum).build();
+        return LongArgument.<C>builder(name).asOptionalWithDefault(defaultNum).build();
     }
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ShortArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ShortArgument.java
@@ -64,12 +64,28 @@ public final class ShortArgument<C> extends CommandArgument<C, Short> {
     /**
      * Create a new {@link Builder}.
      *
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
+     * Create a new builder
+     *
      * @param name Name of the argument
      * @param <C>  Command sender type
      * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
      */
-    public static <C> ShortArgument.@NonNull Builder<C> newBuilder(final @NonNull String name) {
-        return new Builder<>(name);
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
+    public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
+        return builder(name);
     }
 
     /**
@@ -80,7 +96,7 @@ public final class ShortArgument<C> extends CommandArgument<C, Short> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Short> of(final @NonNull String name) {
-        return ShortArgument.<C>newBuilder(name).asRequired().build();
+        return ShortArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -91,7 +107,7 @@ public final class ShortArgument<C> extends CommandArgument<C, Short> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Short> optional(final @NonNull String name) {
-        return ShortArgument.<C>newBuilder(name).asOptional().build();
+        return ShortArgument.<C>builder(name).asOptional().build();
     }
 
     /**
@@ -103,7 +119,7 @@ public final class ShortArgument<C> extends CommandArgument<C, Short> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Short> optional(final @NonNull String name, final short defaultNum) {
-        return ShortArgument.<C>newBuilder(name).asOptionalWithDefault(defaultNum).build();
+        return ShortArgument.<C>builder(name).asOptionalWithDefault(defaultNum).build();
     }
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringArgument.java
@@ -69,14 +69,30 @@ public final class StringArgument<C> extends CommandArgument<C, String> {
     }
 
     /**
+     * Create a new {@link Builder}.
+     *
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
      * Create a new builder
      *
      * @param name Name of the argument
      * @param <C>  Command sender type
      * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
      */
-    public static <C> StringArgument.@NonNull Builder<C> newBuilder(final @NonNull String name) {
-        return new StringArgument.Builder<>(name);
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
+    public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
+        return builder(name);
     }
 
     /**
@@ -87,7 +103,7 @@ public final class StringArgument<C> extends CommandArgument<C, String> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, String> of(final @NonNull String name) {
-        return StringArgument.<C>newBuilder(name).single().asRequired().build();
+        return StringArgument.<C>builder(name).single().asRequired().build();
     }
 
     /**
@@ -102,7 +118,7 @@ public final class StringArgument<C> extends CommandArgument<C, String> {
             final @NonNull String name,
             final @NonNull StringMode stringMode
     ) {
-        return StringArgument.<C>newBuilder(name).withMode(stringMode).asRequired().build();
+        return StringArgument.<C>builder(name).withMode(stringMode).asRequired().build();
     }
 
     /**
@@ -113,7 +129,7 @@ public final class StringArgument<C> extends CommandArgument<C, String> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, String> optional(final @NonNull String name) {
-        return StringArgument.<C>newBuilder(name).single().asOptional().build();
+        return StringArgument.<C>builder(name).single().asOptional().build();
     }
 
     /**
@@ -128,7 +144,7 @@ public final class StringArgument<C> extends CommandArgument<C, String> {
             final @NonNull String name,
             final @NonNull StringMode stringMode
     ) {
-        return StringArgument.<C>newBuilder(name).withMode(stringMode).asOptional().build();
+        return StringArgument.<C>builder(name).withMode(stringMode).asOptional().build();
     }
 
     /**
@@ -143,7 +159,7 @@ public final class StringArgument<C> extends CommandArgument<C, String> {
             final @NonNull String name,
             final @NonNull String defaultString
     ) {
-        return StringArgument.<C>newBuilder(name).asOptionalWithDefault(defaultString).build();
+        return StringArgument.<C>builder(name).asOptionalWithDefault(defaultString).build();
     }
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/UUIDArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/UUIDArgument.java
@@ -57,14 +57,30 @@ public final class UUIDArgument<C> extends CommandArgument<C, UUID> {
     }
 
     /**
+     * Create a new {@link Builder}.
+     *
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
      * Create a new builder
      *
-     * @param name Name of the component
+     * @param name Name of the argument
      * @param <C>  Command sender type
      * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
      */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
     public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
-        return new Builder<>(name);
+        return builder(name);
     }
 
     /**
@@ -75,7 +91,7 @@ public final class UUIDArgument<C> extends CommandArgument<C, UUID> {
      * @return Created component
      */
     public static <C> @NonNull CommandArgument<C, UUID> of(final @NonNull String name) {
-        return UUIDArgument.<C>newBuilder(name).asRequired().build();
+        return UUIDArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -86,7 +102,7 @@ public final class UUIDArgument<C> extends CommandArgument<C, UUID> {
      * @return Created component
      */
     public static <C> @NonNull CommandArgument<C, UUID> optional(final @NonNull String name) {
-        return UUIDArgument.<C>newBuilder(name).asOptional().build();
+        return UUIDArgument.<C>builder(name).asOptional().build();
     }
 
     /**
@@ -101,7 +117,7 @@ public final class UUIDArgument<C> extends CommandArgument<C, UUID> {
             final @NonNull String name,
             final @NonNull UUID defaultUUID
     ) {
-        return UUIDArgument.<C>newBuilder(name).asOptionalWithDefault(defaultUUID.toString()).build();
+        return UUIDArgument.<C>builder(name).asOptionalWithDefault(defaultUUID.toString()).build();
     }
 
 

--- a/cloud-core/src/main/java/cloud/commandframework/execution/AsynchronousCommandExecutionCoordinator.java
+++ b/cloud-core/src/main/java/cloud/commandframework/execution/AsynchronousCommandExecutionCoordinator.java
@@ -65,11 +65,26 @@ public final class AsynchronousCommandExecutionCoordinator<C> extends CommandExe
     }
 
     /**
+     * Create a new {@link Builder} instance.
+     *
+     * @param <C> sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder() {
+        return new Builder<>();
+    }
+
+    /**
      * Create a new {@link Builder} instance
      *
      * @param <C> Command sender type
      * @return Builder
+     * @deprecated prefer {@link #builder()}
      */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
     public static <C> @NonNull Builder<C> newBuilder() {
         return new Builder<>();
     }

--- a/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
@@ -53,18 +53,18 @@ public class CommandSuggestionsTest {
         manager.command(manager.commandBuilder("test").literal("two").build());
         manager.command(manager.commandBuilder("test")
                 .literal("var")
-                .argument(StringArgument.<TestCommandSender>newBuilder("str")
+                .argument(StringArgument.<TestCommandSender>builder("str")
                         .withSuggestionsProvider((c, s) -> Arrays.asList("one", "two")))
                 .argument(EnumArgument.of(TestEnum.class, "enum")));
         manager.command(manager.commandBuilder("test")
                 .literal("comb")
-                .argument(StringArgument.<TestCommandSender>newBuilder("str")
+                .argument(StringArgument.<TestCommandSender>builder("str")
                         .withSuggestionsProvider((c, s) -> Arrays.asList("one", "two")))
-                .argument(IntegerArgument.<TestCommandSender>newBuilder("num")
+                .argument(IntegerArgument.<TestCommandSender>builder("num")
                         .withMin(1).withMax(95).asOptional()));
         manager.command(manager.commandBuilder("test")
                 .literal("alt")
-                .argument(IntegerArgument.<TestCommandSender>newBuilder("num")
+                .argument(IntegerArgument.<TestCommandSender>builder("num")
                         .withSuggestionsProvider((c, s) -> Arrays.asList("3", "33", "333"))));
 
         manager.command(manager.commandBuilder("com")
@@ -110,11 +110,11 @@ public class CommandSuggestionsTest {
         manager.command(manager.commandBuilder("numberswithfollowingargument").argument(IntegerArgument.of("num"))
                 .argument(BooleanArgument.of("another_argument")));
         manager.command(manager.commandBuilder("numberswithmin")
-                .argument(IntegerArgument.<TestCommandSender>newBuilder("num").withMin(5).withMax(100)));
+                .argument(IntegerArgument.<TestCommandSender>builder("num").withMin(5).withMax(100)));
 
         manager.command(manager.commandBuilder("partial")
                 .argument(
-                        StringArgument.<TestCommandSender>newBuilder("arg")
+                        StringArgument.<TestCommandSender>builder("arg")
                                 .withSuggestionsProvider((contect, input) -> Arrays.asList("hi", "hey", "heya", "hai", "hello"))
                 )
                 .literal("literal")
@@ -122,7 +122,7 @@ public class CommandSuggestionsTest {
 
         manager.command(manager.commandBuilder("literal_with_variable")
                 .argument(
-                        StringArgument.<TestCommandSender>newBuilder("arg")
+                        StringArgument.<TestCommandSender>builder("arg")
                                 .withSuggestionsProvider((context, input) -> Arrays.asList("veni", "vidi")).build()
                 )
                 .literal("now"));
@@ -453,7 +453,7 @@ public class CommandSuggestionsTest {
         manager.command(
                 manager.commandBuilder("command")
                         .argument(
-                                StringArgument.<TestCommandSender>newBuilder("string")
+                                StringArgument.<TestCommandSender>builder("string")
                                         .greedyFlagYielding()
                                         .withSuggestionsProvider((context, input) -> Collections.singletonList("hello"))
                                         .build()
@@ -520,7 +520,7 @@ public class CommandSuggestionsTest {
         manager.command(
                 manager.commandBuilder("command")
                         .argument(
-                                StringArgument.<TestCommandSender>newBuilder("string")
+                                StringArgument.<TestCommandSender>builder("string")
                                         .greedyFlagYielding()
                                         .withSuggestionsProvider((context, input) -> Collections.singletonList("hello"))
                                         .build()

--- a/cloud-core/src/test/java/cloud/commandframework/issue/Issue281.java
+++ b/cloud-core/src/test/java/cloud/commandframework/issue/Issue281.java
@@ -47,7 +47,7 @@ class Issue281 {
     void commandExceptionShouldNotBeSwallowed() {
         // Arrange
         final CommandManager<TestCommandSender> commandManager = new CommandManager<TestCommandSender>(
-                AsynchronousCommandExecutionCoordinator.<TestCommandSender>newBuilder().withSynchronousParsing().build(),
+                AsynchronousCommandExecutionCoordinator.<TestCommandSender>builder().withSynchronousParsing().build(),
                 CommandRegistrationHandler.nullCommandRegistrationHandler()
         ) {
             @Override

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/ChannelArgument.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/ChannelArgument.java
@@ -37,6 +37,7 @@ import java.util.function.BiFunction;
 import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.NotNull;
@@ -73,14 +74,30 @@ public final class ChannelArgument<C> extends CommandArgument<C, MessageChannel>
     }
 
     /**
+     * Create a new {@link Builder}.
+     *
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
      * Create a new builder
      *
-     * @param name Name of the component
+     * @param name Name of the argument
      * @param <C>  Command sender type
      * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
      */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
     public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
-        return new Builder<>(name);
+        return builder(name);
     }
 
     /**
@@ -91,7 +108,7 @@ public final class ChannelArgument<C> extends CommandArgument<C, MessageChannel>
      * @return Created component
      */
     public static <C> @NonNull CommandArgument<C, MessageChannel> of(final @NonNull String name) {
-        return ChannelArgument.<C>newBuilder(name).asRequired().build();
+        return ChannelArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -102,7 +119,7 @@ public final class ChannelArgument<C> extends CommandArgument<C, MessageChannel>
      * @return Created component
      */
     public static <C> @NonNull CommandArgument<C, MessageChannel> optional(final @NonNull String name) {
-        return ChannelArgument.<C>newBuilder(name).asOptional().build();
+        return ChannelArgument.<C>builder(name).asOptional().build();
     }
 
     /**

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/RoleArgument.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/RoleArgument.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.NotNull;
@@ -64,14 +65,30 @@ public final class RoleArgument<C> extends CommandArgument<C, Role> {
     }
 
     /**
+     * Create a new {@link Builder}.
+     *
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
      * Create a new builder
      *
-     * @param name Name of the component
+     * @param name Name of the argument
      * @param <C>  Command sender type
      * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
      */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
     public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
-        return new Builder<>(name);
+        return builder(name);
     }
 
     /**
@@ -82,7 +99,7 @@ public final class RoleArgument<C> extends CommandArgument<C, Role> {
      * @return Created component
      */
     public static <C> @NonNull CommandArgument<C, Role> of(final @NonNull String name) {
-        return RoleArgument.<C>newBuilder(name).asRequired().build();
+        return RoleArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -93,7 +110,7 @@ public final class RoleArgument<C> extends CommandArgument<C, Role> {
      * @return Created component
      */
     public static <C> @NonNull CommandArgument<C, Role> optional(final @NonNull String name) {
-        return RoleArgument.<C>newBuilder(name).asOptional().build();
+        return RoleArgument.<C>builder(name).asOptional().build();
     }
 
     /**

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/UserArgument.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/UserArgument.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.NotNull;
@@ -79,14 +80,30 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
     }
 
     /**
+     * Create a new {@link Builder}.
+     *
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
      * Create a new builder
      *
-     * @param name Name of the component
+     * @param name Name of the argument
      * @param <C>  Command sender type
      * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
      */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
     public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
-        return new Builder<>(name);
+        return builder(name);
     }
 
     /**
@@ -97,7 +114,7 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
      * @return Created component
      */
     public static <C> @NonNull CommandArgument<C, User> of(final @NonNull String name) {
-        return UserArgument.<C>newBuilder(name).withParserMode(ParserMode.MENTION).asRequired().build();
+        return UserArgument.<C>builder(name).withParserMode(ParserMode.MENTION).asRequired().build();
     }
 
     /**
@@ -108,7 +125,7 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
      * @return Created component
      */
     public static <C> @NonNull CommandArgument<C, User> optional(final @NonNull String name) {
-        return UserArgument.<C>newBuilder(name).withParserMode(ParserMode.MENTION).asOptional().build();
+        return UserArgument.<C>builder(name).withParserMode(ParserMode.MENTION).asOptional().build();
     }
 
     /**

--- a/cloud-irc/cloud-pircbotx/src/main/java/cloud/commandframework/pircbotx/arguments/UserArgument.java
+++ b/cloud-irc/cloud-pircbotx/src/main/java/cloud/commandframework/pircbotx/arguments/UserArgument.java
@@ -36,6 +36,7 @@ import io.leangen.geantyref.TypeToken;
 import java.util.List;
 import java.util.Queue;
 import java.util.function.BiFunction;
+import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.pircbotx.PircBotX;
@@ -70,14 +71,30 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
     }
 
     /**
-     * Create a new user argument builder
+     * Create a new {@link Builder}.
      *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Builder instance
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
      */
-    public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
         return new Builder<>(name);
+    }
+
+    /**
+     * Create a new builder
+     *
+     * @param name Name of the argument
+     * @param <C>  Command sender type
+     * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
+     */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
+    public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
+        return builder(name);
     }
 
     /**
@@ -88,7 +105,7 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
      * @return Argument instance
      */
     public static <C> @NonNull CommandArgument<C, User> of(final @NonNull String name) {
-        return UserArgument.<C>newBuilder(name).asRequired().build();
+        return UserArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -99,7 +116,7 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
      * @return Argument instance
      */
     public static <C> @NonNull CommandArgument<C, User> optional(final @NonNull String name) {
-        return UserArgument.<C>newBuilder(name).asOptional().build();
+        return UserArgument.<C>builder(name).asOptional().build();
     }
 
 

--- a/cloud-kotlin/cloud-kotlin-coroutines-annotations/src/test/kotlin/cloud/commandframework/kotlin/coroutines/annotations/KotlinAnnotatedMethodsTest.kt
+++ b/cloud-kotlin/cloud-kotlin-coroutines-annotations/src/test/kotlin/cloud/commandframework/kotlin/coroutines/annotations/KotlinAnnotatedMethodsTest.kt
@@ -87,7 +87,7 @@ class KotlinAnnotatedMethodsTest {
     private class TestCommandSender
 
     private class TestCommandManager : CommandManager<TestCommandSender>(
-        AsynchronousCommandExecutionCoordinator.newBuilder<TestCommandSender>()
+        AsynchronousCommandExecutionCoordinator.builder<TestCommandSender>()
             .withExecutor(executorService)
             .build(),
         CommandRegistrationHandler.nullCommandRegistrationHandler()

--- a/cloud-kotlin/cloud-kotlin-coroutines/src/test/kotlin/cloud/commandframework/kotlin/coroutines/SuspendingHandlerTest.kt
+++ b/cloud-kotlin/cloud-kotlin-coroutines/src/test/kotlin/cloud/commandframework/kotlin/coroutines/SuspendingHandlerTest.kt
@@ -62,7 +62,7 @@ class SuspendingHandlerTest {
     private class TestCommandSender
 
     private class TestCommandManager : CommandManager<TestCommandSender>(
-        AsynchronousCommandExecutionCoordinator.newBuilder<TestCommandSender>()
+        AsynchronousCommandExecutionCoordinator.builder<TestCommandSender>()
             .withExecutor(executorService)
             .build(),
         CommandRegistrationHandler.nullCommandRegistrationHandler()

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/EnchantmentArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/EnchantmentArgument.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import java.util.function.BiFunction;
+import org.apiguardian.api.API;
 import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -68,14 +69,30 @@ public class EnchantmentArgument<C> extends CommandArgument<C, Enchantment> {
     }
 
     /**
+     * Create a new {@link Builder}.
+     *
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
+        return new EnchantmentArgument.Builder<>(name);
+    }
+
+    /**
      * Create a new builder
      *
      * @param name Name of the argument
      * @param <C>  Command sender type
      * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
      */
-    public static <C> EnchantmentArgument.@NonNull Builder<C> newBuilder(final @NonNull String name) {
-        return new EnchantmentArgument.Builder<>(name);
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
+    public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
+        return builder(name);
     }
 
     /**
@@ -86,7 +103,7 @@ public class EnchantmentArgument<C> extends CommandArgument<C, Enchantment> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Enchantment> of(final @NonNull String name) {
-        return EnchantmentArgument.<C>newBuilder(name).asRequired().build();
+        return EnchantmentArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -97,7 +114,7 @@ public class EnchantmentArgument<C> extends CommandArgument<C, Enchantment> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Enchantment> optional(final @NonNull String name) {
-        return EnchantmentArgument.<C>newBuilder(name).asOptional().build();
+        return EnchantmentArgument.<C>builder(name).asOptional().build();
     }
 
     /**
@@ -112,7 +129,7 @@ public class EnchantmentArgument<C> extends CommandArgument<C, Enchantment> {
             final @NonNull String name,
             final @NonNull Enchantment enchantment
     ) {
-        return EnchantmentArgument.<C>newBuilder(name).asOptionalWithDefault(enchantment.getKey().toString()).build();
+        return EnchantmentArgument.<C>builder(name).asOptionalWithDefault(enchantment.getKey().toString()).build();
     }
 
     public static final class Builder<C> extends CommandArgument.Builder<C, Enchantment> {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/MaterialArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/MaterialArgument.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import java.util.function.BiFunction;
+import org.apiguardian.api.API;
 import org.bukkit.Material;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -59,14 +60,30 @@ public class MaterialArgument<C> extends CommandArgument<C, Material> {
     }
 
     /**
+     * Create a new {@link Builder}.
+     *
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
      * Create a new builder
      *
      * @param name Name of the argument
      * @param <C>  Command sender type
      * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
      */
-    public static <C> MaterialArgument.@NonNull Builder<C> newBuilder(final @NonNull String name) {
-        return new MaterialArgument.Builder<>(name);
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
+    public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
+        return builder(name);
     }
 
     /**
@@ -77,7 +94,7 @@ public class MaterialArgument<C> extends CommandArgument<C, Material> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Material> of(final @NonNull String name) {
-        return MaterialArgument.<C>newBuilder(name).asRequired().build();
+        return MaterialArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -88,7 +105,7 @@ public class MaterialArgument<C> extends CommandArgument<C, Material> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Material> optional(final @NonNull String name) {
-        return MaterialArgument.<C>newBuilder(name).asOptional().build();
+        return MaterialArgument.<C>builder(name).asOptional().build();
     }
 
     /**
@@ -103,7 +120,7 @@ public class MaterialArgument<C> extends CommandArgument<C, Material> {
             final @NonNull String name,
             final @NonNull Material material
     ) {
-        return MaterialArgument.<C>newBuilder(name).asOptionalWithDefault(material.name().toLowerCase()).build();
+        return MaterialArgument.<C>builder(name).asOptionalWithDefault(material.name().toLowerCase()).build();
     }
 
     public static final class Builder<C> extends CommandArgument.Builder<C, Material> {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/OfflinePlayerArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/OfflinePlayerArgument.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import java.util.function.BiFunction;
+import org.apiguardian.api.API;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
@@ -75,14 +76,30 @@ public final class OfflinePlayerArgument<C> extends CommandArgument<C, OfflinePl
     }
 
     /**
+     * Create a new {@link Builder}.
+     *
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
      * Create a new builder
      *
-     * @param name Name of the component
+     * @param name Name of the argument
      * @param <C>  Command sender type
      * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
      */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
     public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
-        return new Builder<>(name);
+        return builder(name);
     }
 
     /**
@@ -93,7 +110,7 @@ public final class OfflinePlayerArgument<C> extends CommandArgument<C, OfflinePl
      * @return Created component
      */
     public static <C> @NonNull CommandArgument<C, OfflinePlayer> of(final @NonNull String name) {
-        return OfflinePlayerArgument.<C>newBuilder(name).asRequired().build();
+        return OfflinePlayerArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -104,7 +121,7 @@ public final class OfflinePlayerArgument<C> extends CommandArgument<C, OfflinePl
      * @return Created component
      */
     public static <C> @NonNull CommandArgument<C, OfflinePlayer> optional(final @NonNull String name) {
-        return OfflinePlayerArgument.<C>newBuilder(name).asOptional().build();
+        return OfflinePlayerArgument.<C>builder(name).asOptional().build();
     }
 
     /**
@@ -119,7 +136,7 @@ public final class OfflinePlayerArgument<C> extends CommandArgument<C, OfflinePl
             final @NonNull String name,
             final @NonNull String defaultPlayer
     ) {
-        return OfflinePlayerArgument.<C>newBuilder(name).asOptionalWithDefault(defaultPlayer).build();
+        return OfflinePlayerArgument.<C>builder(name).asOptionalWithDefault(defaultPlayer).build();
     }
 
 

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/PlayerArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/PlayerArgument.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import java.util.function.BiFunction;
+import org.apiguardian.api.API;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -63,14 +64,30 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
     }
 
     /**
+     * Create a new {@link Builder}.
+     *
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
      * Create a new builder
      *
-     * @param name Name of the component
+     * @param name Name of the argument
      * @param <C>  Command sender type
      * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
      */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
     public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
-        return new Builder<>(name);
+        return builder(name);
     }
 
     /**
@@ -81,7 +98,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
      * @return Created component
      */
     public static <C> @NonNull CommandArgument<C, Player> of(final @NonNull String name) {
-        return PlayerArgument.<C>newBuilder(name).asRequired().build();
+        return PlayerArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -92,7 +109,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
      * @return Created component
      */
     public static <C> @NonNull CommandArgument<C, Player> optional(final @NonNull String name) {
-        return PlayerArgument.<C>newBuilder(name).asOptional().build();
+        return PlayerArgument.<C>builder(name).asOptional().build();
     }
 
     /**
@@ -107,7 +124,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
             final @NonNull String name,
             final @NonNull String defaultPlayer
     ) {
-        return PlayerArgument.<C>newBuilder(name).asOptionalWithDefault(defaultPlayer).build();
+        return PlayerArgument.<C>builder(name).asOptionalWithDefault(defaultPlayer).build();
     }
 
 

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/WorldArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/WorldArgument.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Queue;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
+import org.apiguardian.api.API;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -59,14 +60,30 @@ public class WorldArgument<C> extends CommandArgument<C, World> {
     }
 
     /**
+     * Create a new {@link Builder}.
+     *
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
      * Create a new builder
      *
      * @param name Name of the argument
      * @param <C>  Command sender type
      * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
      */
-    public static <C> CommandArgument.@NonNull Builder<C, World> newBuilder(final @NonNull String name) {
-        return new WorldArgument.Builder<>(name);
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
+    public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
+        return builder(name);
     }
 
     /**
@@ -77,7 +94,7 @@ public class WorldArgument<C> extends CommandArgument<C, World> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, World> of(final @NonNull String name) {
-        return WorldArgument.<C>newBuilder(name).asRequired().build();
+        return WorldArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -88,7 +105,7 @@ public class WorldArgument<C> extends CommandArgument<C, World> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, World> optional(final @NonNull String name) {
-        return WorldArgument.<C>newBuilder(name).asOptional().build();
+        return WorldArgument.<C>builder(name).asOptional().build();
     }
 
     /**
@@ -103,7 +120,7 @@ public class WorldArgument<C> extends CommandArgument<C, World> {
             final @NonNull String name,
             final @NonNull String defaultValue
     ) {
-        return WorldArgument.<C>newBuilder(name).asOptionalWithDefault(defaultValue).build();
+        return WorldArgument.<C>builder(name).asOptionalWithDefault(defaultValue).build();
     }
 
 

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/Location2DArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/Location2DArgument.java
@@ -36,6 +36,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 import java.util.function.BiFunction;
+import org.apiguardian.api.API;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.command.BlockCommandSender;
@@ -76,16 +77,30 @@ public final class Location2DArgument<C> extends CommandArgument<C, Location2D> 
     }
 
     /**
-     * Create a new argument builder
+     * Create a new {@link Builder}.
      *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Builder instance
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
      */
-    public static <C> @NonNull Builder<C> newBuilder(
-            final @NonNull String name
-    ) {
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
         return new Builder<>(name);
+    }
+
+    /**
+     * Create a new builder
+     *
+     * @param name Name of the argument
+     * @param <C>  Command sender type
+     * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
+     */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
+    public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
+        return builder(name);
     }
 
     /**
@@ -98,9 +113,7 @@ public final class Location2DArgument<C> extends CommandArgument<C, Location2D> 
     public static <C> @NonNull CommandArgument<C, Location2D> of(
             final @NonNull String name
     ) {
-        return Location2DArgument.<C>newBuilder(
-                name
-        ).asRequired().build();
+        return Location2DArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -113,9 +126,7 @@ public final class Location2DArgument<C> extends CommandArgument<C, Location2D> 
     public static <C> @NonNull CommandArgument<C, Location2D> optional(
             final @NonNull String name
     ) {
-        return Location2DArgument.<C>newBuilder(
-                name
-        ).asOptional().build();
+        return Location2DArgument.<C>builder(name).asOptional().build();
     }
 
 

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/LocationArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/LocationArgument.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Queue;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
+import org.apiguardian.api.API;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.command.BlockCommandSender;
@@ -81,16 +82,30 @@ public final class LocationArgument<C> extends CommandArgument<C, Location> {
     }
 
     /**
-     * Create a new argument builder
+     * Create a new {@link Builder}.
      *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Builder instance
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
      */
-    public static <C> @NonNull Builder<C> newBuilder(
-            final @NonNull String name
-    ) {
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
         return new Builder<>(name);
+    }
+
+    /**
+     * Create a new builder
+     *
+     * @param name Name of the argument
+     * @param <C>  Command sender type
+     * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
+     */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
+    public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
+        return builder(name);
     }
 
     /**
@@ -103,9 +118,7 @@ public final class LocationArgument<C> extends CommandArgument<C, Location> {
     public static <C> @NonNull CommandArgument<C, Location> of(
             final @NonNull String name
     ) {
-        return LocationArgument.<C>newBuilder(
-                name
-        ).asRequired().build();
+        return LocationArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -118,9 +131,7 @@ public final class LocationArgument<C> extends CommandArgument<C, Location> {
     public static <C> @NonNull CommandArgument<C, Location> optional(
             final @NonNull String name
     ) {
-        return LocationArgument.<C>newBuilder(
-                name
-        ).asOptional().build();
+        return LocationArgument.<C>builder(name).asOptional().build();
     }
 
 

--- a/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/PlayerArgument.java
+++ b/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/PlayerArgument.java
@@ -41,6 +41,7 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -74,20 +75,30 @@ public final class PlayerArgument<C> extends CommandArgument<C, ProxiedPlayer> {
     }
 
     /**
-     * Create a new argument builder
+     * Create a new {@link Builder}.
      *
-     * @param name Argument name
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
+     */
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
+     * Create a new builder
+     *
+     * @param name Name of the argument
      * @param <C>  Command sender type
-     * @return Constructed builder
-     **/
-    public static <C> CommandArgument.@NonNull Builder<C, ProxiedPlayer> newBuilder(
-            final @NonNull String name
-    ) {
-        return new Builder<C>(
-                name
-        ).withParser(
-                new PlayerParser<>()
-        );
+     * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
+     */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
+    public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
+        return builder(name);
     }
 
     /**
@@ -100,7 +111,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, ProxiedPlayer> {
     public static <C> CommandArgument<C, ProxiedPlayer> of(
             final @NonNull String name
     ) {
-        return PlayerArgument.<C>newBuilder(name).asRequired().build();
+        return PlayerArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -113,7 +124,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, ProxiedPlayer> {
     public static <C> CommandArgument<C, ProxiedPlayer> optional(
             final @NonNull String name
     ) {
-        return PlayerArgument.<C>newBuilder(name).asOptional().build();
+        return PlayerArgument.<C>builder(name).asOptional().build();
     }
 
 

--- a/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/ServerArgument.java
+++ b/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/ServerArgument.java
@@ -41,6 +41,7 @@ import java.util.Queue;
 import java.util.function.BiFunction;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.config.ServerInfo;
+import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -74,20 +75,30 @@ public final class ServerArgument<C> extends CommandArgument<C, ServerInfo> {
     }
 
     /**
-     * Create a new argument builder
+     * Create a new {@link Builder}.
      *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Constructed builder
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
      */
-    public static <C> CommandArgument.@NonNull Builder<C, ServerInfo> newBuilder(
-            final @NonNull String name
-    ) {
-        return new Builder<C>(
-                name
-        ).withParser(
-                new ServerParser<>()
-        );
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
+     * Create a new builder
+     *
+     * @param name Name of the argument
+     * @param <C>  Command sender type
+     * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
+     */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
+    public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
+        return builder(name);
     }
 
     /**
@@ -100,7 +111,7 @@ public final class ServerArgument<C> extends CommandArgument<C, ServerInfo> {
     public static <C> @NonNull CommandArgument<C, ServerInfo> of(
             final @NonNull String name
     ) {
-        return ServerArgument.<C>newBuilder(name).asRequired().build();
+        return ServerArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -113,7 +124,7 @@ public final class ServerArgument<C> extends CommandArgument<C, ServerInfo> {
     public static <C> @NonNull CommandArgument<C, ServerInfo> optional(
             final @NonNull String name
     ) {
-        return ServerArgument.<C>newBuilder(name).asOptional().build();
+        return ServerArgument.<C>builder(name).asOptional().build();
     }
 
     public static final class Builder<C> extends CommandArgument.Builder<C, ServerInfo> {

--- a/cloud-minecraft/cloud-fabric/src/testmod/java/cloud/commandframework/fabric/testmod/FabricClientExample.java
+++ b/cloud-minecraft/cloud-fabric/src/testmod/java/cloud/commandframework/fabric/testmod/FabricClientExample.java
@@ -129,7 +129,7 @@ public final class FabricClientExample implements ClientModInitializer {
 
         commandManager.command(base.literal("flag_test")
                 .argument(StringArgument.optional("parameter"))
-                .flag(CommandFlag.newBuilder("flag").withAliases("f"))
+                .flag(CommandFlag.builder("flag").withAliases("f"))
                 .handler(ctx -> ctx.getSender().sendFeedback(Component.literal("Had flag: " + ctx.flags().isPresent("flag")))));
     }
 

--- a/cloud-minecraft/cloud-fabric/src/testmod/java/cloud/commandframework/fabric/testmod/FabricExample.java
+++ b/cloud-minecraft/cloud-fabric/src/testmod/java/cloud/commandframework/fabric/testmod/FabricExample.java
@@ -78,7 +78,7 @@ public final class FabricExample implements ModInitializer {
         final Command.Builder<CommandSourceStack> base = manager.commandBuilder("cloudtest");
 
         final CommandArgument<CommandSourceStack, String> name = StringArgument.of("name");
-        final CommandArgument<CommandSourceStack, Integer> hugs = IntegerArgument.<CommandSourceStack>newBuilder("hugs")
+        final CommandArgument<CommandSourceStack, Integer> hugs = IntegerArgument.<CommandSourceStack>builder("hugs")
                 .asOptionalWithDefault("1")
                 .build();
 
@@ -148,7 +148,7 @@ public final class FabricExample implements ModInitializer {
                 .permission("cloud.give")
                 .argument(MultiplePlayerSelectorArgument.of("targets"))
                 .argument(ItemInputArgument.of("item"))
-                .argument(IntegerArgument.<CommandSourceStack>newBuilder("amount")
+                .argument(IntegerArgument.<CommandSourceStack>builder("amount")
                         .withMin(1)
                         .asOptionalWithDefault("1"))
                 .handler(ctx -> {

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/PlayerArgument.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/PlayerArgument.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Queue;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
+import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -74,20 +75,30 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
     }
 
     /**
-     * Create a new argument builder
+     * Create a new {@link Builder}.
      *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Constructed builder
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
      */
-    public static <C> CommandArgument.@NonNull Builder<C, Player> newBuilder(
-            final @NonNull String name
-    ) {
-        return new Builder<C>(
-                name
-        ).withParser(
-                new PlayerParser<>()
-        );
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
+     * Create a new builder
+     *
+     * @param name Name of the argument
+     * @param <C>  Command sender type
+     * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
+     */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
+    public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
+        return builder(name);
     }
 
     /**
@@ -100,7 +111,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
     public static <C> @NonNull CommandArgument<C, Player> of(
             final @NonNull String name
     ) {
-        return PlayerArgument.<C>newBuilder(name).asRequired().build();
+        return PlayerArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -113,7 +124,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
     public static <C> @NonNull CommandArgument<C, Player> optional(
             final @NonNull String name
     ) {
-        return PlayerArgument.<C>newBuilder(name).asOptional().build();
+        return PlayerArgument.<C>builder(name).asOptional().build();
     }
 
 

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/ServerArgument.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/ServerArgument.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Queue;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
+import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -74,20 +75,30 @@ public final class ServerArgument<C> extends CommandArgument<C, RegisteredServer
     }
 
     /**
-     * Create a new argument builder
+     * Create a new {@link Builder}.
      *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Constructed builder
+     * @param name argument name
+     * @param <C>  sender type
+     * @return new {@link Builder}
+     * @since 1.8.0
      */
-    public static <C> CommandArgument.@NonNull Builder<C, RegisteredServer> newBuilder(
-            final @NonNull String name
-    ) {
-        return new Builder<C>(
-                name
-        ).withParser(
-                new ServerParser<>()
-        );
+    @API(status = API.Status.STABLE, since = "1.8.0")
+    public static <C> @NonNull Builder<C> builder(final @NonNull String name) {
+        return new Builder<>(name);
+    }
+
+    /**
+     * Create a new builder
+     *
+     * @param name Name of the argument
+     * @param <C>  Command sender type
+     * @return Created builder
+     * @deprecated prefer {@link #builder(String)}
+     */
+    @API(status = API.Status.DEPRECATED, since = "1.8.0")
+    @Deprecated
+    public static <C> @NonNull Builder<C> newBuilder(final @NonNull String name) {
+        return builder(name);
     }
 
     /**
@@ -100,7 +111,7 @@ public final class ServerArgument<C> extends CommandArgument<C, RegisteredServer
     public static <C> @NonNull CommandArgument<C, RegisteredServer> of(
             final @NonNull String name
     ) {
-        return ServerArgument.<C>newBuilder(name).asRequired().build();
+        return ServerArgument.<C>builder(name).asRequired().build();
     }
 
     /**
@@ -111,7 +122,7 @@ public final class ServerArgument<C> extends CommandArgument<C, RegisteredServer
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, RegisteredServer> optional(final @NonNull String name) {
-        return ServerArgument.<C>newBuilder(name).asOptional().build();
+        return ServerArgument.<C>builder(name).asOptional().build();
     }
 
     public static final class Builder<C> extends CommandArgument.Builder<C, RegisteredServer> {

--- a/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/ExamplePlugin.java
+++ b/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/ExamplePlugin.java
@@ -124,7 +124,7 @@ public final class ExamplePlugin extends JavaPlugin {
         // asynchronously
         //
         final Function<CommandTree<CommandSender>, CommandExecutionCoordinator<CommandSender>> executionCoordinatorFunction =
-                AsynchronousCommandExecutionCoordinator.<CommandSender>newBuilder().build();
+                AsynchronousCommandExecutionCoordinator.<CommandSender>builder().build();
         //
         // However, in many cases it is fine for to run everything synchronously:
         //

--- a/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/Mc113.java
+++ b/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/Mc113.java
@@ -61,7 +61,7 @@ final class Mc113 {
                 .argument(BlockPredicateArgument.of("predicate"))
                 .literal("with")
                 .argument(MaterialArgument.of("block")) // todo: use BlockDataArgument
-                .argument(IntegerArgument.<CommandSender>newBuilder("radius").withMin(1))
+                .argument(IntegerArgument.<CommandSender>builder("radius").withMin(1))
                 .handler(this::executeReplace));
 
         this.manager.command(builder.literal("test_item")

--- a/examples/example-bungee/src/main/java/cloud/commandframework/examples/bungee/ExamplePlugin.java
+++ b/examples/example-bungee/src/main/java/cloud/commandframework/examples/bungee/ExamplePlugin.java
@@ -57,7 +57,7 @@ public final class ExamplePlugin extends Plugin {
     @Override
     public void onEnable() {
         final Function<CommandTree<CommandSender>, CommandExecutionCoordinator<CommandSender>> executionCoordinatorFunction =
-                AsynchronousCommandExecutionCoordinator.<CommandSender>newBuilder().build();
+                AsynchronousCommandExecutionCoordinator.<CommandSender>builder().build();
 
         final Function<CommandSender, CommandSender> mapperFunction = Function.identity();
 


### PR DESCRIPTION
For a while now, new arguments have used `builder` instead of `newBuilder` for their static builder factories, this updates all existing types to use the new pattern for consistency.