### PR TITLE
Log cause of CommandExecutionException in fabric's default exception handler

### DIFF
--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/FabricExecutor.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/FabricExecutor.java
@@ -158,7 +158,7 @@ final class FabricExecutor<C, S extends SharedSuggestionProvider> implements Com
                         LOGGER.warn(
                                 "Error occurred while executing command for user {}:",
                                 this.getName.apply(source),
-                                throwable
+                                throwable.getCause()
                         );
                     }
             );


### PR DESCRIPTION
This is in line with the other cloud implementations.