### PR TITLE
Fix flags not tab-completing unless string is empty

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
@@ -41,7 +41,6 @@ import cloud.commandframework.keys.SimpleCloudKey;
 import cloud.commandframework.permission.CommandPermission;
 import cloud.commandframework.permission.OrPermission;
 import cloud.commandframework.types.tuples.Pair;
-import io.leangen.geantyref.GenericTypeReflector;
 import io.leangen.geantyref.TypeToken;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -613,10 +612,6 @@ public final class CommandTree<C> {
             if (!lastFlag.isPresent()) {
                 commandContext.remove(FlagArgument.FLAG_META_KEY);
             }
-        } else if (GenericTypeReflector.erase(child.getValue().getValueType().getType()).isArray()) {
-            while (commandQueue.size() > 1) {
-                commandQueue.remove();
-            }
         } else if (commandQueue.size() <= child.getValue().getParser().getRequestedArgumentCount()) {
             for (int i = 0; i < child.getValue().getParser().getRequestedArgumentCount() - 1
                     && commandQueue.size() > 1; i++) {
@@ -636,7 +631,7 @@ public final class CommandTree<C> {
             } else if (child.getValue() instanceof CompoundArgument) {
                 return this.directSuggestions(commandContext, child, ((LinkedList<String>) commandQueue).getLast());
             }
-        } else if (commandQueue.size() == 1 && commandQueue.peek().isEmpty()) {
+        } else if (commandQueue.size() == 1) {
             return this.directSuggestions(commandContext, child, commandQueue.peek());
         }
 

--- a/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
@@ -23,6 +23,7 @@
 //
 package cloud.commandframework;
 
+import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.compound.ArgumentTriplet;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.standard.BooleanArgument;
@@ -37,8 +38,10 @@ import cloud.commandframework.types.tuples.Triplet;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static cloud.commandframework.util.TestUtils.createManager;
@@ -634,6 +637,41 @@ public class CommandSuggestionsTest {
         assertThat(suggestions5).containsExactly("-f");
         assertThat(suggestions6).isEmpty();
     }
+
+    @Test
+    void testTextFlagCompletion() {
+        // Arrange
+        final CommandManager<TestCommandSender> manager = createManager();
+        manager.setSetting(CommandManager.ManagerSettings.LIBERAL_FLAG_PARSING, true);
+        manager.command(
+                manager.commandBuilder("command")
+                        .flag(manager.flagBuilder("flag").withAliases("f")
+                                .withArgument(EnumArgument.of(TestEnum.class, "test")).build())
+                        .flag(manager.flagBuilder("flog").build())
+        );
+
+        // Act
+        final List<String> suggestions1 = suggest(manager, "command ");
+        final List<String> suggestions2 = suggest(manager, "command --");
+        final List<String> suggestions3 = suggest(manager, "command --f");
+        final List<String> suggestions4 = suggest(manager, "command --fla");
+        final List<String> suggestions5 = suggest(manager, "command -f");
+        final List<String> suggestions6 = suggest(manager, "command -");
+
+        final List<String> suggestions7 = suggest(manager, "command -f ");
+        final List<String> suggestions8 = suggest(manager, "command -f b");
+
+        // Assert
+        assertThat(suggestions1).containsExactly("--flag", "--flog", "-f");
+        assertThat(suggestions2).containsExactly("--flag", "--flog");
+        assertThat(suggestions3).containsExactly("--flag", "--flog");
+        assertThat(suggestions4).containsExactly("--flag");
+        assertThat(suggestions5).containsExactly("-f");
+        assertThat(suggestions6).containsExactly("--flag", "--flog", "-f");
+        assertThat(suggestions7).containsExactly("foo", "bar");
+        assertThat(suggestions8).containsExactly("bar");
+    }
+
 
     private List<String> suggest(CommandManager<TestCommandSender> manager, String command) {
         return manager.suggest(new TestCommandSender(), command);


### PR DESCRIPTION
Currently trying to tab complete flag arguments only works if the string is empty, example:

`/command -f ` will work
`/command -f va` will not suggest "value" or anything else.

This is because it attempts to `parse` the value of the flag instead of trying to suggest. I'm unsure as to why the if for directSuggestions only will enter if the value is empty, when given a size of 1 you know for sure it's going to be a direct-suggest. This if was last edited by myself in #428, where i added the size == 1 condition, it apparently seems like that ==1 should be the whole condition.



#### Additionally, it solves #459 (tests were breaking otherwise).
I've removed the argument-pruning that was occurring in array types, as the tests broke the moment i modified the if. They were working out of pure luck, we remove all args except the last, then it attempts to parse the remaining `--` with the array parser (and nothing is consumed due to it being flag-yielding and the next param starting with `-`) meaning it goes to the next argument (the flag) and ends up suggesting. That stopped working when i modified the if so that the last arg is always direct parsed, as we were still in the parent param (array) not the child (flag). 

Simply deleting the code that prunes the params solves the issue properly: when there's multiple params it'll parse them normally, they'll consume until the `-` due to flag-yielding, and the child node (flags) will take it from there.

