### PR TITLE
Fix parser registry not properly resolving `TypeToken`s

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/arguments/parser/StandardParserRegistry.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/parser/StandardParserRegistry.java
@@ -42,9 +42,11 @@ import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.arguments.standard.StringArrayArgument;
 import cloud.commandframework.arguments.standard.UUIDArgument;
 import cloud.commandframework.context.CommandContext;
+import io.leangen.geantyref.AnnotatedTypeMap;
 import io.leangen.geantyref.GenericTypeReflector;
 import io.leangen.geantyref.TypeToken;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedType;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
@@ -85,7 +87,7 @@ public final class StandardParserRegistry<C> implements ParserRegistry<C> {
     };
 
     private final Map<String, Function<ParserParameters, ArgumentParser<C, ?>>> namedParsers = new HashMap<>();
-    private final Map<TypeToken<?>, Function<ParserParameters, ArgumentParser<C, ?>>> parserSuppliers = new HashMap<>();
+    private final Map<AnnotatedType, Function<ParserParameters, ArgumentParser<C, ?>>> parserSuppliers = new AnnotatedTypeMap<>();
     private final Map<Class<? extends Annotation>, BiFunction<? extends Annotation, TypeToken<?>, ParserParameters>>
             annotationMappers = new HashMap<>();
     private final Map<String, BiFunction<@NonNull CommandContext<C>, @NonNull String, @NonNull List<String>>>
@@ -190,7 +192,7 @@ public final class StandardParserRegistry<C> implements ParserRegistry<C> {
             final @NonNull Function<@NonNull ParserParameters,
                     @NonNull ArgumentParser<C, ?>> supplier
     ) {
-        this.parserSuppliers.put(type, supplier);
+        this.parserSuppliers.put(type.getAnnotatedType(), supplier);
     }
 
     @Override
@@ -243,7 +245,7 @@ public final class StandardParserRegistry<C> implements ParserRegistry<C> {
         } else {
             actualType = type;
         }
-        final Function<ParserParameters, ArgumentParser<C, ?>> producer = this.parserSuppliers.get(actualType);
+        final Function<ParserParameters, ArgumentParser<C, ?>> producer = this.parserSuppliers.get(actualType.getAnnotatedType());
         if (producer == null) {
             /* Give enums special treatment */
             if (GenericTypeReflector.isSuperType(Enum.class, actualType.getType())) {


### PR DESCRIPTION
Use `AnnotatedTypeMap` instead of `HashMap` for the parser registry, as recommended by leangen/geantyref#17

Fixes #453