### PR TITLE
Expose CommandPermission in NoPermissionException

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/NoPermissionException.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/NoPermissionException.java
@@ -64,6 +64,9 @@ public class NoPermissionException extends CommandParseException {
     }
 
     /**
+     * Get the missing permission node
+     *
+     * @return Get the missing permission node
      * @deprecated use {@link #missingPermission()) instead
      */
     @API(status = API.Status.DEPRECATED, since = "1.8.5")

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/NoPermissionException.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/NoPermissionException.java
@@ -64,12 +64,23 @@ public class NoPermissionException extends CommandParseException {
     }
 
     /**
-     * Get the missing permission node
-     *
-     * @return Get the missing permission node
+     * @deprecated use {@link #missingPermission()) instead
      */
+    @API(status = API.Status.DEPRECATED, since = "1.8.5")
+    @Deprecated
     public @NonNull String getMissingPermission() {
         return this.missingPermission.toString();
+    }
+
+    /**
+     * Returns the missing {@link CommandPermission}
+     *
+     * @return the missing permission
+     * @since 1.8.5
+     */
+    @API(status = API.Status.STABLE, since = "1.8.5")
+    public @NonNull CommandPermission missingPermission() {
+        return this.missingPermission;
     }
 
     @Override

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/NoPermissionException.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/NoPermissionException.java
@@ -79,7 +79,7 @@ public class NoPermissionException extends CommandParseException {
      * Returns the missing {@link CommandPermission}
      *
      * @return the missing permission
-     * @since 1.8.5
+     * @since 1.9.0
      */
     @API(status = API.Status.STABLE, since = "1.9.0")
     public @NonNull CommandPermission missingPermission() {

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/NoPermissionException.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/NoPermissionException.java
@@ -67,7 +67,7 @@ public class NoPermissionException extends CommandParseException {
      * Get the missing permission node
      *
      * @return Get the missing permission node
-     * @deprecated use {@link #missingPermission()) instead
+     * @deprecated use {@link #missingPermission()} instead
      */
     @API(status = API.Status.DEPRECATED, since = "1.8.5")
     @Deprecated

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/NoPermissionException.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/NoPermissionException.java
@@ -69,7 +69,7 @@ public class NoPermissionException extends CommandParseException {
      * @return Get the missing permission node
      * @deprecated use {@link #missingPermission()} instead
      */
-    @API(status = API.Status.DEPRECATED, since = "1.8.5")
+    @API(status = API.Status.DEPRECATED, since = "1.9.0")
     @Deprecated
     public @NonNull String getMissingPermission() {
         return this.missingPermission.toString();
@@ -81,7 +81,7 @@ public class NoPermissionException extends CommandParseException {
      * @return the missing permission
      * @since 1.8.5
      */
-    @API(status = API.Status.STABLE, since = "1.8.5")
+    @API(status = API.Status.STABLE, since = "1.9.0")
     public @NonNull CommandPermission missingPermission() {
         return this.missingPermission;
     }


### PR DESCRIPTION
Not quite sure how I feel about the new method being fluent, while the other exceptions don't use fluent getters. This seemed like the best name though given what there is to work with.