### PR TITLE
Fix last argument always being treated as greedy in suggestions

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
@@ -630,16 +630,13 @@ public final class CommandTree<C> {
         if (commandQueue.isEmpty()) {
             return Collections.emptyList();
         } else if (child.isLeaf()) {
-            final String input;
+            // Handles only simple cases, others will attempt to parse and then decide based on what gets consumed.
             if (commandQueue.size() == 1) {
-                input = commandQueue.peek();
-            } else {
-                input = child.getValue() instanceof CompoundArgument
-                        ? ((LinkedList<String>) commandQueue).getLast()
-                        : String.join(" ", commandQueue);
+                return this.directSuggestions(commandContext, child, commandQueue.peek());
+            } else if (child.getValue() instanceof CompoundArgument) {
+                return this.directSuggestions(commandContext, child, ((LinkedList<String>) commandQueue).getLast());
             }
-            return this.directSuggestions(commandContext, child, input);
-        } else if (commandQueue.peek().isEmpty()) {
+        } else if (commandQueue.size() == 1 && commandQueue.peek().isEmpty()) {
             return this.directSuggestions(commandContext, child, commandQueue.peek());
         }
 
@@ -661,6 +658,18 @@ public final class CommandTree<C> {
             final ArgumentParseResult<?> result = child.getValue().getParser().parse(commandContext, commandQueue);
             final Optional<?> parsedValue = result.getParsedValue();
             final boolean parseSuccess = parsedValue.isPresent();
+
+            // It's the last node, we don't care for success or not as we don't need to delegate to a child
+            if (child.isLeaf()) {
+                if (commandQueue.isEmpty()) {
+                    // Greedy parser took all the input, we can restore and just ask for suggestions
+                    commandQueue.addAll(commandQueueOriginal);
+                    return this.directSuggestions(commandContext, child, String.join(" ", commandQueue));
+                } else {
+                    // It's a leaf and there's leftover stuff, no possible suggestions!
+                    return Collections.emptyList();
+                }
+            }
 
             if (parseSuccess && !commandQueue.isEmpty()) {
                 // the current argument at the position is parsable and there are more arguments following
@@ -688,10 +697,10 @@ public final class CommandTree<C> {
             // Therefore we shouldn't list the suggestions of the current argument, as clearly the suggestions of
             // one of the following arguments is requested
             return Collections.emptyList();
+        } else {
+            // Fallback: use suggestion provider of argument
+            return this.directSuggestions(commandContext, child, commandQueue.peek());
         }
-
-        // Fallback: use suggestion provider of argument
-        return this.directSuggestions(commandContext, child, commandQueue.peek());
     }
 
     private @NonNull String stringOrEmpty(final @Nullable String string) {

--- a/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
@@ -26,6 +26,7 @@ package cloud.commandframework;
 import cloud.commandframework.arguments.compound.ArgumentTriplet;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.standard.BooleanArgument;
+import cloud.commandframework.arguments.standard.DurationArgument;
 import cloud.commandframework.arguments.standard.EnumArgument;
 import cloud.commandframework.arguments.standard.IntegerArgument;
 import cloud.commandframework.arguments.standard.StringArgument;
@@ -112,6 +113,8 @@ public class CommandSuggestionsTest {
                 .argument(BooleanArgument.of("another_argument")));
         manager.command(manager.commandBuilder("numberswithmin")
                 .argument(IntegerArgument.<TestCommandSender>builder("num").withMin(5).withMax(100)));
+
+        manager.command(manager.commandBuilder("duration").argument(DurationArgument.of("duration")));
 
         manager.command(manager.commandBuilder("partial")
                 .argument(
@@ -316,6 +319,10 @@ public class CommandSuggestionsTest {
         final String input5 = "numberswithmin ";
         final List<String> suggestions5 = manager.suggest(new TestCommandSender(), input5);
         Assertions.assertEquals(Arrays.asList("5", "6", "7", "8", "9"), suggestions5);
+
+        final String input6 = "numbers 1 ";
+        final List<String> suggestions6 = manager.suggest(new TestCommandSender(), input6);
+        Assertions.assertEquals(Collections.emptyList(), suggestions6);
     }
 
     @Test
@@ -335,6 +342,22 @@ public class CommandSuggestionsTest {
                 Arrays.asList("-1", "-10", "-11", "-12", "-13", "-14", "-15", "-16", "-17", "-18", "-19"),
                 suggestions4
         );
+    }
+
+    @Test
+    void testDurations() {
+        final String input = "duration ";
+        final List<String> suggestions = manager.suggest(new TestCommandSender(), input);
+        Assertions.assertEquals(Arrays.asList("1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions);
+        final String input2 = "duration 5";
+        final List<String> suggestions2 = manager.suggest(new TestCommandSender(), input2);
+        Assertions.assertEquals(Arrays.asList("5d", "5h", "5m", "5s"), suggestions2);
+        final String input3 = "duration 5s";
+        final List<String> suggestions3 = manager.suggest(new TestCommandSender(), input3);
+        Assertions.assertEquals(Collections.emptyList(), suggestions3);
+        final String input4 = "duration 5s ";
+        final List<String> suggestions4 = manager.suggest(new TestCommandSender(), input4);
+        Assertions.assertEquals(Collections.emptyList(), suggestions4);
     }
 
     @Test


### PR DESCRIPTION
Ever since the fix for #190 was merged (#414), *all* parsers would be treated as greedy if they were the last parser on the command, one of the argument parsers that heavily suffered from this was duration, here's how it looks like:

![image](https://user-images.githubusercontent.com/11789291/215344489-1fa86fd0-ca67-4bfc-989b-1bc69c15e431.png)
This is due to duration parser suggesting letters if the last char is not a letter, since the input was `5s `, it attempts to suggest [input] + "d" etc, leaving these weird suggestions.

The change makes it so if there's an ambiguity about what to do with the last parser (ie: there's only one parser left, but there's more than one string left in the queue) it will let it get parsed, and observes what's left in the command queue after the parse. If the parser consumed all strings, then it's free to suggest the whole string with spaces, otherwise, it is understood that the parser is non-greedy, and the leftover text is not part of the command, and as such, should suggest nothing:

![image](https://user-images.githubusercontent.com/11789291/215344695-2f8b5aea-9f28-464f-9152-b2b2bbcabc38.png)


Tested with greedy arguments and seems to work just fine too.