### PR TITLE
added permission when owner is null and command permission is not empty

### DIFF
--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommand.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommand.java
@@ -81,6 +81,9 @@ final class BukkitCommand<C> extends org.bukkit.command.Command implements Plugi
         this.cloudCommand = cloudCommand;
         if (this.command.getOwningCommand() != null) {
             this.setPermission(this.command.getOwningCommand().getCommandPermission().toString());
+        } else {
+            final String string = this.cloudCommand.getCommandPermission().toString();
+            if (!string.isEmpty()) this.setPermission(string);
         }
         this.disabled = false;
     }


### PR DESCRIPTION
This pull request aims to fix the issue from my last pr #443
I realized what @jpenilla really meant with:
> [`permission` is allowed to be null](https://github.com/Incendo/cloud/pull/443#issuecomment-1537522935)

I added a condition, so the permission can still be null in case the permission is empty