### PR TITLE
fixed null permission

### DIFF
--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommand.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommand.java
@@ -81,6 +81,8 @@ final class BukkitCommand<C> extends org.bukkit.command.Command implements Plugi
         this.cloudCommand = cloudCommand;
         if (this.command.getOwningCommand() != null) {
             this.setPermission(this.command.getOwningCommand().getCommandPermission().toString());
+        } else {
+            this.setPermission(this.cloudCommand.getCommandPermission().toString());
         }
         this.disabled = false;
     }


### PR DESCRIPTION
minecraft (bukkit) commands registered by cloud have no permission
![image](https://user-images.githubusercontent.com/54660361/236692486-0f256b27-a7ab-4da3-b2b7-2ab42e7f6e0c.png)
(not a good representation, but the two messages below shall represent the issue)