### PR TITLE
Add command context type lookup methods

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
             echo "STATUS=release" >> $GITHUB_ENV
           fi
       - name: Publish Snapshot
-        if: "${{ env.STATUS != 'release' && github.event_name == 'push' && github.ref == 'refs/heads/1.8.0-dev' }}"
+        if: "${{ env.STATUS != 'release' && github.event_name == 'push' && github.ref == 'refs/heads/1.9.0-dev' }}"
         run: ./gradlew publish
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: "${{ secrets.SONATYPE_USERNAME }}"

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Snapshot builds of Cloud are available through the [Sonatype OSS Snapshot reposi
 <dependency>  
  <groupId>cloud.commandframework</groupId>
  <artifactId>cloud-PLATFORM</artifactId>
- <version>1.8.0</version>
+ <version>1.9.0-SNAPSHOT</version>
 </dependency>
 <!-- 
 ~    Optional: Allows you to use annotated methods
@@ -124,7 +124,7 @@ Snapshot builds of Cloud are available through the [Sonatype OSS Snapshot reposi
 <dependency>  
  <groupId>cloud.commandframework</groupId>
  <artifactId>cloud-annotations</artifactId>
- <version>1.8.0</version>
+ <version>1.9.0-SNAPSHOT</version>
 </dependency>
 ``` 
 
@@ -185,7 +185,7 @@ repositories {
 
 ```kotlin
 dependencies {
-    implementation("cloud.commandframework", "cloud-PLATFORM", "1.8.0")
+    implementation("cloud.commandframework", "cloud-PLATFORM", "1.9.0-SNAPSHOT")
 }
 ```
 

--- a/cloud-core/src/main/java/cloud/commandframework/context/CommandContext.java
+++ b/cloud-core/src/main/java/cloud/commandframework/context/CommandContext.java
@@ -586,6 +586,9 @@ public class CommandContext<C> {
     /**
      * Locates elements in the command context by type.
      *
+     * <p>If you have or are able to get the key for a value, it should be preferred
+     * to retrieve values by their key.</p>
+     *
      * <p>When {@code exactType} is {@code flase}, a value may be returned
      * if it's type is assignable to {@code type}. Otherwise the type must pass
      * an equals comparison.</p>
@@ -622,6 +625,9 @@ public class CommandContext<C> {
      * Locates an element in the command context by type. If no matching elements
      * are found, returns {@code null}.
      *
+     * <p>If you have or are able to get the key for a value, it should be preferred
+     * to retrieve values by their key.</p>
+     *
      * <p>When {@code exactType} is {@code flase}, a value may be returned
      * if it's type is assignable to {@code type}. Otherwise the type must pass
      * an equals comparison.</p>
@@ -652,6 +658,9 @@ public class CommandContext<C> {
 
     /**
      * Locates an element in the command context by type.
+     *
+     * <p>If you have or are able to get the key for a value, it should be preferred
+     * to retrieve values by their key.</p>
      *
      * <p>When {@code exactType} is {@code flase}, a value may be returned
      * if it's type is assignable to {@code type}. Otherwise the type must pass

--- a/cloud-core/src/main/java/cloud/commandframework/context/CommandContext.java
+++ b/cloud-core/src/main/java/cloud/commandframework/context/CommandContext.java
@@ -590,11 +590,13 @@ public class CommandContext<C> {
      * if it's type is assignable to {@code type}. Otherwise the type must pass
      * an equals comparison.</p>
      *
-     * @param type       type to find
-     * @param exactType  whether exact type is required
-     * @param allowEmpty whether to allow empty result
-     * @param <T>        type to find
-     * @return found elements, may be empty when {@code allowEmpty} is {@code true}
+     * <p>Note that any undocumented/internal values returned by this method
+     * are not to be relied upon as API.</p>
+     *
+     * @param type      type to find
+     * @param exactType whether exact type is required
+     * @param <T>       type to find
+     * @return found elements, may be empty if there are no matching elements
      * @throws IllegalStateException when {@code allowEmpty} is {@code false} and no elements are found
      * @since 1.9.0
      */
@@ -602,8 +604,7 @@ public class CommandContext<C> {
     @SuppressWarnings("unchecked")
     public <@NonNull T> @NonNull Collection<Pair<CloudKey<? extends T>, T>> find(
             final @NonNull Class<T> type,
-            final boolean exactType,
-            final boolean allowEmpty
+            final boolean exactType
     ) {
         final List<Pair<CloudKey<? extends T>, T>> found = new ArrayList<>();
         for (final Map.Entry<CloudKey<?>, Object> entry : this.internalStorage.entrySet()) {
@@ -613,9 +614,6 @@ public class CommandContext<C> {
             if (test) {
                 found.add(Pair.of((CloudKey<? extends T>) entry.getKey(), (T) entry.getValue()));
             }
-        }
-        if (found.isEmpty() && !allowEmpty) {
-            throw new IllegalStateException("allowEmpty was false, but no elements were found matching '" + type.getName() + "'");
         }
         return found;
     }
@@ -627,6 +625,9 @@ public class CommandContext<C> {
      * <p>When {@code exactType} is {@code flase}, a value may be returned
      * if it's type is assignable to {@code type}. Otherwise the type must pass
      * an equals comparison.</p>
+     *
+     * <p>Note that any undocumented/internal values returned by this method
+     * are not to be relied upon as API.</p>
      *
      * @param type      type to find
      * @param exactType whether exact type is required
@@ -640,7 +641,7 @@ public class CommandContext<C> {
             final @NonNull Class<T> type,
             final boolean exactType
     ) {
-        final Collection<Pair<CloudKey<? extends T>, T>> found = this.find(type, exactType, true);
+        final Collection<Pair<CloudKey<? extends T>, T>> found = this.find(type, exactType);
         if (found.size() > 1) {
             throw new IllegalStateException("More than one element (" + found.size() + ") located with type '" + type.getName() + "'.");
         } else if (found.isEmpty()) {
@@ -655,6 +656,9 @@ public class CommandContext<C> {
      * <p>When {@code exactType} is {@code flase}, a value may be returned
      * if it's type is assignable to {@code type}. Otherwise the type must pass
      * an equals comparison.</p>
+     *
+     * <p>Note that any undocumented/internal values returned by this method
+     * are not to be relied upon as API.</p>
      *
      * @param type      type to find
      * @param exactType whether exact type is required

--- a/cloud-minecraft/README.md
+++ b/cloud-minecraft/README.md
@@ -24,14 +24,14 @@ mappings will be available.
 <dependency>
     <groupId>cloud.commandframework</groupId>
     <artifactId>cloud-bukkit</artifactId>
-    <version>1.8.0</version>
+    <version>1.9.0-SNAPSHOT</version>
 </dependency>
 ```
 
 **gradle**:
 ```groovy
 dependencies {
-    implementation 'cloud.commandframework:cloud-bukkit:1.8.0'
+    implementation 'cloud.commandframework:cloud-bukkit:1.9.0-SNAPSHOT'
 }
 ```
 
@@ -93,14 +93,14 @@ mappings are available even without commodore present.
 <dependency>
     <groupId>cloud.commandframework</groupId>
     <artifactId>cloud-paper</artifactId>
-    <version>1.8.0</version>
+    <version>1.9.0-SNAPSHOT</version>
 </dependency>
 ```
 
 **gradle**:
 ```groovy
 dependencies {
-    implementation 'cloud.commandframework:cloud-paper:1.8.0'
+    implementation 'cloud.commandframework:cloud-paper:1.9.0-SNAPSHOT'
 }
 ```
 
@@ -118,14 +118,14 @@ BungeeCord mappings for cloud.
 <dependency>
     <groupId>cloud.commandframework</groupId>
     <artifactId>cloud-bungee</artifactId>
-    <version>1.8.0</version>
+    <version>1.9.0-SNAPSHOT</version>
 </dependency>
 ```
 
 **gradle**:
 ```groovy
 dependencies {
-    implementation 'cloud.commandframework:cloud-bungee:1.8.0'
+    implementation 'cloud.commandframework:cloud-bungee:1.9.0-SNAPSHOT'
 }
 ```
 
@@ -150,14 +150,14 @@ cloud mappings for Velocity 1.1.0.
 <dependency>
     <groupId>cloud.commandframework</groupId>
     <artifactId>cloud-velocity</artifactId>
-    <version>1.8.0</version>
+    <version>1.9.0-SNAPSHOT</version>
 </dependency>
 ```
 
 **gradle**:
 ```groovy
 dependencies {
-    implementation 'cloud.commandframework:cloud-velocity:1.8.0'
+    implementation 'cloud.commandframework:cloud-velocity:1.9.0-SNAPSHOT'
 }
 ```
 
@@ -181,14 +181,14 @@ cloud mappings for CloudBurst 1.0.0-SNAPSHOT.
 <dependency>
     <groupId>cloud.commandframework</groupId>
     <artifactId>cloud-cloudburst</artifactId>
-    <version>1.8.0</version>
+    <version>1.9.0-SNAPSHOT</version>
 </dependency>
 ```
 
 **gradle**:
 ```groovy
 dependencies {
-    implementation 'cloud.commandframework:cloud-velocity:1.8.0'
+    implementation 'cloud.commandframework:cloud-velocity:1.9.0-SNAPSHOT'
 }
 ```
 
@@ -217,7 +217,7 @@ the latest release of cloud.
 **gradle**:
 ```groovy
 dependencies {
-    modImplementation 'cloud.commandframework:cloud-fabric:1.8.0'
+    modImplementation 'cloud.commandframework:cloud-fabric:1.9.0-SNAPSHOT'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=cloud.commandframework
-version=1.8.0
+version=1.9.0-SNAPSHOT
 description=Command framework and dispatcher for the JVM
 
 org.gradle.caching=true


### PR DESCRIPTION
Things to consider:
- Do we want a custom result type instead of `Pair`/`Collection<Pair>`?
- Overloads with default values for the two booleans (or some sort of `Query` with a builder? could be more powerful (add key filtering/type predicates?) but also more overkill)
- Adding tests