### PR TITLE
feature: move argument requirement out of CommandArgument

### DIFF
--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagExtractor.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagExtractor.java
@@ -122,7 +122,7 @@ final class FlagExtractor implements Function<@NonNull Method, Collection<@NonNu
                         parameter.getType(),
                         flagName
                 );
-                final CommandArgument.Builder argumentBuilder = argumentBuilder0.asRequired()
+                final CommandArgument.Builder argumentBuilder = argumentBuilder0
                         .manager(this.commandManager)
                         .withParser(parser);
                 final CommandArgument argument;

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/MethodCommandExecutionHandler.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/MethodCommandExecutionHandler.java
@@ -23,8 +23,8 @@
 //
 package cloud.commandframework.annotations;
 
+import cloud.commandframework.CommandComponent;
 import cloud.commandframework.annotations.injection.ParameterInjectorRegistry;
-import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.flags.FlagContext;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.CommandExecutionException;
@@ -116,8 +116,8 @@ public class MethodCommandExecutionHandler<C> implements CommandExecutionHandler
                     argumentName = this.annotationParser.processString(argument.value());
                 }
 
-                final CommandArgument<C, ?> commandArgument = this.context.commandArguments.get(argumentName);
-                if (commandArgument.isRequired()) {
+                final CommandComponent<C> commandComponent = this.context.commandComponents.get(argumentName);
+                if (commandComponent.required()) {
                     arguments.add(commandContext.get(argumentName));
                 } else {
                     final Object optional = commandContext.getOptional(argumentName).orElse(null);
@@ -207,19 +207,19 @@ public class MethodCommandExecutionHandler<C> implements CommandExecutionHandler
     public static class CommandMethodContext<C> {
 
         private final Object instance;
-        private final Map<String, CommandArgument<C, ?>> commandArguments;
+        private final Map<String, CommandComponent<C>> commandComponents;
         private final Method method;
         private final ParameterInjectorRegistry<C> injectorRegistry;
         private final AnnotationParser<C> annotationParser;
 
         CommandMethodContext(
                 final @NonNull Object instance,
-                final @NonNull Map<@NonNull String, @NonNull CommandArgument<@NonNull C, @NonNull ?>> commandArguments,
+                final @NonNull Map<@NonNull String, @NonNull CommandComponent<C>> commandComponents,
                 final @NonNull Method method,
                 final @NonNull AnnotationParser<C> annotationParser
         ) {
             this.instance = instance;
-            this.commandArguments = commandArguments;
+            this.commandComponents = commandComponents;
             this.method = method;
             this.method.setAccessible(true);
             this.injectorRegistry = annotationParser.getParameterInjectorRegistry();
@@ -250,10 +250,10 @@ public class MethodCommandExecutionHandler<C> implements CommandExecutionHandler
          * The compiled command arguments
          *
          * @return Compiled command arguments
-         * @since 1.6.0
+         * @since 2.0.0
          */
-        public final @NonNull Map<@NonNull String, @NonNull CommandArgument<C, ?>> commandArguments() {
-            return this.commandArguments;
+        public final @NonNull Map<@NonNull String, @NonNull CommandComponent<C>> commandComponents() {
+            return this.commandComponents;
         }
 
         /**

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
@@ -87,7 +87,7 @@ class AnnotationParserTest {
         /* Register a builder modifier */
         annotationParser.registerBuilderModifier(
                 IntegerArgumentInjector.class,
-                (injector, builder) -> builder.argument(IntegerArgument.of(injector.value()))
+                (injector, builder) -> builder.required(IntegerArgument.of(injector.value()))
         );
         /* Parse the class. Required for both testMethodConstruction() and testNamedSuggestionProvider() */
         commands = new ArrayList<>();
@@ -189,7 +189,7 @@ class AnnotationParserTest {
 
         // Find the root command that we are looking for.
         for (final Command<TestCommandSender> command : commands) {
-            final StaticArgument<?> argument = (StaticArgument<?>) command.getArguments().get(0);
+            final StaticArgument<?> argument = (StaticArgument<?>) command.components().get(0).argument();
 
             if (argument.getAliases().contains("acommand")) {
                 final Set<String> requiredAliases = new HashSet<>(Arrays.asList("acommand", "analias", "anotheralias"));

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/StringProcessingTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/StringProcessingTest.java
@@ -24,6 +24,7 @@
 package cloud.commandframework.annotations.feature;
 
 import cloud.commandframework.Command;
+import cloud.commandframework.CommandComponent;
 import cloud.commandframework.annotations.AnnotationParser;
 import cloud.commandframework.annotations.Argument;
 import cloud.commandframework.annotations.CommandDescription;
@@ -105,10 +106,10 @@ class StringProcessingTest {
         assertThat(command.getCommandPermission().toString()).isEqualTo(testProperty);
         assertThat(command.getCommandMeta().get(CommandMeta.DESCRIPTION)).hasValue(testProperty);
 
-        final List<CommandArgument<TestCommandSender, ?>> arguments = command.getArguments();
-        assertThat(arguments).hasSize(3);
+        final List<CommandComponent<TestCommandSender>> components = command.components();
+        assertThat(components).hasSize(3);
 
-        final FlagArgument<TestCommandSender> flagArgument = (FlagArgument<TestCommandSender>) arguments.get(2);
+        final FlagArgument<TestCommandSender> flagArgument = (FlagArgument<TestCommandSender>) components.get(2).argument();
         assertThat(flagArgument).isNotNull();
 
         final List<CommandFlag<?>> flags = new ArrayList<>(flagArgument.getFlags());

--- a/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
@@ -536,14 +536,14 @@ public abstract class CommandManager<C> {
         }
 
         // Mark the command for deletion.
-        final CommandTree.Node<@Nullable CommandArgument<C, ?>> node = this.commandTree.getNamedNode(rootCommand);
+        final CommandTree.CommandNode<C> node = this.commandTree.getNamedNode(rootCommand);
         if (node == null) {
             // If the node doesn't exist, we don't really need to delete it...
             return;
         }
 
         // The registration handler gets to act before we destruct the command.
-        this.commandRegistrationHandler.unregisterRootCommand((StaticArgument<?>) node.getValue());
+        this.commandRegistrationHandler.unregisterRootCommand((StaticArgument<?>) node.argument());
 
         // We then delete it from the tree.
         this.commandTree.deleteRecursively(node, true, this.commands::remove);
@@ -563,7 +563,7 @@ public abstract class CommandManager<C> {
     public @NonNull Collection<@NonNull String> rootCommands() {
         return this.commandTree.getRootNodes()
                 .stream()
-                .map(CommandTree.Node::getValue)
+                .map(CommandTree.CommandNode::argument)
                 .filter(arg -> arg instanceof StaticArgument)
                 .map(arg -> (StaticArgument<C>) arg)
                 .map(StaticArgument::getName)

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/CommandArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/CommandArgument.java
@@ -48,7 +48,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.returnsreceiver.qual.This;
 
 /**
- * A argument that belongs to a command
+ * An argument that belongs to a command
  *
  * @param <C> Command sender type
  * @param <T> The type that the argument parses into
@@ -67,14 +67,6 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
      */
     private final CloudKey<T> key;
     /**
-     * Indicates whether or not the argument is required
-     * or not. All arguments prior to any other required
-     * argument must also be required, such that the predicate
-     * (∀ c_i ∈ required)({c_0, ..., c_i-1} ⊂ required) holds true,
-     * where {c_0, ..., c_n-1} is the set of command arguments.
-     */
-    private final boolean required;
-    /**
      * The command argument name. This might be exposed
      * to command senders and so should be chosen carefully.
      */
@@ -84,10 +76,6 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
      * into the corresponding command type
      */
     private final ArgumentParser<C, T> parser;
-    /**
-     * Default value, will be empty if none was supplied
-     */
-    private final String defaultValue;
     /**
      * The type that is produces by the argument's parser
      */
@@ -118,10 +106,8 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
     /**
      * Construct a new command argument
      *
-     * @param required              Whether or not the argument is required
      * @param name                  The argument name
      * @param parser                The argument parser
-     * @param defaultValue          Default value used when no value is provided by the command sender
      * @param valueType             Type produced by the parser
      * @param suggestionsProvider   Suggestions provider
      * @param defaultDescription    Default description to use when registering
@@ -130,23 +116,19 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
      */
     @API(status = API.Status.STABLE, since = "1.4.0")
     public CommandArgument(
-            final boolean required,
             final @NonNull String name,
             final @NonNull ArgumentParser<C, T> parser,
-            final @NonNull String defaultValue,
             final @NonNull TypeToken<T> valueType,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>, @NonNull Queue<@NonNull String>,
                     @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
     ) {
-        this.required = required;
         this.name = Objects.requireNonNull(name, "Name may not be null");
         if (!NAME_PATTERN.asPredicate().test(name)) {
             throw new IllegalArgumentException("Name must be alphanumeric");
         }
         this.parser = Objects.requireNonNull(parser, "Parser may not be null");
-        this.defaultValue = defaultValue;
         this.valueType = valueType;
         this.suggestionsProvider = suggestionsProvider == null
                 ? buildDefaultSuggestionsProvider(this)
@@ -159,29 +141,23 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
     /**
      * Construct a new command argument
      *
-     * @param required              Whether or not the argument is required
      * @param name                  The argument name
      * @param parser                The argument parser
-     * @param defaultValue          Default value used when no value is provided by the command sender
      * @param valueType             Type produced by the parser
      * @param suggestionsProvider   Suggestions provider
      * @param argumentPreprocessors Argument preprocessors
      */
     public CommandArgument(
-            final boolean required,
             final @NonNull String name,
             final @NonNull ArgumentParser<C, T> parser,
-            final @NonNull String defaultValue,
             final @NonNull TypeToken<T> valueType,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>, @NonNull Queue<@NonNull String>,
                     @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
     ) {
         this(
-                required,
                 name,
                 parser,
-                defaultValue,
                 valueType,
                 suggestionsProvider,
                 ArgumentDescription.empty(),
@@ -192,31 +168,25 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
     /**
      * Construct a new command argument
      *
-     * @param required            Whether or not the argument is required
      * @param name                The argument name
      * @param parser              The argument parser
-     * @param defaultValue        Default value used when no value is provided by the command sender
      * @param valueType           Type produced by the parser
      * @param suggestionsProvider Suggestions provider
      */
     public CommandArgument(
-            final boolean required,
             final @NonNull String name,
             final @NonNull ArgumentParser<C, T> parser,
-            final @NonNull String defaultValue,
             final @NonNull TypeToken<T> valueType,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider
     ) {
-        this(required, name, parser, defaultValue, valueType, suggestionsProvider, Collections.emptyList());
+        this(name, parser, valueType, suggestionsProvider, Collections.emptyList());
     }
 
     /**
      * Construct a new command argument
      *
-     * @param required            Whether or not the argument is required
      * @param name                The argument name
      * @param parser              The argument parser
-     * @param defaultValue        Default value used when no value is provided by the command sender
      * @param valueType           Type produced by the parser
      * @param suggestionsProvider Suggestions provider
      * @param defaultDescription  Default description to use when registering
@@ -224,46 +194,38 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
      */
     @API(status = API.Status.STABLE, since = "1.4.0")
     public CommandArgument(
-            final boolean required,
             final @NonNull String name,
             final @NonNull ArgumentParser<C, T> parser,
-            final @NonNull String defaultValue,
             final @NonNull TypeToken<T> valueType,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        this(required, name, parser, defaultValue, valueType, suggestionsProvider, defaultDescription, Collections.emptyList());
+        this(name, parser, valueType, suggestionsProvider, defaultDescription, Collections.emptyList());
     }
 
     /**
      * Construct a new command argument
      *
-     * @param required            Whether or not the argument is required
      * @param name                The argument name
      * @param parser              The argument parser
-     * @param defaultValue        Default value used when no value is provided by the command sender
      * @param valueType           Type produced by the parser
      * @param suggestionsProvider Suggestions provider
      */
     public CommandArgument(
-            final boolean required,
             final @NonNull String name,
             final @NonNull ArgumentParser<C, T> parser,
-            final @NonNull String defaultValue,
             final @NonNull Class<T> valueType,
             final @Nullable BiFunction<@NonNull CommandContext<C>,
                     @NonNull String, @NonNull List<@NonNull String>> suggestionsProvider
     ) {
-        this(required, name, parser, defaultValue, TypeToken.get(valueType), suggestionsProvider);
+        this(name, parser, TypeToken.get(valueType), suggestionsProvider);
     }
 
     /**
      * Construct a new command argument
      *
-     * @param required            Whether or not the argument is required
      * @param name                The argument name
      * @param parser              The argument parser
-     * @param defaultValue        Default value used when no value is provided by the command sender
      * @param valueType           Type produced by the parser
      * @param suggestionsProvider Suggestions provider
      * @param defaultDescription  Default description to use when registering
@@ -271,33 +233,29 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
      */
     @API(status = API.Status.STABLE, since = "1.4.0")
     public CommandArgument(
-            final boolean required,
             final @NonNull String name,
             final @NonNull ArgumentParser<C, T> parser,
-            final @NonNull String defaultValue,
             final @NonNull Class<T> valueType,
             final @Nullable BiFunction<@NonNull CommandContext<C>,
                     @NonNull String, @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        this(required, name, parser, defaultValue, TypeToken.get(valueType), suggestionsProvider, defaultDescription);
+        this(name, parser, TypeToken.get(valueType), suggestionsProvider, defaultDescription);
     }
 
     /**
      * Construct a new command argument
      *
-     * @param required  Whether the argument is required
      * @param name      The argument name
      * @param parser    The argument parser
      * @param valueType Type produced by the parser
      */
     public CommandArgument(
-            final boolean required,
             final @NonNull String name,
             final @NonNull ArgumentParser<C, T> parser,
             final @NonNull Class<T> valueType
     ) {
-        this(required, name, parser, "", valueType, null);
+        this(name, parser, valueType, null);
     }
 
     private static <C> @NonNull BiFunction<@NonNull CommandContext<C>, @NonNull String,
@@ -340,15 +298,6 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
     @Override
     public final @NonNull CloudKey<T> getKey() {
         return this.key;
-    }
-
-    /**
-     * Check whether or not the command argument is required
-     *
-     * @return {@code true} if the argument is required, {@code false} if not
-     */
-    public boolean isRequired() {
-        return this.required;
     }
 
     /**
@@ -466,12 +415,12 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
             return false;
         }
         final CommandArgument<?, ?> that = (CommandArgument<?, ?>) o;
-        return this.isRequired() == that.isRequired() && Objects.equals(this.getName(), that.getName());
+        return Objects.equals(this.getName(), that.getName());
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hash(this.isRequired(), this.getName());
+        return Objects.hash(this.getName());
     }
 
     @Override
@@ -492,25 +441,6 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
     }
 
     /**
-     * Get the default value
-     *
-     * @return Default value
-     */
-    public @NonNull String getDefaultValue() {
-        return this.defaultValue;
-    }
-
-    /**
-     * Check if the argument has a default value
-     *
-     * @return {@code true} if the argument has a default value, {@code false} if not
-     */
-    public boolean hasDefaultValue() {
-        return !this.isRequired()
-                && !this.getDefaultValue().isEmpty();
-    }
-
-    /**
      * Get the type of this argument's value
      *
      * @return Value type
@@ -528,13 +458,6 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
         CommandArgument.Builder<C, T> builder = ofType(this.valueType, this.name);
         builder = builder.withSuggestionsProvider(this.suggestionsProvider);
         builder = builder.withParser(this.parser);
-        if (this.isRequired()) {
-            builder = builder.asRequired();
-        } else if (this.defaultValue.isEmpty()) {
-            builder = builder.asOptional();
-        } else {
-            builder = builder.asOptionalWithDefault(this.defaultValue);
-        }
         builder = builder.withDefaultDescription(this.defaultDescription);
 
         return builder.build();
@@ -570,9 +493,7 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
         private final String name;
 
         private CommandManager<C> manager;
-        private boolean required = true;
         private ArgumentParser<C, T> parser;
-        private String defaultValue = "";
         private BiFunction<@NonNull CommandContext<C>, @NonNull String, @NonNull List<String>> suggestionsProvider;
         private @NonNull ArgumentDescription defaultDescription = ArgumentDescription.empty();
 
@@ -603,50 +524,6 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
          */
         public @NonNull @This Builder<@NonNull C, @NonNull T> manager(final @NonNull CommandManager<C> manager) {
             this.manager = manager;
-            return this;
-        }
-
-        /**
-         * Indicates that the argument is required.
-         * All arguments prior to any other required
-         * argument must also be required, such that the predicate
-         * (∀ c_i ∈ required)({c_0, ..., c_i-1} ⊂ required) holds true,
-         * where {c_0, ..., c_n-1} is the set of command arguments.
-         *
-         * @return Builder instance
-         */
-        public @NonNull @This Builder<@NonNull C, @NonNull T> asRequired() {
-            this.required = true;
-            return this;
-        }
-
-        /**
-         * Indicates that the argument is optional.
-         * All arguments prior to any other required
-         * argument must also be required, such that the predicate
-         * (∀ c_i ∈ required)({c_0, ..., c_i-1} ⊂ required) holds true,
-         * where {c_0, ..., c_n-1} is the set of command arguments.
-         *
-         * @return Builder instance
-         */
-        public @NonNull @This Builder<@NonNull C, @NonNull T> asOptional() {
-            this.required = false;
-            return this;
-        }
-
-        /**
-         * Indicates that the argument is optional.
-         * All arguments prior to any other required
-         * argument must also be required, such that the predicate
-         * (∀ c_i ∈ required)({c_0, ..., c_i-1} ⊂ required) holds true,
-         * where {c_0, ..., c_n-1} is the set of command arguments.
-         *
-         * @param defaultValue Default value that will be used if none was supplied
-         * @return Builder instance
-         */
-        public @NonNull @This Builder<@NonNull C, @NonNull T> asOptionalWithDefault(final @NonNull String defaultValue) {
-            this.defaultValue = defaultValue;
-            this.required = false;
             return this;
         }
 
@@ -710,10 +587,8 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
                 this.suggestionsProvider = new DelegatingSuggestionsProvider<>(this.name, this.parser);
             }
             return new CommandArgument<>(
-                    this.required,
                     this.name,
                     this.parser,
-                    this.defaultValue,
                     this.valueType,
                     this.suggestionsProvider,
                     this.defaultDescription
@@ -724,17 +599,10 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
             return this.name;
         }
 
-        protected final boolean isRequired() {
-            return this.required;
-        }
-
         protected final @NonNull ArgumentParser<@NonNull C, @NonNull T> getParser() {
             return this.parser;
         }
 
-        protected final @NonNull String getDefaultValue() {
-            return this.defaultValue;
-        }
 
         protected final @NonNull BiFunction<@NonNull CommandContext<C>, @NonNull String, @NonNull List<String>>
         getSuggestionsProvider() {
@@ -786,33 +654,6 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
         @Override
         public @NonNull B manager(final @NonNull CommandManager<C> manager) {
             super.manager(manager);
-            return this.self();
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public @NonNull B asRequired() {
-            super.asRequired();
-            return this.self();
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public @NonNull B asOptional() {
-            super.asOptional();
-            return this.self();
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public @NonNull B asOptionalWithDefault(final @NonNull String defaultValue) {
-            super.asOptionalWithDefault(defaultValue);
             return this.self();
         }
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/CommandSyntaxFormatter.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/CommandSyntaxFormatter.java
@@ -23,6 +23,7 @@
 //
 package cloud.commandframework.arguments;
 
+import cloud.commandframework.CommandComponent;
 import cloud.commandframework.CommandTree;
 import java.util.List;
 import org.apiguardian.api.API;
@@ -41,16 +42,16 @@ public interface CommandSyntaxFormatter<C> {
     /**
      * Format the command arguments into a syntax string
      *
-     * @param commandArguments Command arguments that have been unambiguously specified up until this point. This
-     *                         should include the "current" command, if such a command exists.
-     * @param node             The current command node. The children of this node will be appended onto the
-     *                         command syntax string, as long as an unambiguous path can be identified. The node
-     *                         itself will not be appended onto the syntax string. This can be set to {@code null} if
-     *                         no node is relevant at the point of formatting.
+     * @param commandComponents Command arguments that have been unambiguously specified up until this point. This
+     *                          should include the "current" command, if such a command exists.
+     * @param node              The current command node. The children of this node will be appended onto the
+     *                          command syntax string, as long as an unambiguous path can be identified. The node
+     *                          itself will not be appended onto the syntax string. This can be set to {@code null} if
+     *                          no node is relevant at the point of formatting.
      * @return The formatted syntax string
      */
     @NonNull String apply(
-            @NonNull List<@NonNull CommandArgument<C, ?>> commandArguments,
-            CommandTree.@Nullable Node<@Nullable CommandArgument<C, ?>> node
+            @NonNull List<@NonNull CommandComponent<C>> commandComponents,
+            CommandTree.@Nullable CommandNode<C> node
     );
 }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/StaticArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/StaticArgument.java
@@ -46,8 +46,8 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 @API(status = API.Status.STABLE)
 public final class StaticArgument<C> extends CommandArgument<C, String> {
 
-    private StaticArgument(final boolean required, final @NonNull String name, final @NonNull String... aliases) {
-        super(required, name, new StaticArgumentParser<>(name, aliases), String.class);
+    private StaticArgument(final @NonNull String name, final @NonNull String... aliases) {
+        super(name, new StaticArgumentParser<>(name, aliases), String.class);
     }
 
     /**
@@ -62,7 +62,7 @@ public final class StaticArgument<C> extends CommandArgument<C, String> {
             final @NonNull String name,
             final @NonNull String... aliases
     ) {
-        return new StaticArgument<>(true, name, aliases);
+        return new StaticArgument<>(name, aliases);
     }
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/compound/ArgumentPair.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/compound/ArgumentPair.java
@@ -47,7 +47,6 @@ public class ArgumentPair<C, U, V, O> extends CompoundArgument<Pair<U, V>, C, O>
     /**
      * Create a new argument pair.
      *
-     * @param required   Whether or not the argument is required
      * @param name       The argument name
      * @param names      Names of the sub-arguments (in order)
      * @param types      Types of the sub-arguments (in order)
@@ -57,7 +56,6 @@ public class ArgumentPair<C, U, V, O> extends CompoundArgument<Pair<U, V>, C, O>
      */
     @SuppressWarnings("unchecked")
     protected ArgumentPair(
-            final boolean required,
             final @NonNull String name,
             final @NonNull Pair<@NonNull String, @NonNull String> names,
             final @NonNull Pair<@NonNull Class<U>, @NonNull Class<V>> types,
@@ -65,7 +63,7 @@ public class ArgumentPair<C, U, V, O> extends CompoundArgument<Pair<U, V>, C, O>
             final @NonNull BiFunction<@NonNull C, @NonNull Pair<@NonNull U, @NonNull V>, @NonNull O> mapper,
             final @NonNull TypeToken<O> valueType
     ) {
-        super(required, name, names, parserPair, types, mapper, o -> Pair.of((U) o[0], (V) o[1]), valueType);
+        super(name, names, parserPair, types, mapper, o -> Pair.of((U) o[0], (V) o[1]), valueType);
     }
 
     /**
@@ -103,7 +101,7 @@ public class ArgumentPair<C, U, V, O> extends CompoundArgument<Pair<U, V>, C, O>
         ).orElseThrow(() ->
                 new IllegalArgumentException(
                         "Could not create parser for secondary type"));
-        return new ArgumentPairIntermediaryBuilder<>(true, name, names, Pair.of(firstParser, secondaryParser), types);
+        return new ArgumentPairIntermediaryBuilder<>(name, names, Pair.of(firstParser, secondaryParser), types);
     }
 
 
@@ -111,21 +109,18 @@ public class ArgumentPair<C, U, V, O> extends CompoundArgument<Pair<U, V>, C, O>
     @API(status = API.Status.STABLE)
     public static final class ArgumentPairIntermediaryBuilder<C, U, V> {
 
-        private final boolean required;
         private final String name;
         private final Pair<ArgumentParser<C, U>, ArgumentParser<C, V>> parserPair;
         private final Pair<String, String> names;
         private final Pair<Class<U>, Class<V>> types;
 
         private ArgumentPairIntermediaryBuilder(
-                final boolean required,
                 final @NonNull String name,
                 final @NonNull Pair<@NonNull String, @NonNull String> names,
                 final @NonNull Pair<@NonNull ArgumentParser<@NonNull C, @NonNull U>,
                         @NonNull ArgumentParser<@NonNull C, @NonNull V>> parserPair,
                 final @NonNull Pair<@NonNull Class<U>, @NonNull Class<V>> types
         ) {
-            this.required = required;
             this.name = name;
             this.names = names;
             this.parserPair = parserPair;
@@ -139,7 +134,6 @@ public class ArgumentPair<C, U, V, O> extends CompoundArgument<Pair<U, V>, C, O>
          */
         public @NonNull ArgumentPair<@NonNull C, @NonNull U, @NonNull V, @NonNull Pair<@NonNull U, @NonNull V>> simple() {
             return new ArgumentPair<C, U, V, Pair<U, V>>(
-                    this.required,
                     this.name,
                     this.names,
                     this.types,
@@ -163,7 +157,7 @@ public class ArgumentPair<C, U, V, O> extends CompoundArgument<Pair<U, V>, C, O>
                 final @NonNull BiFunction<@NonNull C, @NonNull Pair<@NonNull U,
                         @NonNull V>, @NonNull O> mapper
         ) {
-            return new ArgumentPair<C, U, V, O>(this.required, this.name, this.names, this.types, this.parserPair, mapper, clazz);
+            return new ArgumentPair<C, U, V, O>(this.name, this.names, this.types, this.parserPair, mapper, clazz);
         }
 
         /**

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/compound/ArgumentTriplet.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/compound/ArgumentTriplet.java
@@ -48,7 +48,6 @@ public class ArgumentTriplet<C, U, V, W, O> extends CompoundArgument<Triplet<U, 
     /**
      * Create a new argument triplet.
      *
-     * @param required      Whether or not the argument is required
      * @param name          The argument name
      * @param names         Names of the sub-arguments (in order)
      * @param types         Types of the sub-arguments (in order)
@@ -58,7 +57,6 @@ public class ArgumentTriplet<C, U, V, W, O> extends CompoundArgument<Triplet<U, 
      */
     @SuppressWarnings("unchecked")
     protected ArgumentTriplet(
-            final boolean required,
             final @NonNull String name,
             final @NonNull Triplet<@NonNull String, @NonNull String, @NonNull String> names,
             final @NonNull Triplet<@NonNull Class<U>, @NonNull Class<V>, @NonNull Class<W>> types,
@@ -68,7 +66,7 @@ public class ArgumentTriplet<C, U, V, W, O> extends CompoundArgument<Triplet<U, 
                     @NonNull Triplet<U, @NonNull V, @NonNull W>, @NonNull O> mapper,
             final @NonNull TypeToken<O> valueType
     ) {
-        super(required, name, names, parserTriplet, types, mapper, o -> Triplet.of((U) o[0], (V) o[1], (W) o[2]), valueType);
+        super(name, names, parserTriplet, types, mapper, o -> Triplet.of((U) o[0], (V) o[1], (W) o[2]), valueType);
     }
 
     /**
@@ -112,7 +110,7 @@ public class ArgumentTriplet<C, U, V, W, O> extends CompoundArgument<Triplet<U, 
         ).orElseThrow(() ->
                 new IllegalArgumentException(
                         "Could not create parser for tertiary type"));
-        return new ArgumentTripletIntermediaryBuilder<>(true, name, names,
+        return new ArgumentTripletIntermediaryBuilder<>(name, names,
                 Triplet.of(firstParser, secondaryParser, tertiaryParser), types
         );
     }
@@ -122,14 +120,12 @@ public class ArgumentTriplet<C, U, V, W, O> extends CompoundArgument<Triplet<U, 
     @API(status = API.Status.STABLE)
     public static final class ArgumentTripletIntermediaryBuilder<C, U, V, W> {
 
-        private final boolean required;
         private final String name;
         private final Triplet<ArgumentParser<C, U>, ArgumentParser<C, V>, ArgumentParser<C, W>> parserTriplet;
         private final Triplet<String, String, String> names;
         private final Triplet<Class<U>, Class<V>, Class<W>> types;
 
         private ArgumentTripletIntermediaryBuilder(
-                final boolean required,
                 final @NonNull String name,
                 final @NonNull Triplet<@NonNull String, @NonNull String,
                         @NonNull String> names,
@@ -139,7 +135,6 @@ public class ArgumentTriplet<C, U, V, W, O> extends CompoundArgument<Triplet<U, 
                 final @NonNull Triplet<@NonNull Class<U>,
                         @NonNull Class<V>, @NonNull Class<W>> types
         ) {
-            this.required = required;
             this.name = name;
             this.names = names;
             this.parserTriplet = parserTriplet;
@@ -154,7 +149,6 @@ public class ArgumentTriplet<C, U, V, W, O> extends CompoundArgument<Triplet<U, 
         public @NonNull ArgumentTriplet<@NonNull C, @NonNull U, @NonNull V,
                 @NonNull W, Triplet<U, V, W>> simple() {
             return new ArgumentTriplet<>(
-                    this.required,
                     this.name,
                     this.names,
                     this.types,
@@ -179,7 +173,7 @@ public class ArgumentTriplet<C, U, V, W, O> extends CompoundArgument<Triplet<U, 
                 final @NonNull BiFunction<@NonNull C, @NonNull Triplet<@NonNull U,
                         @NonNull V, @NonNull W>, @NonNull O> mapper
         ) {
-            return new ArgumentTriplet<>(this.required, this.name, this.names, this.types, this.parserTriplet, mapper, clazz);
+            return new ArgumentTriplet<>(this.name, this.names, this.types, this.parserTriplet, mapper, clazz);
         }
 
         /**
@@ -196,7 +190,7 @@ public class ArgumentTriplet<C, U, V, W, O> extends CompoundArgument<Triplet<U, 
                         @NonNull U, @NonNull V, @NonNull W>,
                         @NonNull O> mapper
         ) {
-            return new ArgumentTriplet<>(this.required, this.name, this.names, this.types,
+            return new ArgumentTriplet<>(this.name, this.names, this.types,
                     this.parserTriplet, mapper, TypeToken.get(clazz)
             );
         }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/compound/CompoundArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/compound/CompoundArgument.java
@@ -53,7 +53,6 @@ public class CompoundArgument<T extends Tuple, C, O> extends CommandArgument<C, 
     /**
      * Construct a Compound Argument
      *
-     * @param required     Whether or not the argument is required
      * @param name         The argument name
      * @param names        Names of the sub-arguments (in order)
      * @param parserTuple  The sub arguments
@@ -63,7 +62,6 @@ public class CompoundArgument<T extends Tuple, C, O> extends CommandArgument<C, 
      * @param valueType    The output type
      */
     public CompoundArgument(
-            final boolean required,
             final @NonNull String name,
             final @NonNull Tuple names,
             final @NonNull Tuple parserTuple,
@@ -73,10 +71,8 @@ public class CompoundArgument<T extends Tuple, C, O> extends CommandArgument<C, 
             final @NonNull TypeToken<O> valueType
     ) {
         super(
-                required,
                 name,
                 new CompoundParser<>(parserTuple, mapper, tupleFactory),
-                "",
                 valueType,
                 null
         );

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/compound/FlagArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/compound/FlagArgument.java
@@ -98,7 +98,6 @@ public final class FlagArgument<C> extends CommandArgument<C, Object> {
      */
     public FlagArgument(final Collection<CommandFlag<?>> flags) {
         super(
-                false,
                 FLAG_ARGUMENT_NAME,
                 new FlagArgumentParser<>(flags.toArray(new CommandFlag<?>[0])),
                 Object.class

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/BooleanArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/BooleanArgument.java
@@ -51,15 +51,13 @@ public final class BooleanArgument<C> extends CommandArgument<C, Boolean> {
     private final boolean liberal;
 
     private BooleanArgument(
-            final boolean required,
             final @NonNull String name,
             final boolean liberal,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription description
     ) {
-        super(required, name, new BooleanParser<>(liberal), defaultValue, Boolean.class, suggestionsProvider, description);
+        super(name, new BooleanParser<>(liberal), Boolean.class, suggestionsProvider, description);
         this.liberal = liberal;
     }
 
@@ -98,33 +96,7 @@ public final class BooleanArgument<C> extends CommandArgument<C, Boolean> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Boolean> of(final @NonNull String name) {
-        return BooleanArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional command argument
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, Boolean> optional(final @NonNull String name) {
-        return BooleanArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new required command argument with a default value
-     *
-     * @param name           Argument name
-     * @param defaultBoolean Default num
-     * @param <C>            Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, Boolean> optional(
-            final @NonNull String name,
-            final boolean defaultBoolean
-    ) {
-        return BooleanArgument.<C>builder(name).asOptionalWithDefault(Boolean.toString(defaultBoolean)).build();
+        return BooleanArgument.<C>builder(name).build();
     }
 
     /**
@@ -165,10 +137,8 @@ public final class BooleanArgument<C> extends CommandArgument<C, Boolean> {
         @Override
         public @NonNull BooleanArgument<C> build() {
             return new BooleanArgument<>(
-                    this.isRequired(),
                     this.getName(),
                     this.liberal,
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ByteArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ByteArgument.java
@@ -47,16 +47,14 @@ public final class ByteArgument<C> extends CommandArgument<C, Byte> {
     private final byte max;
 
     private ByteArgument(
-            final boolean required,
             final @NonNull String name,
             final byte min,
             final byte max,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(required, name, new ByteParser<>(min, max), defaultValue, Byte.class, suggestionsProvider, defaultDescription);
+        super(name, new ByteParser<>(min, max), Byte.class, suggestionsProvider, defaultDescription);
         this.min = min;
         this.max = max;
     }
@@ -96,48 +94,22 @@ public final class ByteArgument<C> extends CommandArgument<C, Byte> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Byte> of(final @NonNull String name) {
-        return ByteArgument.<C>builder(name).asRequired().build();
+        return ByteArgument.<C>builder(name).build();
     }
 
     /**
-     * Create a new optional {@link ByteArgument}.
+     * Get the minimum accepted byte that could have been parsed
      *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, Byte> optional(final @NonNull String name) {
-        return ByteArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link ByteArgument} with the specified default value.
-     *
-     * @param name       Argument name
-     * @param defaultNum Default num
-     * @param <C>        Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, Byte> optional(
-            final @NonNull String name,
-            final byte defaultNum
-    ) {
-        return ByteArgument.<C>builder(name).asOptionalWithDefault(defaultNum).build();
-    }
-
-    /**
-     * Get the minimum accepted byteeger that could have been parsed
-     *
-     * @return Minimum byteeger
+     * @return Minimum byte
      */
     public byte getMin() {
         return this.min;
     }
 
     /**
-     * Get the maximum accepted byteeger that could have been parsed
+     * Get the maximum accepted byte that could have been parsed
      *
-     * @return Maximum byteeger
+     * @return Maximum byte
      */
     public byte getMax() {
         return this.max;
@@ -177,28 +149,13 @@ public final class ByteArgument<C> extends CommandArgument<C, Byte> {
         }
 
         /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        @API(status = API.Status.STABLE, since = "1.5.0")
-        public @NonNull Builder<C> asOptionalWithDefault(final byte defaultValue) {
-            return (Builder<C>) this.asOptionalWithDefault(Byte.toString(defaultValue));
-        }
-
-        /**
          * Builder a new byte argument
          *
          * @return Constructed argument
          */
         @Override
         public @NonNull ByteArgument<C> build() {
-            return new ByteArgument<>(this.isRequired(), this.getName(), this.min, this.max,
-                    this.getDefaultValue(), this.getSuggestionsProvider(), this.getDefaultDescription()
-            );
+            return new ByteArgument<>(this.getName(), this.min, this.max, this.getSuggestionsProvider(), this.getDefaultDescription());
         }
     }
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/CharArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/CharArgument.java
@@ -45,14 +45,12 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class CharArgument<C> extends CommandArgument<C, Character> {
 
     private CharArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>,
                     @NonNull String, @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(required, name, new CharacterParser<>(), defaultValue, Character.class, suggestionsProvider, defaultDescription);
+        super(name, new CharacterParser<>(), Character.class, suggestionsProvider, defaultDescription);
     }
 
     /**
@@ -90,33 +88,7 @@ public final class CharArgument<C> extends CommandArgument<C, Character> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Character> of(final @NonNull String name) {
-        return CharArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional command argument
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, Character> optional(final @NonNull String name) {
-        return CharArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new required command argument with a default value
-     *
-     * @param name       Argument name
-     * @param defaultNum Default num
-     * @param <C>        Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, Character> optional(
-            final @NonNull String name,
-            final @NonNull String defaultNum
-    ) {
-        return CharArgument.<C>builder(name).asOptionalWithDefault(defaultNum).build();
+        return CharArgument.<C>builder(name).build();
     }
 
 
@@ -134,9 +106,7 @@ public final class CharArgument<C> extends CommandArgument<C, Character> {
          */
         @Override
         public @NonNull CharArgument<C> build() {
-            return new CharArgument<>(this.isRequired(), this.getName(),
-                    this.getDefaultValue(), this.getSuggestionsProvider(), this.getDefaultDescription()
-            );
+            return new CharArgument<>(this.getName(), this.getSuggestionsProvider(), this.getDefaultDescription());
         }
     }
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DoubleArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DoubleArgument.java
@@ -47,16 +47,14 @@ public final class DoubleArgument<C> extends CommandArgument<C, Double> {
     private final double max;
 
     private DoubleArgument(
-            final boolean required,
             final @NonNull String name,
             final double min,
             final double max,
-            final String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(required, name, new DoubleParser<>(min, max), defaultValue, Double.class, suggestionsProvider, defaultDescription);
+        super(name, new DoubleParser<>(min, max), Double.class, suggestionsProvider, defaultDescription);
         this.min = min;
         this.max = max;
     }
@@ -96,33 +94,7 @@ public final class DoubleArgument<C> extends CommandArgument<C, Double> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Double> of(final @NonNull String name) {
-        return DoubleArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link DoubleArgument}.
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, Double> optional(final @NonNull String name) {
-        return DoubleArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link DoubleArgument} with the specified default value.
-     *
-     * @param name       Argument name
-     * @param defaultNum Default num
-     * @param <C>        Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, Double> optional(
-            final @NonNull String name,
-            final double defaultNum
-    ) {
-        return DoubleArgument.<C>builder(name).asOptionalWithDefault(defaultNum).build();
+        return DoubleArgument.<C>builder(name).build();
     }
 
     /**
@@ -177,27 +149,18 @@ public final class DoubleArgument<C> extends CommandArgument<C, Double> {
         }
 
         /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        @API(status = API.Status.STABLE, since = "1.5.0")
-        public @NonNull Builder<C> asOptionalWithDefault(final double defaultValue) {
-            return (Builder<C>) this.asOptionalWithDefault(Double.toString(defaultValue));
-        }
-
-        /**
          * Builder a new double argument
          *
          * @return Constructed argument
          */
         @Override
         public @NonNull DoubleArgument<C> build() {
-            return new DoubleArgument<>(this.isRequired(), this.getName(), this.min, this.max,
-                    this.getDefaultValue(), this.getSuggestionsProvider(), this.getDefaultDescription()
+            return new DoubleArgument<>(
+                    this.getName(),
+                    this.min,
+                    this.max,
+                    this.getSuggestionsProvider(),
+                    this.getDefaultDescription()
             );
         }
     }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DurationArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DurationArgument.java
@@ -62,18 +62,14 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
     private static final Pattern DURATION_PATTERN = Pattern.compile("(([1-9][0-9]+|[1-9])[dhms])");
 
     private DurationArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 new Parser<>(),
-                defaultValue,
                 Duration.class,
                 suggestionsProvider,
                 defaultDescription
@@ -101,51 +97,7 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
      * @since 1.7.0
      */
     public static <C> @NonNull DurationArgument<C> of(final @NonNull String name) {
-        return DurationArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link DurationArgument}.
-     *
-     * @param name argument name
-     * @param <C>  sender type
-     * @return built argument
-     * @since 1.7.0
-     */
-    public static <C> @NonNull DurationArgument<C> optional(final @NonNull String name) {
-        return DurationArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link DurationArgument} with the specified default value.
-     *
-     * @param name            argument name
-     * @param defaultDuration default duration
-     * @param <C>             sender type
-     * @return built argument
-     * @since 1.7.0
-     */
-    public static <C> @NonNull DurationArgument<C> optional(
-            final @NonNull String name,
-            final @NonNull String defaultDuration
-    ) {
-        return DurationArgument.<C>builder(name).asOptionalWithDefault(defaultDuration).build();
-    }
-
-    /**
-     * Create a new optional {@link DurationArgument} with the specified default value.
-     *
-     * @param name            argument name
-     * @param defaultDuration default duration
-     * @param <C>             sender type
-     * @return built argument
-     * @since 1.7.0
-     */
-    public static <C> @NonNull DurationArgument<C> optional(
-            final @NonNull String name,
-            final @NonNull Duration defaultDuration
-    ) {
-        return DurationArgument.<C>builder(name).asOptionalWithDefault(defaultDuration).build();
+        return DurationArgument.<C>builder(name).build();
     }
 
 
@@ -163,18 +115,6 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
         }
 
         /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.7.0
-         */
-        public @NonNull Builder<C> asOptionalWithDefault(final @NonNull Duration defaultValue) {
-            return this.asOptionalWithDefault(defaultValue.getSeconds() + "s");
-        }
-
-        /**
          * Create a new {@link DurationArgument} from this builder.
          *
          * @return built argument
@@ -183,9 +123,7 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
         @Override
         public @NonNull DurationArgument<C> build() {
             return new DurationArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/EnumArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/EnumArgument.java
@@ -54,14 +54,12 @@ public class EnumArgument<C, E extends Enum<E>> extends CommandArgument<C, E> {
 
     protected EnumArgument(
             final @NonNull Class<E> enumClass,
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(required, name, new EnumParser<>(enumClass), defaultValue, enumClass, suggestionsProvider, defaultDescription);
+        super(name, new EnumParser<>(enumClass), enumClass, suggestionsProvider, defaultDescription);
     }
 
     /**
@@ -114,41 +112,7 @@ public class EnumArgument<C, E extends Enum<E>> extends CommandArgument<C, E> {
             final @NonNull Class<E> enumClass,
             final @NonNull String name
     ) {
-        return EnumArgument.<C, E>builder(enumClass, name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional command argument
-     *
-     * @param enumClass Enum class
-     * @param name      Name of the argument
-     * @param <C>       Command sender type
-     * @param <E>       Enum type
-     * @return Created argument
-     */
-    public static <C, E extends Enum<E>> @NonNull CommandArgument<C, E> optional(
-            final @NonNull Class<E> enumClass,
-            final @NonNull String name
-    ) {
-        return EnumArgument.<C, E>builder(enumClass, name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional command argument with a default value
-     *
-     * @param enumClass    Enum class
-     * @param name         Name of the argument
-     * @param defaultValue Default value
-     * @param <C>          Command sender type
-     * @param <E>          Enum type
-     * @return Created argument
-     */
-    public static <C, E extends Enum<E>> @NonNull CommandArgument<C, E> optional(
-            final @NonNull Class<E> enumClass,
-            final @NonNull String name,
-            final @NonNull E defaultValue
-    ) {
-        return EnumArgument.<C, E>builder(enumClass, name).asOptionalWithDefault(defaultValue.name().toLowerCase()).build();
+        return EnumArgument.<C, E>builder(enumClass, name).build();
     }
 
 
@@ -164,9 +128,7 @@ public class EnumArgument<C, E extends Enum<E>> extends CommandArgument<C, E> {
 
         @Override
         public @NonNull CommandArgument<C, E> build() {
-            return new EnumArgument<>(this.enumClass, this.isRequired(), this.getName(),
-                    this.getDefaultValue(), this.getSuggestionsProvider(), this.getDefaultDescription()
-            );
+            return new EnumArgument<>(this.enumClass, this.getName(), this.getSuggestionsProvider(), this.getDefaultDescription());
         }
     }
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/FloatArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/FloatArgument.java
@@ -47,16 +47,14 @@ public final class FloatArgument<C> extends CommandArgument<C, Float> {
     private final float max;
 
     private FloatArgument(
-            final boolean required,
             final @NonNull String name,
             final float min,
             final float max,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>,
                     @NonNull String, @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(required, name, new FloatParser<>(min, max), defaultValue, Float.class, suggestionsProvider, defaultDescription);
+        super(name, new FloatParser<>(min, max), Float.class, suggestionsProvider, defaultDescription);
         this.min = min;
         this.max = max;
     }
@@ -96,33 +94,7 @@ public final class FloatArgument<C> extends CommandArgument<C, Float> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Float> of(final @NonNull String name) {
-        return FloatArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link FloatArgument}.
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, Float> optional(final @NonNull String name) {
-        return FloatArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link FloatArgument} with the specified default value.
-     *
-     * @param name       Argument name
-     * @param defaultNum Default num
-     * @param <C>        Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, Float> optional(
-            final @NonNull String name,
-            final float defaultNum
-    ) {
-        return FloatArgument.<C>builder(name).asOptionalWithDefault(defaultNum).build();
+        return FloatArgument.<C>builder(name).build();
     }
 
     /**
@@ -176,23 +148,14 @@ public final class FloatArgument<C> extends CommandArgument<C, Float> {
             return this;
         }
 
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        @API(status = API.Status.STABLE, since = "1.5.0")
-        public @NonNull Builder<C> asOptionalWithDefault(final float defaultValue) {
-            return (Builder<C>) this.asOptionalWithDefault(Float.toString(defaultValue));
-        }
-
         @Override
         public @NonNull FloatArgument<C> build() {
-            return new FloatArgument<>(this.isRequired(), this.getName(), this.min, this.max,
-                    this.getDefaultValue(), this.getSuggestionsProvider(), this.getDefaultDescription()
+            return new FloatArgument<>(
+                    this.getName(),
+                    this.min,
+                    this.max,
+                    this.getSuggestionsProvider(),
+                    this.getDefaultDescription()
             );
         }
     }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/IntegerArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/IntegerArgument.java
@@ -54,20 +54,16 @@ public final class IntegerArgument<C> extends CommandArgument<C, Integer> {
     private final int max;
 
     private IntegerArgument(
-            final boolean required,
             final @NonNull String name,
             final int min,
             final int max,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 new IntegerParser<>(min, max),
-                defaultValue,
                 Integer.class,
                 suggestionsProvider,
                 defaultDescription
@@ -111,30 +107,7 @@ public final class IntegerArgument<C> extends CommandArgument<C, Integer> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Integer> of(final @NonNull String name) {
-        return IntegerArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link IntegerArgument}.
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, Integer> optional(final @NonNull String name) {
-        return IntegerArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new required {@link IntegerArgument} with the specified default value.
-     *
-     * @param name       Argument name
-     * @param defaultNum Default value
-     * @param <C>        Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, Integer> optional(final @NonNull String name, final int defaultNum) {
-        return IntegerArgument.<C>builder(name).asOptionalWithDefault(defaultNum).build();
+        return IntegerArgument.<C>builder(name).build();
     }
 
     /**
@@ -188,23 +161,10 @@ public final class IntegerArgument<C> extends CommandArgument<C, Integer> {
             return this;
         }
 
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        @API(status = API.Status.STABLE, since = "1.5.0")
-        public @NonNull Builder<C> asOptionalWithDefault(final int defaultValue) {
-            return (Builder<C>) this.asOptionalWithDefault(Integer.toString(defaultValue));
-        }
-
         @Override
         public @NonNull IntegerArgument<C> build() {
-            return new IntegerArgument<>(this.isRequired(), this.getName(), this.min, this.max,
-                    this.getDefaultValue(), this.getSuggestionsProvider(), this.getDefaultDescription()
+            return new IntegerArgument<>(this.getName(), this.min, this.max,
+                    this.getSuggestionsProvider(), this.getDefaultDescription()
             );
         }
     }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/LongArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/LongArgument.java
@@ -47,16 +47,14 @@ public final class LongArgument<C> extends CommandArgument<C, Long> {
     private final long max;
 
     private LongArgument(
-            final boolean required,
             final @NonNull String name,
             final long min,
             final long max,
-            final String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(required, name, new LongParser<>(min, max), defaultValue, Long.class, suggestionsProvider, defaultDescription);
+        super(name, new LongParser<>(min, max), Long.class, suggestionsProvider, defaultDescription);
         this.min = min;
         this.max = max;
     }
@@ -96,33 +94,7 @@ public final class LongArgument<C> extends CommandArgument<C, Long> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Long> of(final @NonNull String name) {
-        return LongArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link LongArgument}.
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, Long> optional(final @NonNull String name) {
-        return LongArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link LongArgument} with the specified default value.
-     *
-     * @param name       Argument name
-     * @param defaultNum Default num
-     * @param <C>        Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, Long> optional(
-            final @NonNull String name,
-            final long defaultNum
-    ) {
-        return LongArgument.<C>builder(name).asOptionalWithDefault(defaultNum).build();
+        return LongArgument.<C>builder(name).build();
     }
 
     /**
@@ -176,23 +148,10 @@ public final class LongArgument<C> extends CommandArgument<C, Long> {
             return this;
         }
 
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        @API(status = API.Status.STABLE, since = "1.5.0")
-        public @NonNull Builder<C> asOptionalWithDefault(final long defaultValue) {
-            return (Builder<C>) this.asOptionalWithDefault(Long.toString(defaultValue));
-        }
-
         @Override
         public @NonNull LongArgument<C> build() {
-            return new LongArgument<>(this.isRequired(), this.getName(), this.min,
-                    this.max, this.getDefaultValue(), this.getSuggestionsProvider(), this.getDefaultDescription()
+            return new LongArgument<>(this.getName(), this.min,
+                    this.max, this.getSuggestionsProvider(), this.getDefaultDescription()
             );
         }
     }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ShortArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ShortArgument.java
@@ -47,16 +47,14 @@ public final class ShortArgument<C> extends CommandArgument<C, Short> {
     private final short max;
 
     private ShortArgument(
-            final boolean required,
             final @NonNull String name,
             final short min,
             final short max,
-            final String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(required, name, new ShortParser<>(min, max), defaultValue, Short.class, suggestionsProvider, defaultDescription);
+        super(name, new ShortParser<>(min, max), Short.class, suggestionsProvider, defaultDescription);
         this.min = min;
         this.max = max;
     }
@@ -96,30 +94,7 @@ public final class ShortArgument<C> extends CommandArgument<C, Short> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Short> of(final @NonNull String name) {
-        return ShortArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link ShortArgument}.
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, Short> optional(final @NonNull String name) {
-        return ShortArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new required {@link ShortArgument} with the specified default value.
-     *
-     * @param name       Argument name
-     * @param defaultNum Default value
-     * @param <C>        Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, Short> optional(final @NonNull String name, final short defaultNum) {
-        return ShortArgument.<C>builder(name).asOptionalWithDefault(defaultNum).build();
+        return ShortArgument.<C>builder(name).build();
     }
 
     /**
@@ -173,23 +148,10 @@ public final class ShortArgument<C> extends CommandArgument<C, Short> {
             return this;
         }
 
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        @API(status = API.Status.STABLE, since = "1.5.0")
-        public @NonNull Builder<C> asOptionalWithDefault(final short defaultValue) {
-            return (Builder<C>) this.asOptionalWithDefault(Short.toString(defaultValue));
-        }
-
         @Override
         public @NonNull ShortArgument<C> build() {
-            return new ShortArgument<>(this.isRequired(), this.getName(), this.min, this.max,
-                    this.getDefaultValue(), this.getSuggestionsProvider(), this.getDefaultDescription()
+            return new ShortArgument<>(this.getName(), this.min, this.max,
+                    this.getSuggestionsProvider(), this.getDefaultDescription()
             );
         }
     }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringArgument.java
@@ -54,16 +54,14 @@ public final class StringArgument<C> extends CommandArgument<C, String> {
     private final StringMode stringMode;
 
     private StringArgument(
-            final boolean required,
             final @NonNull String name,
             final @NonNull StringMode stringMode,
-            final @NonNull String defaultValue,
             final @NonNull BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(required, name, new StringParser<>(stringMode, suggestionsProvider),
-                defaultValue, String.class, suggestionsProvider, defaultDescription
+        super(name, new StringParser<>(stringMode, suggestionsProvider),
+                String.class, suggestionsProvider, defaultDescription
         );
         this.stringMode = stringMode;
     }
@@ -103,7 +101,7 @@ public final class StringArgument<C> extends CommandArgument<C, String> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, String> of(final @NonNull String name) {
-        return StringArgument.<C>builder(name).single().asRequired().build();
+        return StringArgument.<C>builder(name).single().build();
     }
 
     /**
@@ -118,48 +116,7 @@ public final class StringArgument<C> extends CommandArgument<C, String> {
             final @NonNull String name,
             final @NonNull StringMode stringMode
     ) {
-        return StringArgument.<C>builder(name).withMode(stringMode).asRequired().build();
-    }
-
-    /**
-     * Create a new optional single string command argument
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, String> optional(final @NonNull String name) {
-        return StringArgument.<C>builder(name).single().asOptional().build();
-    }
-
-    /**
-     * Create a new optional command argument
-     *
-     * @param name       Argument name
-     * @param stringMode String mode
-     * @param <C>        Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, String> optional(
-            final @NonNull String name,
-            final @NonNull StringMode stringMode
-    ) {
-        return StringArgument.<C>builder(name).withMode(stringMode).asOptional().build();
-    }
-
-    /**
-     * Create a new required command argument with a default value
-     *
-     * @param name          Argument name
-     * @param defaultString Default string
-     * @param <C>           Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, String> optional(
-            final @NonNull String name,
-            final @NonNull String defaultString
-    ) {
-        return StringArgument.<C>builder(name).asOptionalWithDefault(defaultString).build();
+        return StringArgument.<C>builder(name).withMode(stringMode).build();
     }
 
     /**
@@ -318,8 +275,8 @@ public final class StringArgument<C> extends CommandArgument<C, String> {
          */
         @Override
         public @NonNull StringArgument<C> build() {
-            return new StringArgument<>(this.isRequired(), this.getName(), this.stringMode,
-                    this.getDefaultValue(), this.suggestionsProvider, this.getDefaultDescription()
+            return new StringArgument<>(this.getName(), this.stringMode,
+                    this.suggestionsProvider, this.getDefaultDescription()
             );
         }
     }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringArrayArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringArrayArgument.java
@@ -49,17 +49,14 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class StringArrayArgument<C> extends CommandArgument<C, String[]> {
 
     private StringArrayArgument(
-            final boolean required,
             final @NonNull String name,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final boolean flagYielding
     ) {
         super(
-                required,
                 name,
                 new StringArrayParser<>(flagYielding),
-                "",
                 TypeToken.get(String[].class),
                 suggestionsProvider,
                 defaultDescription
@@ -79,7 +76,6 @@ public final class StringArrayArgument<C> extends CommandArgument<C, String[]> {
             final @NonNull BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider
     ) {
         return new StringArrayArgument<>(
-                true /* required */,
                 name,
                 suggestionsProvider,
                 ArgumentDescription.empty(),
@@ -104,53 +100,6 @@ public final class StringArrayArgument<C> extends CommandArgument<C, String[]> {
             final @NonNull BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider
     ) {
         return new StringArrayArgument<>(
-                true /* required */,
-                name,
-                suggestionsProvider,
-                ArgumentDescription.empty(),
-                flagYielding
-        );
-    }
-
-    /**
-     * Create a new optional string array argument
-     *
-     * @param name                Argument name
-     * @param suggestionsProvider Suggestions provider
-     * @param <C>                 Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull StringArrayArgument<C> optional(
-            final @NonNull String name,
-            final @NonNull BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider
-    ) {
-        return new StringArrayArgument<>(
-                false /* required */,
-                name,
-                suggestionsProvider,
-                ArgumentDescription.empty(),
-                false /* flagYielding */
-        );
-    }
-
-    /**
-     * Create a new optional string array argument
-     *
-     * @param name                Argument name
-     * @param flagYielding        Whether the parser should stop parsing when encountering a potential flag
-     * @param suggestionsProvider Suggestions provider
-     * @param <C>                 Command sender type
-     * @return Created argument
-     * @since 1.7.0
-     */
-    @API(status = API.Status.STABLE, since = "1.7.0")
-    public static <C> @NonNull StringArrayArgument<C> optional(
-            final @NonNull String name,
-            final boolean flagYielding,
-            final @NonNull BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider
-    ) {
-        return new StringArrayArgument<>(
-                false /* required */,
                 name,
                 suggestionsProvider,
                 ArgumentDescription.empty(),

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/UUIDArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/UUIDArgument.java
@@ -46,14 +46,12 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class UUIDArgument<C> extends CommandArgument<C, UUID> {
 
     private UUIDArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>,
                     @NonNull String, @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(required, name, new UUIDParser<>(), defaultValue, UUID.class, suggestionsProvider, defaultDescription);
+        super(name, new UUIDParser<>(), UUID.class, suggestionsProvider, defaultDescription);
     }
 
     /**
@@ -91,33 +89,7 @@ public final class UUIDArgument<C> extends CommandArgument<C, UUID> {
      * @return Created component
      */
     public static <C> @NonNull CommandArgument<C, UUID> of(final @NonNull String name) {
-        return UUIDArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional command component
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created component
-     */
-    public static <C> @NonNull CommandArgument<C, UUID> optional(final @NonNull String name) {
-        return UUIDArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new required command component with a default value
-     *
-     * @param name        Component name
-     * @param defaultUUID Default uuid
-     * @param <C>         Command sender type
-     * @return Created component
-     */
-    public static <C> @NonNull CommandArgument<C, UUID> optional(
-            final @NonNull String name,
-            final @NonNull UUID defaultUUID
-    ) {
-        return UUIDArgument.<C>builder(name).asOptionalWithDefault(defaultUUID.toString()).build();
+        return UUIDArgument.<C>builder(name).build();
     }
 
 
@@ -136,9 +108,7 @@ public final class UUIDArgument<C> extends CommandArgument<C, UUID> {
         @Override
         public @NonNull UUIDArgument<C> build() {
             return new UUIDArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/ArgumentParseException.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/ArgumentParseException.java
@@ -23,7 +23,7 @@
 //
 package cloud.commandframework.exceptions;
 
-import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.CommandComponent;
 import java.util.List;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -45,7 +45,7 @@ public class ArgumentParseException extends CommandParseException {
     public ArgumentParseException(
             final @NonNull Throwable throwable,
             final @NonNull Object commandSender,
-            final @NonNull List<@NonNull CommandArgument<?, ?>> currentChain
+            final @NonNull List<@NonNull CommandComponent<?>> currentChain
     ) {
         super(commandSender, currentChain);
         this.cause = throwable;

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/CommandParseException.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/CommandParseException.java
@@ -23,7 +23,7 @@
 //
 package cloud.commandframework.exceptions;
 
-import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.CommandComponent;
 import java.util.Collections;
 import java.util.List;
 import org.apiguardian.api.API;
@@ -38,7 +38,7 @@ public class CommandParseException extends IllegalArgumentException {
 
     private static final long serialVersionUID = -2415981126382517435L;
     private final Object commandSender;
-    private final List<CommandArgument<?, ?>> currentChain;
+    private final List<CommandComponent<?>> currentChain;
 
     /**
      * Construct a new command parse exception
@@ -49,7 +49,7 @@ public class CommandParseException extends IllegalArgumentException {
     @API(status = API.Status.INTERNAL, consumers = "cloud.commandframework.*")
     protected CommandParseException(
             final @NonNull Object commandSender,
-            final @NonNull List<CommandArgument<?, ?>> currentChain
+            final @NonNull List<CommandComponent<?>> currentChain
     ) {
         this.commandSender = commandSender;
         this.currentChain = currentChain;
@@ -69,7 +69,7 @@ public class CommandParseException extends IllegalArgumentException {
      *
      * @return Unmodifiable list of command arguments
      */
-    public @NonNull List<@NonNull CommandArgument<?, ?>> getCurrentChain() {
+    public @NonNull List<@NonNull CommandComponent<?>> getCurrentChain() {
         return Collections.unmodifiableList(this.currentChain);
     }
 }

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/InvalidCommandSenderException.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/InvalidCommandSenderException.java
@@ -24,7 +24,7 @@
 package cloud.commandframework.exceptions;
 
 import cloud.commandframework.Command;
-import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.CommandComponent;
 import java.util.List;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -52,7 +52,7 @@ public final class InvalidCommandSenderException extends CommandParseException {
     public InvalidCommandSenderException(
             final @NonNull Object commandSender,
             final @NonNull Class<?> requiredSender,
-            final @NonNull List<@NonNull CommandArgument<?, ?>> currentChain
+            final @NonNull List<@NonNull CommandComponent<?>> currentChain
     ) {
         this(commandSender, requiredSender, currentChain, null);
     }
@@ -70,7 +70,7 @@ public final class InvalidCommandSenderException extends CommandParseException {
     public InvalidCommandSenderException(
             final @NonNull Object commandSender,
             final @NonNull Class<?> requiredSender,
-            final @NonNull List<@NonNull CommandArgument<?, ?>> currentChain,
+            final @NonNull List<@NonNull CommandComponent<?>> currentChain,
             final @Nullable Command<?> command
     ) {
         super(commandSender, currentChain);

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/InvalidSyntaxException.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/InvalidSyntaxException.java
@@ -23,7 +23,7 @@
 //
 package cloud.commandframework.exceptions;
 
-import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.CommandComponent;
 import java.util.List;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -49,7 +49,7 @@ public class InvalidSyntaxException extends CommandParseException {
     public InvalidSyntaxException(
             final @NonNull String correctSyntax,
             final @NonNull Object commandSender,
-            final @NonNull List<@NonNull CommandArgument<?, ?>> currentChain
+            final @NonNull List<@NonNull CommandComponent<?>> currentChain
     ) {
         super(commandSender, currentChain);
         this.correctSyntax = correctSyntax;

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/NoPermissionException.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/NoPermissionException.java
@@ -24,7 +24,7 @@
 package cloud.commandframework.exceptions;
 
 import cloud.commandframework.Command;
-import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.CommandComponent;
 import cloud.commandframework.permission.CommandPermission;
 import java.util.List;
 import org.apiguardian.api.API;
@@ -52,7 +52,7 @@ public class NoPermissionException extends CommandParseException {
     public NoPermissionException(
             final @NonNull CommandPermission missingPermission,
             final @NonNull Object commandSender,
-            final @NonNull List<@NonNull CommandArgument<?, ?>> currentChain
+            final @NonNull List<@NonNull CommandComponent<?>> currentChain
     ) {
         super(commandSender, currentChain);
         this.missingPermission = missingPermission;

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/NoSuchCommandException.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/NoSuchCommandException.java
@@ -23,7 +23,7 @@
 //
 package cloud.commandframework.exceptions;
 
-import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.CommandComponent;
 import java.util.List;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -49,7 +49,7 @@ public final class NoSuchCommandException extends CommandParseException {
     @API(status = API.Status.INTERNAL, consumers = "cloud.commandframework.*")
     public NoSuchCommandException(
             final @NonNull Object commandSender,
-            final @NonNull List<CommandArgument<?, ?>> currentChain,
+            final @NonNull List<CommandComponent<?>> currentChain,
             final @NonNull String command
     ) {
         super(commandSender, currentChain);
@@ -60,11 +60,11 @@ public final class NoSuchCommandException extends CommandParseException {
     @Override
     public String getMessage() {
         final StringBuilder builder = new StringBuilder();
-        for (final CommandArgument<?, ?> commandArgument : this.getCurrentChain()) {
-            if (commandArgument == null) {
+        for (final CommandComponent<?> commandComponent : this.getCurrentChain()) {
+            if (commandComponent == null) {
                 continue;
             }
-            builder.append(" ").append(commandArgument.getName());
+            builder.append(" ").append(commandComponent.argument().getName());
         }
         return String.format("Unrecognized command input '%s' following chain%s", this.suppliedCommand, builder.toString());
     }

--- a/cloud-core/src/test/java/cloud/commandframework/CommandDeletionTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandDeletionTest.java
@@ -113,7 +113,7 @@ class CommandDeletionTest {
         final Command<TestCommandSender> command3 = this.commandManager
                 .commandBuilder("test")
                 .literal("literal")
-                .argument(StringArgument.of("string"))
+                .required(StringArgument.of("string"))
                 .handler(handler3)
                 .build();
         this.commandManager.command(command3);

--- a/cloud-core/src/test/java/cloud/commandframework/CommandHelpHandlerTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandHelpHandlerTest.java
@@ -59,12 +59,12 @@ class CommandHelpHandlerTest {
                 .with(CommandMeta.DESCRIPTION, "Command with variables")
                 .build();
         manager.command(manager.commandBuilder("test", meta2).literal("int").
-                argument(IntegerArgument.of("int"), ArgumentDescription.of("A number")).build());
-        manager.command(manager.commandBuilder("test").argument(StringArgument.of("potato")));
+                required(IntegerArgument.of("int"), ArgumentDescription.of("A number")).build());
+        manager.command(manager.commandBuilder("test").required(StringArgument.of("potato")));
 
         manager.command(manager.commandBuilder("vec")
                 .meta(CommandMeta.DESCRIPTION, "Takes in a vector")
-                .argumentPair("vec", Pair.of("x", "y"),
+                .requiredArgumentPair("vec", Pair.of("x", "y"),
                         Pair.of(Double.class, Double.class), ArgumentDescription.of("Vector")
                 )
                 .build());
@@ -173,13 +173,13 @@ class CommandHelpHandlerTest {
 
             //TODO: Use CommandManager syntax for this
             StringBuilder syntax = new StringBuilder();
-            for (CommandArgument<TestCommandSender, ?> argument : verbose.getCommand().getArguments()) {
-                if (argument instanceof StaticArgument) {
-                    syntax.append(argument.getName());
-                } else if (argument.isRequired()) {
-                    syntax.append('<').append(argument.getName()).append('>');
+            for (CommandComponent<TestCommandSender> component : verbose.getCommand().components()) {
+                if (component.argument() instanceof StaticArgument) {
+                    syntax.append(component.argument().getName());
+                } else if (component.required()) {
+                    syntax.append('<').append(component.argument().getName()).append('>');
                 } else {
-                    syntax.append('[').append(argument.getName()).append(']');
+                    syntax.append('[').append(component.argument().getName()).append(']');
                 }
                 syntax.append(' ');
             }
@@ -240,20 +240,20 @@ class CommandHelpHandlerTest {
 
     private void printVerboseHelpTopic(final CommandHelpHandler.VerboseHelpTopic<TestCommandSender> helpTopic) {
         System.out.printf("└── Command: /%s\n", manager.commandSyntaxFormatter()
-                .apply(helpTopic.getCommand().getArguments(), null));
+                .apply(helpTopic.getCommand().components(), null));
         System.out.printf("    ├── Description: %s\n", helpTopic.getDescription());
         System.out.println("    └── Args: ");
-        final Iterator<CommandComponent<TestCommandSender>> iterator = helpTopic.getCommand().getComponents().iterator();
+        final Iterator<CommandComponent<TestCommandSender>> iterator = helpTopic.getCommand().components().iterator();
         while (iterator.hasNext()) {
             final CommandComponent<TestCommandSender> component = iterator.next();
 
-            String description = component.getArgumentDescription().getDescription();
+            String description = component.argumentDescription().getDescription();
             if (!description.isEmpty()) {
                 description = ": " + description;
             }
 
             System.out.printf("        %s %s%s\n", iterator.hasNext() ? "├──" : "└──", manager.commandSyntaxFormatter().apply(
-                    Collections.singletonList(component.getArgument()), null), description);
+                    Collections.singletonList(component), null), description);
         }
     }
 }

--- a/cloud-core/src/test/java/cloud/commandframework/CommandManagerTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandManagerTest.java
@@ -97,7 +97,7 @@ class CommandManagerTest {
                 .build();
         final Command<TestCommandSender> commandC = this.commandManager.commandBuilder("test")
                 .literal("c")
-                .argument(IntegerArgument.optional("opt"))
+                .optional(IntegerArgument.of("opt"))
                 .handler(handlerC)
                 .build();
 
@@ -141,7 +141,7 @@ class CommandManagerTest {
         Command<TestCommandSender> command = this.commandManager.commandBuilder("component")
                 .literal("literal", "literalalias")
                 .literal("detail", ArgumentDescription.of("detaildescription"))
-                .argument(
+                .required(
                         CommandArgument.ofType(int.class, "argument"),
                         ArgumentDescription.of("argumentdescription")
                 )
@@ -149,30 +149,23 @@ class CommandManagerTest {
         this.commandManager.command(command);
 
         // Verify all the details we have configured are present
-        List<CommandArgument<TestCommandSender, ?>> arguments = command.getArguments();
-        List<CommandComponent<TestCommandSender>> components = command.getComponents();
-        assertThat(arguments.size()).isEqualTo(components.size());
+        List<CommandComponent<TestCommandSender>> components = command.components();
         assertThat(components.size()).isEqualTo(4);
-
-        // Arguments should exactly match the component getArgument() result, in same order
-        for (int i = 0; i < components.size(); i++) {
-            assertThat(components.get(i).getArgument()).isEqualTo(arguments.get(i));
-        }
 
         // Argument configuration, we know component has the same argument so no need to test those
         // TODO: Aliases
-        assertThat(arguments.get(0).getName()).isEqualTo("component");
-        assertThat(arguments.get(1).getName()).isEqualTo("literal");
-        assertThat(arguments.get(2).getName()).isEqualTo("detail");
-        assertThat(arguments.get(3).getName()).isEqualTo("argument");
+        assertThat(components.get(0).argument().getName()).isEqualTo("component");
+        assertThat(components.get(1).argument().getName()).isEqualTo("literal");
+        assertThat(components.get(2).argument().getName()).isEqualTo("detail");
+        assertThat(components.get(3).argument().getName()).isEqualTo("argument");
 
         // Check argument is indeed a command argument
-        assertThat(TypeToken.get(int.class)).isEqualTo(arguments.get(3).getValueType());
+        assertThat(TypeToken.get(int.class)).isEqualTo(components.get(3).argument().getValueType());
 
         // Check description is set for all components, is empty when not specified
-        assertThat(components.get(0).getArgumentDescription().getDescription()).isEmpty();
-        assertThat(components.get(1).getArgumentDescription().getDescription()).isEmpty();
-        assertThat(components.get(2).getArgumentDescription().getDescription()).isEqualTo("detaildescription");
-        assertThat(components.get(3).getArgumentDescription().getDescription()).isEqualTo("argumentdescription");
+        assertThat(components.get(0).argumentDescription().getDescription()).isEmpty();
+        assertThat(components.get(1).argumentDescription().getDescription()).isEmpty();
+        assertThat(components.get(2).argumentDescription().getDescription()).isEqualTo("detaildescription");
+        assertThat(components.get(3).argumentDescription().getDescription()).isEqualTo("argumentdescription");
     }
 }

--- a/cloud-core/src/test/java/cloud/commandframework/CommandPermissionTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandPermissionTest.java
@@ -66,7 +66,7 @@ class CommandPermissionTest {
     @Test
     void testComplexPermissions() {
         manager.command(manager.commandBuilder("first").permission("first"));
-        manager.command(manager.commandBuilder("first").argument(IntegerArgument.of("second")).permission("second"));
+        manager.command(manager.commandBuilder("first").required(IntegerArgument.of("second")).permission("second"));
 
         manager.executeCommand(new TestCommandSender(), "first").join();
 

--- a/cloud-core/src/test/java/cloud/commandframework/CommandPreProcessorTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandPreProcessorTest.java
@@ -43,7 +43,7 @@ public class CommandPreProcessorTest {
     static void newTree() {
         manager = createManager();
         manager.command(manager.commandBuilder("test", SimpleCommandMeta.empty())
-                .argument(EnumArgument.of(SampleEnum.class, "enum"))
+                .required(EnumArgument.of(SampleEnum.class, "enum"))
                 .handler(
                         commandContext -> System.out.printf(
                                 "enum = %s | integer = %d\n",

--- a/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
@@ -58,33 +58,33 @@ public class CommandSuggestionsTest {
         manager.command(manager.commandBuilder("test").literal("two").build());
         manager.command(manager.commandBuilder("test")
                 .literal("var")
-                .argument(StringArgument.<TestCommandSender>builder("str")
+                .required(StringArgument.<TestCommandSender>builder("str")
                         .withSuggestionsProvider((c, s) -> Arrays.asList("one", "two")))
-                .argument(EnumArgument.of(TestEnum.class, "enum")));
+                .required(EnumArgument.of(TestEnum.class, "enum")));
         manager.command(manager.commandBuilder("test")
                 .literal("comb")
-                .argument(StringArgument.<TestCommandSender>builder("str")
+                .required(StringArgument.<TestCommandSender>builder("str")
                         .withSuggestionsProvider((c, s) -> Arrays.asList("one", "two")))
-                .argument(IntegerArgument.<TestCommandSender>builder("num")
-                        .withMin(1).withMax(95).asOptional()));
+                .optional(IntegerArgument.<TestCommandSender>builder("num")
+                        .withMin(1).withMax(95)));
         manager.command(manager.commandBuilder("test")
                 .literal("alt")
-                .argument(IntegerArgument.<TestCommandSender>builder("num")
+                .required(IntegerArgument.<TestCommandSender>builder("num")
                         .withSuggestionsProvider((c, s) -> Arrays.asList("3", "33", "333"))));
 
         manager.command(manager.commandBuilder("com")
-                .argumentPair("com", Pair.of("x", "y"), Pair.of(Integer.class, TestEnum.class),
+                .requiredArgumentPair("com", Pair.of("x", "y"), Pair.of(Integer.class, TestEnum.class),
                         ArgumentDescription.empty()
                 )
-                .argument(IntegerArgument.of("int")));
+                .required(IntegerArgument.of("int")));
 
         manager.command(manager.commandBuilder("com2")
-                .argumentPair("com", Pair.of("x", "enum"),
+                .requiredArgumentPair("com", Pair.of("x", "enum"),
                         Pair.of(Integer.class, TestEnum.class), ArgumentDescription.empty()
                 ));
 
         manager.command(manager.commandBuilder("flags")
-                .argument(IntegerArgument.of("num"))
+                .required(IntegerArgument.of("num"))
                 .flag(manager.flagBuilder("enum")
                         .withArgument(EnumArgument.of(TestEnum.class, "enum"))
                         .build())
@@ -111,16 +111,16 @@ public class CommandSuggestionsTest {
                 .flag(manager.flagBuilder("single")
                         .withArgument(IntegerArgument.of("value"))));
 
-        manager.command(manager.commandBuilder("numbers").argument(IntegerArgument.of("num")));
-        manager.command(manager.commandBuilder("numberswithfollowingargument").argument(IntegerArgument.of("num"))
-                .argument(BooleanArgument.of("another_argument")));
+        manager.command(manager.commandBuilder("numbers").required(IntegerArgument.of("num")));
+        manager.command(manager.commandBuilder("numberswithfollowingargument").required(IntegerArgument.of("num"))
+                .required(BooleanArgument.of("another_argument")));
         manager.command(manager.commandBuilder("numberswithmin")
-                .argument(IntegerArgument.<TestCommandSender>builder("num").withMin(5).withMax(100)));
+                .required(IntegerArgument.<TestCommandSender>builder("num").withMin(5).withMax(100)));
 
-        manager.command(manager.commandBuilder("duration").argument(DurationArgument.of("duration")));
+        manager.command(manager.commandBuilder("duration").required(DurationArgument.of("duration")));
 
         manager.command(manager.commandBuilder("partial")
-                .argument(
+                .required(
                         StringArgument.<TestCommandSender>builder("arg")
                                 .withSuggestionsProvider((contect, input) -> Arrays.asList("hi", "hey", "heya", "hai", "hello"))
                 )
@@ -128,7 +128,7 @@ public class CommandSuggestionsTest {
                 .build());
 
         manager.command(manager.commandBuilder("literal_with_variable")
-                .argument(
+                .required(
                         StringArgument.<TestCommandSender>builder("arg")
                                 .withSuggestionsProvider((context, input) -> Arrays.asList("veni", "vidi")).build()
                 )
@@ -138,7 +138,7 @@ public class CommandSuggestionsTest {
                 .literal("later"));
 
         manager.command(manager.commandBuilder("cmd_with_multiple_args")
-                .argument(IntegerArgument.<TestCommandSender>of("number").addPreprocessor((ctx, input) -> {
+                .required(IntegerArgument.<TestCommandSender>of("number").addPreprocessor((ctx, input) -> {
                     String argument = input.peek();
                     if (argument == null || !argument.equals("1024")) {
                         return ArgumentParseResult.success(true);
@@ -146,7 +146,7 @@ public class CommandSuggestionsTest {
                         return ArgumentParseResult.failure(new NullPointerException());
                     }
                 }))
-                .argument(EnumArgument.of(TestEnum.class, "enum"))
+                .required(EnumArgument.of(TestEnum.class, "enum"))
                 .literal("world"));
     }
 
@@ -479,7 +479,7 @@ public class CommandSuggestionsTest {
         final CommandManager<TestCommandSender> manager = createManager();
         manager.command(
                 manager.commandBuilder("command")
-                        .argument(
+                        .required(
                                 StringArgument.<TestCommandSender>builder("string")
                                         .greedyFlagYielding()
                                         .withSuggestionsProvider((context, input) -> Collections.singletonList("hello"))
@@ -511,7 +511,7 @@ public class CommandSuggestionsTest {
         final CommandManager<TestCommandSender> manager = createManager();
         manager.command(
                 manager.commandBuilder("command")
-                        .argument(
+                        .required(
                                 StringArrayArgument.of(
                                         "array",
                                         true,
@@ -544,7 +544,7 @@ public class CommandSuggestionsTest {
         final CommandManager<TestCommandSender> manager = createManager();
         manager.command(
                 manager.commandBuilder("command")
-                        .argument(
+                        .required(
                                 StringArgument.<TestCommandSender>builder("string")
                                         .greedy()
                                         .withSuggestionsProvider((context, input) -> Collections.singletonList("hello world"))
@@ -578,7 +578,7 @@ public class CommandSuggestionsTest {
         manager.setSetting(CommandManager.ManagerSettings.LIBERAL_FLAG_PARSING, true);
         manager.command(
                 manager.commandBuilder("command")
-                        .argument(
+                        .required(
                                 StringArgument.<TestCommandSender>builder("string")
                                         .greedyFlagYielding()
                                         .withSuggestionsProvider((context, input) -> Collections.singletonList("hello"))
@@ -611,7 +611,7 @@ public class CommandSuggestionsTest {
         manager.setSetting(CommandManager.ManagerSettings.LIBERAL_FLAG_PARSING, true);
         manager.command(
                 manager.commandBuilder("command")
-                        .argument(
+                        .required(
                                 StringArrayArgument.of(
                                         "array",
                                         true,

--- a/cloud-core/src/test/java/cloud/commandframework/CommandTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandTest.java
@@ -39,7 +39,7 @@ class CommandTest {
                 Command
                         .newBuilder("test", SimpleCommandMeta.empty())
                         .build()
-                        .getArguments()
+                        .components()
                         .size()
         ).isEqualTo(1);
     }
@@ -48,8 +48,8 @@ class CommandTest {
     void ensureOrdering() {
         Assertions.assertThrows(IllegalArgumentException.class, () ->
                 Command.newBuilder("test", SimpleCommandMeta.empty())
-                        .argument(StringArgument.optional("something"))
-                        .argument(StaticArgument.of("somethingelse"))
+                        .optional(StringArgument.of("something"))
+                        .required(StaticArgument.of("somethingelse"))
                         .build()
         );
     }

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationArgumentSuggestionsTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationArgumentSuggestionsTest.java
@@ -42,7 +42,7 @@ public class DurationArgumentSuggestionsTest {
     static void setupManager() {
         manager = createManager();
         manager.command(manager.commandBuilder("duration")
-                .argument(DurationArgument.of("duration")));
+                .required(DurationArgument.of("duration")));
     }
 
 

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationArgumentTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationArgumentTest.java
@@ -44,7 +44,7 @@ public class DurationArgumentTest {
     static void setup() {
         manager = createManager();
         manager.command(manager.commandBuilder("duration")
-                .argument(DurationArgument.of("duration"))
+                .required(DurationArgument.of("duration"))
                 .handler(c -> {
                     final Duration duration = c.get("duration");
                     storage[0] = duration;

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/StringArgumentTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/StringArgumentTest.java
@@ -43,8 +43,8 @@ class StringArgumentTest {
     static void setup() {
         manager = createManager();
         manager.command(manager.commandBuilder("quoted")
-                .argument(StringArgument.of("message1", StringArgument.StringMode.QUOTED))
-                .argument(StringArgument.of("message2"))
+                .required(StringArgument.of("message1", StringArgument.StringMode.QUOTED))
+                .required(StringArgument.of("message2"))
                 .handler(c -> {
                     final String message1 = c.get("message1");
                     final String message2 = c.get("message2");
@@ -53,14 +53,14 @@ class StringArgumentTest {
                 })
                 .build());
         manager.command(manager.commandBuilder("single")
-                .argument(StringArgument.of("message"))
+                .required(StringArgument.of("message"))
                 .handler(c -> {
                     final String message = c.get("message");
                     storage[0] = message;
                 })
                 .build());
         manager.command(manager.commandBuilder("greedy")
-                .argument(StringArgument.of("message", StringArgument.StringMode.GREEDY))
+                .required(StringArgument.of("message", StringArgument.StringMode.GREEDY))
                 .handler(c -> {
                     final String message = c.get("message");
                     storage[0] = message;

--- a/cloud-core/src/test/java/cloud/commandframework/context/ArgumentContextTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/context/ArgumentContextTest.java
@@ -47,9 +47,9 @@ class ArgumentContextTest {
     void testConsumedInput() throws Exception {
         // Arrange
         this.commandManager.command(
-                this.commandManager.commandBuilder("test", "t").argument(
+                this.commandManager.commandBuilder("test", "t").required(
                         IntegerArgument.builder("int")
-                ).argument(
+                ).required(
                         StringArgument.greedy("string")
                 )
         );

--- a/cloud-core/src/test/java/cloud/commandframework/feature/ArbitraryPositionFlagTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/feature/ArbitraryPositionFlagTest.java
@@ -53,7 +53,7 @@ class ArbitraryPositionFlagTest {
         this.commandManager.command(
                 this.commandManager.commandBuilder("test")
                         .literal("literal")
-                        .argument(StringArgument.greedyFlagYielding("text"))
+                        .required(StringArgument.greedyFlagYielding("text"))
                         .flag(this.commandManager.flagBuilder("flag").withAliases("f")));
     }
 

--- a/cloud-discord/cloud-javacord/src/main/java/cloud/commandframework/javacord/JavacordRegistrationHandler.java
+++ b/cloud-discord/cloud-javacord/src/main/java/cloud/commandframework/javacord/JavacordRegistrationHandler.java
@@ -48,7 +48,7 @@ final class JavacordRegistrationHandler<C> implements CommandRegistrationHandler
     @Override
     public boolean registerCommand(final @NonNull Command<?> command) {
         /* We only care about the root command argument */
-        final CommandArgument<?, ?> commandArgument = command.getArguments().get(0);
+        final CommandArgument<?, ?> commandArgument = command.components().get(0).argument();
         if (this.registeredCommands.containsKey(commandArgument)) {
             return false;
         }

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/ChannelArgument.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/ChannelArgument.java
@@ -53,19 +53,15 @@ public final class ChannelArgument<C> extends CommandArgument<C, MessageChannel>
     private final Set<ParserMode> modes;
 
     private ChannelArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>,
                     @NonNull String, @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final @NonNull Set<ParserMode> modes
     ) {
         super(
-                required,
                 name,
                 new MessageParser<>(modes),
-                defaultValue,
                 MessageChannel.class,
                 suggestionsProvider,
                 defaultDescription
@@ -108,18 +104,7 @@ public final class ChannelArgument<C> extends CommandArgument<C, MessageChannel>
      * @return Created component
      */
     public static <C> @NonNull CommandArgument<C, MessageChannel> of(final @NonNull String name) {
-        return ChannelArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional command component
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created component
-     */
-    public static <C> @NonNull CommandArgument<C, MessageChannel> optional(final @NonNull String name) {
-        return ChannelArgument.<C>builder(name).asOptional().build();
+        return ChannelArgument.<C>builder(name).build();
     }
 
     /**
@@ -166,9 +151,7 @@ public final class ChannelArgument<C> extends CommandArgument<C, MessageChannel>
         @Override
         public @NonNull ChannelArgument<C> build() {
             return new ChannelArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription(),
                     this.modes

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/RoleArgument.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/RoleArgument.java
@@ -52,15 +52,13 @@ public final class RoleArgument<C> extends CommandArgument<C, Role> {
     private final Set<ParserMode> modes;
 
     private RoleArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>,
                     @NonNull String, @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final @NonNull Set<ParserMode> modes
     ) {
-        super(required, name, new RoleParser<>(modes), defaultValue, Role.class, suggestionsProvider, defaultDescription);
+        super(name, new RoleParser<>(modes), Role.class, suggestionsProvider, defaultDescription);
         this.modes = modes;
     }
 
@@ -99,18 +97,7 @@ public final class RoleArgument<C> extends CommandArgument<C, Role> {
      * @return Created component
      */
     public static <C> @NonNull CommandArgument<C, Role> of(final @NonNull String name) {
-        return RoleArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional command component
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created component
-     */
-    public static <C> @NonNull CommandArgument<C, Role> optional(final @NonNull String name) {
-        return RoleArgument.<C>builder(name).asOptional().build();
+        return RoleArgument.<C>builder(name).build();
     }
 
     /**
@@ -157,9 +144,7 @@ public final class RoleArgument<C> extends CommandArgument<C, Role> {
         @Override
         public @NonNull RoleArgument<C> build() {
             return new RoleArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription(),
                     this.modes

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/UserArgument.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/UserArgument.java
@@ -57,9 +57,7 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
     private final Isolation isolationLevel;
 
     private UserArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>,
                     @NonNull String, @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription,
@@ -67,10 +65,8 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
             final @NonNull Isolation isolationLevel
     ) {
         super(
-                required,
                 name,
                 new UserParser<>(modes, isolationLevel),
-                defaultValue,
                 User.class,
                 suggestionsProvider,
                 defaultDescription
@@ -114,18 +110,7 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
      * @return Created component
      */
     public static <C> @NonNull CommandArgument<C, User> of(final @NonNull String name) {
-        return UserArgument.<C>builder(name).withParserMode(ParserMode.MENTION).asRequired().build();
-    }
-
-    /**
-     * Create a new optional command component
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created component
-     */
-    public static <C> @NonNull CommandArgument<C, User> optional(final @NonNull String name) {
-        return UserArgument.<C>builder(name).withParserMode(ParserMode.MENTION).asOptional().build();
+        return UserArgument.<C>builder(name).withParserMode(ParserMode.MENTION).build();
     }
 
     /**
@@ -200,9 +185,7 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
         @Override
         public @NonNull UserArgument<C> build() {
             return new UserArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription(),
                     this.modes,

--- a/cloud-irc/cloud-pircbotx/src/main/java/cloud/commandframework/pircbotx/arguments/UserArgument.java
+++ b/cloud-irc/cloud-pircbotx/src/main/java/cloud/commandframework/pircbotx/arguments/UserArgument.java
@@ -52,18 +52,14 @@ import org.pircbotx.exception.DaoException;
 public final class UserArgument<C> extends CommandArgument<C, User> {
 
     private UserArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>,
                     @NonNull String, @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 new UserArgumentParser<>(),
-                defaultValue,
                 TypeToken.get(User.class),
                 suggestionsProvider,
                 defaultDescription
@@ -105,18 +101,7 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
      * @return Argument instance
      */
     public static <C> @NonNull CommandArgument<C, User> of(final @NonNull String name) {
-        return UserArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a optional user argument
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Argument instance
-     */
-    public static <C> @NonNull CommandArgument<C, User> optional(final @NonNull String name) {
-        return UserArgument.<C>builder(name).asOptional().build();
+        return UserArgument.<C>builder(name).build();
     }
 
 
@@ -134,9 +119,7 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
         @Override
         public @NonNull CommandArgument<@NonNull C, @NonNull User> build() {
             return new UserArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );

--- a/cloud-kotlin/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/MutableCommandBuilder.kt
+++ b/cloud-kotlin/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/MutableCommandBuilder.kt
@@ -480,17 +480,25 @@ public class MutableCommandBuilder<C : Any>(
      * @param argument argument to add
      * @param description description of the argument
      * @return this mutable builder
-     * @since 1.3.0
+     * @since 2.0.0
      */
-    @Suppress("DEPRECATION")
-    @Deprecated(
-        message = "ArgumentDescription should be used over Description",
-        level = DeprecationLevel.HIDDEN
-    )
-    public fun argument(
+    public fun required(
         argument: CommandArgument<C, *>,
-        description: Description = Description.empty()
-    ): MutableCommandBuilder<C> = mutate { it.argument(argument, description) }
+        description: ArgumentDescription = ArgumentDescription.empty()
+    ): MutableCommandBuilder<C> = mutate { it.required(argument, description) }
+
+    /**
+     * Add a new argument to this command
+     *
+     * @param argument argument to add
+     * @param description description of the argument
+     * @return this mutable builder
+     * @since 2.0.0
+     */
+    public fun optional(
+        argument: CommandArgument<C, *>,
+        description: ArgumentDescription = ArgumentDescription.empty()
+    ): MutableCommandBuilder<C> = mutate { it.optional(argument, description) }
 
     /**
      * Add a new argument to this command
@@ -500,28 +508,10 @@ public class MutableCommandBuilder<C : Any>(
      * @return this mutable builder
      * @since 1.4.0
      */
-    public fun argument(
-        argument: CommandArgument<C, *>,
-        description: ArgumentDescription = ArgumentDescription.empty()
-    ): MutableCommandBuilder<C> = mutate { it.argument(argument, description) }
-
-    /**
-     * Add a new argument to this command
-     *
-     * @param argument argument to add
-     * @param description description of the argument
-     * @return this mutable builder
-     * @since 1.3.0
-     */
-    @Suppress("DEPRECATION")
-    @Deprecated(
-        message = "ArgumentDescription should be used over Description",
-        level = DeprecationLevel.HIDDEN
-    )
-    public fun argument(
+    public fun required(
         argument: CommandArgument.Builder<C, *>,
-        description: Description = Description.empty()
-    ): MutableCommandBuilder<C> = mutate { it.argument(argument, description) }
+        description: ArgumentDescription = ArgumentDescription.empty()
+    ): MutableCommandBuilder<C> = mutate { it.required(argument, description) }
 
     /**
      * Add a new argument to this command
@@ -531,10 +521,10 @@ public class MutableCommandBuilder<C : Any>(
      * @return this mutable builder
      * @since 1.4.0
      */
-    public fun argument(
+    public fun optional(
         argument: CommandArgument.Builder<C, *>,
         description: ArgumentDescription = ArgumentDescription.empty()
-    ): MutableCommandBuilder<C> = mutate { it.argument(argument, description) }
+    ): MutableCommandBuilder<C> = mutate { it.optional(argument, description) }
 
     /**
      * Add a new argument to this command
@@ -542,50 +532,25 @@ public class MutableCommandBuilder<C : Any>(
      * @param description description of the argument
      * @param argumentSupplier supplier of the argument to add
      * @return this mutable builder
-     * @since 1.3.0
+     * @since 2.0.0
      */
-    @Suppress("DEPRECATION")
-    @Deprecated(
-        message = "ArgumentDescription should be used over Description",
-        level = DeprecationLevel.HIDDEN
-    )
-    public fun argument(
-        description: Description = Description.empty(),
-        argumentSupplier: () -> CommandArgument<C, *>
-    ): MutableCommandBuilder<C> = mutate { it.argument(argumentSupplier(), description) }
-
-    /**
-     * Add a new argument to this command
-     *
-     * @param description description of the argument
-     * @param argumentSupplier supplier of the argument to add
-     * @return this mutable builder
-     * @since 1.4.0
-     */
-    public fun argument(
+    public fun required(
         description: ArgumentDescription = ArgumentDescription.empty(),
         argumentSupplier: () -> CommandArgument<C, *>
-    ): MutableCommandBuilder<C> = mutate { it.argument(argumentSupplier(), description) }
+    ): MutableCommandBuilder<C> = mutate { it.required(argumentSupplier(), description) }
 
     /**
-     * Add a new literal argument to this command
+     * Add a new argument to this command
      *
-     * @param name main argument name
-     * @param description literal description
-     * @param aliases argument aliases
+     * @param description description of the argument
+     * @param argumentSupplier supplier of the argument to add
      * @return this mutable builder
-     * @since 1.3.0
+     * @since 2.0.0
      */
-    @Suppress("DEPRECATION")
-    @Deprecated(
-        message = "ArgumentDescription should be used over Description",
-        level = DeprecationLevel.HIDDEN
-    )
-    public fun literal(
-        name: String,
-        description: Description = Description.empty(),
-        vararg aliases: String
-    ): MutableCommandBuilder<C> = mutate { it.literal(name, description, *aliases) }
+    public fun optional(
+        description: ArgumentDescription = ArgumentDescription.empty(),
+        argumentSupplier: () -> CommandArgument<C, *>
+    ): MutableCommandBuilder<C> = mutate { it.optional(argumentSupplier(), description) }
 
     /**
      * Add a new literal argument to this command

--- a/cloud-kotlin/cloud-kotlin-extensions/src/test/kotlin/cloud/commandframework/kotlin/CommandBuildingDSLTest.kt
+++ b/cloud-kotlin/cloud-kotlin-extensions/src/test/kotlin/cloud/commandframework/kotlin/CommandBuildingDSLTest.kt
@@ -48,7 +48,7 @@ class CommandBuildingDSLTest {
                 senderType<SpecificCommandSender>()
 
                 literal("dsl")
-                argument(argumentDescription("An amazing command argument")) {
+                required(argumentDescription("An amazing command argument")) {
                     StringArgument.of("moment")
                 }
                 handler {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommand.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommand.java
@@ -197,20 +197,20 @@ final class BukkitCommand<C> extends org.bukkit.command.Command implements Plugi
     @Override
     public @NonNull String getUsage() {
         return this.manager.commandSyntaxFormatter().apply(
-                Collections.singletonList(Objects.requireNonNull(this.namedNode().getValue())),
+                Collections.singletonList(Objects.requireNonNull(this.namedNode().component())),
                 this.namedNode()
         );
     }
 
     @Override
     public boolean testPermissionSilent(final @NonNull CommandSender target) {
-        final CommandTree.Node<CommandArgument<C, ?>> node = this.namedNode();
+        final CommandTree.CommandNode<C> node = this.namedNode();
         if (this.disabled || node == null) {
             return false;
         }
 
         final CommandPermission permission = (CommandPermission) node
-                .getNodeMeta()
+                .nodeMeta()
                 .getOrDefault("permission", Permission.empty());
 
         return this.manager.hasPermission(this.manager.getCommandSenderMapper().apply(target), permission);
@@ -228,7 +228,7 @@ final class BukkitCommand<C> extends org.bukkit.command.Command implements Plugi
         return !this.disabled;
     }
 
-    private CommandTree.@Nullable Node<CommandArgument<C, ?>> namedNode() {
+    private CommandTree.@Nullable CommandNode<C> namedNode() {
         return this.manager.commandTree().getNamedNode(this.command.getName());
     }
 }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitPluginRegistrationHandler.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitPluginRegistrationHandler.java
@@ -74,7 +74,7 @@ public class BukkitPluginRegistrationHandler<C> implements CommandRegistrationHa
     @Override
     public final boolean registerCommand(final @NonNull Command<?> command) {
         /* We only care about the root command argument */
-        final CommandArgument<?, ?> commandArgument = command.getArguments().get(0);
+        final CommandArgument<?, ?> commandArgument = command.components().get(0).argument();
         if (!(this.bukkitCommandManager.commandRegistrationHandler() instanceof CloudCommodoreManager)
                 && this.registeredCommands.containsKey(commandArgument)) {
             return false;

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/argument/NamespacedKeyArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/argument/NamespacedKeyArgument.java
@@ -53,9 +53,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class NamespacedKeyArgument<C> extends CommandArgument<C, NamespacedKey> {
 
     private NamespacedKeyArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription,
@@ -63,10 +61,8 @@ public final class NamespacedKeyArgument<C> extends CommandArgument<C, Namespace
             final String defaultNamespace
     ) {
         super(
-                required,
                 name,
                 new Parser<>(requireExplicitNamespace, defaultNamespace),
-                defaultValue,
                 NamespacedKey.class,
                 suggestionsProvider,
                 defaultDescription
@@ -94,35 +90,7 @@ public final class NamespacedKeyArgument<C> extends CommandArgument<C, Namespace
      * @since 1.7.0
      */
     public static <C> @NonNull NamespacedKeyArgument<C> of(final @NonNull String name) {
-        return NamespacedKeyArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link NamespacedKeyArgument}.
-     *
-     * @param name argument name
-     * @param <C>  sender type
-     * @return argument instance
-     * @since 1.7.0
-     */
-    public static <C> @NonNull NamespacedKeyArgument<C> optional(final @NonNull String name) {
-        return NamespacedKeyArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link NamespacedKeyArgument} using the provided default value.
-     *
-     * @param name         argument name
-     * @param defulatValue default name
-     * @param <C>          sender type
-     * @return argument instance
-     * @since 1.7.0
-     */
-    public static <C> @NonNull NamespacedKeyArgument<C> optional(
-            final @NonNull String name,
-            final @NonNull NamespacedKey defulatValue
-    ) {
-        return NamespacedKeyArgument.<C>builder(name).asOptionalWithDefault(defulatValue).build();
+        return NamespacedKeyArgument.<C>builder(name).build();
     }
 
 
@@ -175,24 +143,10 @@ public final class NamespacedKeyArgument<C> extends CommandArgument<C, Namespace
             return this;
         }
 
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.7.0
-         */
-        public Builder<C> asOptionalWithDefault(final NamespacedKey defaultValue) {
-            return this.asOptionalWithDefault(defaultValue.getNamespace() + ':' + defaultValue.getKey());
-        }
-
         @Override
         public @NonNull NamespacedKeyArgument<C> build() {
             return new NamespacedKeyArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription(),
                     this.requireExplicitNamespace,

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/BlockPredicateArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/BlockPredicateArgument.java
@@ -63,14 +63,12 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class BlockPredicateArgument<C> extends CommandArgument<C, BlockPredicate> {
 
     private BlockPredicateArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(required, name, new Parser<>(), defaultValue, BlockPredicate.class, suggestionsProvider, defaultDescription);
+        super(name, new Parser<>(), BlockPredicate.class, suggestionsProvider, defaultDescription);
     }
 
     /**
@@ -97,18 +95,6 @@ public final class BlockPredicateArgument<C> extends CommandArgument<C, BlockPre
         return BlockPredicateArgument.<C>builder(name).build();
     }
 
-    /**
-     * Create a new optional {@link BlockPredicateArgument}.
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull BlockPredicateArgument<C> optional(final @NonNull String name) {
-        return BlockPredicateArgument.<C>builder(name).asOptional().build();
-    }
-
 
     /**
      * Builder for {@link BlockPredicateArgument}.
@@ -125,9 +111,7 @@ public final class BlockPredicateArgument<C> extends CommandArgument<C, BlockPre
         @Override
         public @NonNull BlockPredicateArgument<C> build() {
             return new BlockPredicateArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/EnchantmentArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/EnchantmentArgument.java
@@ -50,18 +50,14 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class EnchantmentArgument<C> extends CommandArgument<C, Enchantment> {
 
     protected EnchantmentArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 new EnchantmentParser<>(),
-                defaultValue,
                 Enchantment.class,
                 suggestionsProvider,
                 defaultDescription
@@ -103,34 +99,9 @@ public class EnchantmentArgument<C> extends CommandArgument<C, Enchantment> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Enchantment> of(final @NonNull String name) {
-        return EnchantmentArgument.<C>builder(name).asRequired().build();
+        return EnchantmentArgument.<C>builder(name).build();
     }
 
-    /**
-     * Create a new optional argument
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, Enchantment> optional(final @NonNull String name) {
-        return EnchantmentArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional argument with a default value
-     *
-     * @param name        Argument name
-     * @param enchantment Default value
-     * @param <C>         Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, Enchantment> optional(
-            final @NonNull String name,
-            final @NonNull Enchantment enchantment
-    ) {
-        return EnchantmentArgument.<C>builder(name).asOptionalWithDefault(enchantment.getKey().toString()).build();
-    }
 
     public static final class Builder<C> extends CommandArgument.Builder<C, Enchantment> {
 
@@ -141,9 +112,7 @@ public class EnchantmentArgument<C> extends CommandArgument<C, Enchantment> {
         @Override
         public @NonNull CommandArgument<C, Enchantment> build() {
             return new EnchantmentArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/ItemStackArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/ItemStackArgument.java
@@ -67,14 +67,12 @@ import static java.util.Objects.requireNonNull;
 public final class ItemStackArgument<C> extends CommandArgument<C, ProtoItemStack> {
 
     private ItemStackArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(required, name, new Parser<>(), defaultValue, ProtoItemStack.class, suggestionsProvider, defaultDescription);
+        super(name, new Parser<>(), ProtoItemStack.class, suggestionsProvider, defaultDescription);
     }
 
     /**
@@ -101,18 +99,6 @@ public final class ItemStackArgument<C> extends CommandArgument<C, ProtoItemStac
         return ItemStackArgument.<C>builder(name).build();
     }
 
-    /**
-     * Create a new optional {@link ItemStackArgument}.
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull ItemStackArgument<C> optional(final @NonNull String name) {
-        return ItemStackArgument.<C>builder(name).asOptional().build();
-    }
-
 
     /**
      * Builder for {@link ItemStackArgument}.
@@ -129,9 +115,7 @@ public final class ItemStackArgument<C> extends CommandArgument<C, ProtoItemStac
         @Override
         public @NonNull ItemStackArgument<C> build() {
             return new ItemStackArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/ItemStackPredicateArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/ItemStackPredicateArgument.java
@@ -64,14 +64,12 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class ItemStackPredicateArgument<C> extends CommandArgument<C, ItemStackPredicate> {
 
     private ItemStackPredicateArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(required, name, new Parser<>(), defaultValue, ItemStackPredicate.class, suggestionsProvider, defaultDescription);
+        super(name, new Parser<>(), ItemStackPredicate.class, suggestionsProvider, defaultDescription);
     }
 
     /**
@@ -98,18 +96,6 @@ public final class ItemStackPredicateArgument<C> extends CommandArgument<C, Item
         return ItemStackPredicateArgument.<C>builder(name).build();
     }
 
-    /**
-     * Create a new optional {@link ItemStackPredicateArgument}.
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull ItemStackPredicateArgument<C> optional(final @NonNull String name) {
-        return ItemStackPredicateArgument.<C>builder(name).asOptional().build();
-    }
-
 
     /**
      * Builder for {@link ItemStackPredicateArgument}.
@@ -126,9 +112,7 @@ public final class ItemStackPredicateArgument<C> extends CommandArgument<C, Item
         @Override
         public @NonNull ItemStackPredicateArgument<C> build() {
             return new ItemStackPredicateArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/MaterialArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/MaterialArgument.java
@@ -49,14 +49,12 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class MaterialArgument<C> extends CommandArgument<C, Material> {
 
     protected MaterialArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(required, name, new MaterialParser<>(), defaultValue, Material.class, suggestionsProvider, defaultDescription);
+        super(name, new MaterialParser<>(), Material.class, suggestionsProvider, defaultDescription);
     }
 
     /**
@@ -94,34 +92,9 @@ public class MaterialArgument<C> extends CommandArgument<C, Material> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, Material> of(final @NonNull String name) {
-        return MaterialArgument.<C>builder(name).asRequired().build();
+        return MaterialArgument.<C>builder(name).build();
     }
 
-    /**
-     * Create a new optional argument
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, Material> optional(final @NonNull String name) {
-        return MaterialArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional argument with a default value
-     *
-     * @param name     Argument name
-     * @param material Default value
-     * @param <C>      Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, Material> optional(
-            final @NonNull String name,
-            final @NonNull Material material
-    ) {
-        return MaterialArgument.<C>builder(name).asOptionalWithDefault(material.name().toLowerCase()).build();
-    }
 
     public static final class Builder<C> extends CommandArgument.Builder<C, Material> {
 
@@ -132,9 +105,7 @@ public class MaterialArgument<C> extends CommandArgument<C, Material> {
         @Override
         public @NonNull CommandArgument<C, Material> build() {
             return new MaterialArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/OfflinePlayerArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/OfflinePlayerArgument.java
@@ -57,18 +57,14 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class OfflinePlayerArgument<C> extends CommandArgument<C, OfflinePlayer> {
 
     private OfflinePlayerArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 new OfflinePlayerParser<>(),
-                defaultValue,
                 OfflinePlayer.class,
                 suggestionsProvider,
                 defaultDescription
@@ -110,33 +106,7 @@ public final class OfflinePlayerArgument<C> extends CommandArgument<C, OfflinePl
      * @return Created component
      */
     public static <C> @NonNull CommandArgument<C, OfflinePlayer> of(final @NonNull String name) {
-        return OfflinePlayerArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional command component
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created component
-     */
-    public static <C> @NonNull CommandArgument<C, OfflinePlayer> optional(final @NonNull String name) {
-        return OfflinePlayerArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new required command component with a default value
-     *
-     * @param name          Component name
-     * @param defaultPlayer Default player
-     * @param <C>           Command sender type
-     * @return Created component
-     */
-    public static <C> @NonNull CommandArgument<C, OfflinePlayer> optional(
-            final @NonNull String name,
-            final @NonNull String defaultPlayer
-    ) {
-        return OfflinePlayerArgument.<C>builder(name).asOptionalWithDefault(defaultPlayer).build();
+        return OfflinePlayerArgument.<C>builder(name).build();
     }
 
 
@@ -153,9 +123,7 @@ public final class OfflinePlayerArgument<C> extends CommandArgument<C, OfflinePl
          */
         @Override
         public @NonNull OfflinePlayerArgument<C> build() {
-            return new OfflinePlayerArgument<>(this.isRequired(), this.getName(), this.getDefaultValue(),
-                    this.getSuggestionsProvider(), this.getDefaultDescription()
-            );
+            return new OfflinePlayerArgument<>(this.getName(), this.getSuggestionsProvider(), this.getDefaultDescription());
         }
     }
 

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/PlayerArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/PlayerArgument.java
@@ -53,14 +53,12 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class PlayerArgument<C> extends CommandArgument<C, Player> {
 
     private PlayerArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(required, name, new PlayerParser<>(), defaultValue, Player.class, suggestionsProvider, defaultDescription);
+        super(name, new PlayerParser<>(), Player.class, suggestionsProvider, defaultDescription);
     }
 
     /**
@@ -98,33 +96,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
      * @return Created component
      */
     public static <C> @NonNull CommandArgument<C, Player> of(final @NonNull String name) {
-        return PlayerArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional command component
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created component
-     */
-    public static <C> @NonNull CommandArgument<C, Player> optional(final @NonNull String name) {
-        return PlayerArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new required command component with a default value
-     *
-     * @param name          Component name
-     * @param defaultPlayer Default player
-     * @param <C>           Command sender type
-     * @return Created component
-     */
-    public static <C> @NonNull CommandArgument<C, Player> optional(
-            final @NonNull String name,
-            final @NonNull String defaultPlayer
-    ) {
-        return PlayerArgument.<C>builder(name).asOptionalWithDefault(defaultPlayer).build();
+        return PlayerArgument.<C>builder(name).build();
     }
 
 
@@ -142,9 +114,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
         @Override
         public @NonNull PlayerArgument<C> build() {
             return new PlayerArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/WorldArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/WorldArgument.java
@@ -50,13 +50,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class WorldArgument<C> extends CommandArgument<C, World> {
 
     protected WorldArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(required, name, new WorldParser<>(), defaultValue, World.class, suggestionsProvider, defaultDescription);
+        super(name, new WorldParser<>(), World.class, suggestionsProvider, defaultDescription);
     }
 
     /**
@@ -94,33 +92,7 @@ public class WorldArgument<C> extends CommandArgument<C, World> {
      * @return Created argument
      */
     public static <C> @NonNull CommandArgument<C, World> of(final @NonNull String name) {
-        return WorldArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional argument
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, World> optional(final @NonNull String name) {
-        return WorldArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional argument with a default value
-     *
-     * @param name         Argument name
-     * @param defaultValue Default value
-     * @param <C>          Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, World> optional(
-            final @NonNull String name,
-            final @NonNull String defaultValue
-    ) {
-        return WorldArgument.<C>builder(name).asOptionalWithDefault(defaultValue).build();
+        return WorldArgument.<C>builder(name).build();
     }
 
 
@@ -133,9 +105,7 @@ public class WorldArgument<C> extends CommandArgument<C, World> {
         @Override
         public @NonNull CommandArgument<C, World> build() {
             return new WorldArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/Location2DArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/Location2DArgument.java
@@ -56,19 +56,15 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class Location2DArgument<C> extends CommandArgument<C, Location2D> {
 
     private Location2DArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @NonNull ArgumentDescription defaultDescription,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>,
                     @NonNull Queue<@NonNull String>, @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
     ) {
         super(
-                required,
                 name,
                 new Location2DParser<>(),
-                defaultValue,
                 TypeToken.get(Location2D.class),
                 suggestionsProvider,
                 defaultDescription,
@@ -113,20 +109,7 @@ public final class Location2DArgument<C> extends CommandArgument<C, Location2D> 
     public static <C> @NonNull CommandArgument<C, Location2D> of(
             final @NonNull String name
     ) {
-        return Location2DArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional argument
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Constructed argument
-     */
-    public static <C> @NonNull CommandArgument<C, Location2D> optional(
-            final @NonNull String name
-    ) {
-        return Location2DArgument.<C>builder(name).asOptional().build();
+        return Location2DArgument.<C>builder(name).build();
     }
 
 
@@ -144,9 +127,7 @@ public final class Location2DArgument<C> extends CommandArgument<C, Location2D> 
         @Override
         public @NonNull CommandArgument<@NonNull C, @NonNull Location2D> build() {
             return new Location2DArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getDefaultDescription(),
                     this.getSuggestionsProvider(),
                     new LinkedList<>()

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/LocationArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/LocationArgument.java
@@ -61,19 +61,15 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class LocationArgument<C> extends CommandArgument<C, Location> {
 
     private LocationArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>,
                     @NonNull Queue<@NonNull String>, @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
     ) {
         super(
-                required,
                 name,
                 new LocationParser<>(),
-                defaultValue,
                 TypeToken.get(Location.class),
                 suggestionsProvider,
                 defaultDescription,
@@ -118,20 +114,7 @@ public final class LocationArgument<C> extends CommandArgument<C, Location> {
     public static <C> @NonNull CommandArgument<C, Location> of(
             final @NonNull String name
     ) {
-        return LocationArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional argument
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Constructed argument
-     */
-    public static <C> @NonNull CommandArgument<C, Location> optional(
-            final @NonNull String name
-    ) {
-        return LocationArgument.<C>builder(name).asOptional().build();
+        return LocationArgument.<C>builder(name).build();
     }
 
 
@@ -149,9 +132,7 @@ public final class LocationArgument<C> extends CommandArgument<C, Location> {
         @Override
         public @NonNull CommandArgument<@NonNull C, @NonNull Location> build() {
             return new LocationArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription(),
                     new LinkedList<>()

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultipleEntitySelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultipleEntitySelectorArgument.java
@@ -46,14 +46,12 @@ public final class MultipleEntitySelectorArgument<C> extends CommandArgument<C, 
 
     private MultipleEntitySelectorArgument(
             final boolean allowEmpty,
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(required, name, new MultipleEntitySelectorParser<>(allowEmpty), defaultValue,
+        super(name, new MultipleEntitySelectorParser<>(allowEmpty),
                 MultipleEntitySelector.class, suggestionsProvider, defaultDescription
         );
     }
@@ -93,33 +91,7 @@ public final class MultipleEntitySelectorArgument<C> extends CommandArgument<C, 
      * @return Created argument
      */
     public static <C> @NonNull MultipleEntitySelectorArgument<C> of(final @NonNull String name) {
-        return MultipleEntitySelectorArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional command argument
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull MultipleEntitySelectorArgument<C> optional(final @NonNull String name) {
-        return MultipleEntitySelectorArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new required command argument with a default value
-     *
-     * @param name                  Argument name
-     * @param defaultEntitySelector Default player
-     * @param <C>                   Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull MultipleEntitySelectorArgument<C> optional(
-            final @NonNull String name,
-            final @NonNull String defaultEntitySelector
-    ) {
-        return MultipleEntitySelectorArgument.<C>builder(name).asOptionalWithDefault(defaultEntitySelector).build();
+        return MultipleEntitySelectorArgument.<C>builder(name).build();
     }
 
 
@@ -153,9 +125,7 @@ public final class MultipleEntitySelectorArgument<C> extends CommandArgument<C, 
         public @NonNull MultipleEntitySelectorArgument<C> build() {
             return new MultipleEntitySelectorArgument<>(
                     this.allowEmpty,
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultiplePlayerSelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultiplePlayerSelectorArgument.java
@@ -52,14 +52,12 @@ public final class MultiplePlayerSelectorArgument<C> extends CommandArgument<C, 
 
     private MultiplePlayerSelectorArgument(
             final boolean allowEmpty,
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(required, name, new MultiplePlayerSelectorParser<>(allowEmpty), defaultValue, MultiplePlayerSelector.class,
+        super(name, new MultiplePlayerSelectorParser<>(allowEmpty), MultiplePlayerSelector.class,
                 suggestionsProvider, defaultDescription
         );
     }
@@ -99,33 +97,7 @@ public final class MultiplePlayerSelectorArgument<C> extends CommandArgument<C, 
      * @return Created argument
      */
     public static <C> @NonNull MultiplePlayerSelectorArgument<C> of(final @NonNull String name) {
-        return MultiplePlayerSelectorArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional command argument
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull MultiplePlayerSelectorArgument<C> optional(final @NonNull String name) {
-        return MultiplePlayerSelectorArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new required command argument with a default value
-     *
-     * @param name                  Argument name
-     * @param defaultEntitySelector Default player
-     * @param <C>                   Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull MultiplePlayerSelectorArgument<C> optional(
-            final @NonNull String name,
-            final @NonNull String defaultEntitySelector
-    ) {
-        return MultiplePlayerSelectorArgument.<C>builder(name).asOptionalWithDefault(defaultEntitySelector).build();
+        return MultiplePlayerSelectorArgument.<C>builder(name).build();
     }
 
 
@@ -159,9 +131,7 @@ public final class MultiplePlayerSelectorArgument<C> extends CommandArgument<C, 
         public @NonNull MultiplePlayerSelectorArgument<C> build() {
             return new MultiplePlayerSelectorArgument<>(
                     this.allowEmpty,
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SingleEntitySelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SingleEntitySelectorArgument.java
@@ -45,18 +45,14 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class SingleEntitySelectorArgument<C> extends CommandArgument<C, SingleEntitySelector> {
 
     private SingleEntitySelectorArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 new SingleEntitySelectorParser<>(),
-                defaultValue,
                 SingleEntitySelector.class,
                 suggestionsProvider,
                 defaultDescription
@@ -98,33 +94,7 @@ public final class SingleEntitySelectorArgument<C> extends CommandArgument<C, Si
      * @return Created argument
      */
     public static <C> @NonNull SingleEntitySelectorArgument<C> of(final @NonNull String name) {
-        return SingleEntitySelectorArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional command argument
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull SingleEntitySelectorArgument<C> optional(final @NonNull String name) {
-        return SingleEntitySelectorArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new required command argument with a default value
-     *
-     * @param name                  Argument name
-     * @param defaultEntitySelector Default player
-     * @param <C>                   Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull SingleEntitySelectorArgument<C> optional(
-            final @NonNull String name,
-            final @NonNull String defaultEntitySelector
-    ) {
-        return SingleEntitySelectorArgument.<C>builder(name).asOptionalWithDefault(defaultEntitySelector).build();
+        return SingleEntitySelectorArgument.<C>builder(name).build();
     }
 
 
@@ -142,9 +112,7 @@ public final class SingleEntitySelectorArgument<C> extends CommandArgument<C, Si
         @Override
         public @NonNull SingleEntitySelectorArgument<C> build() {
             return new SingleEntitySelectorArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SinglePlayerSelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SinglePlayerSelectorArgument.java
@@ -51,18 +51,14 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class SinglePlayerSelectorArgument<C> extends CommandArgument<C, SinglePlayerSelector> {
 
     private SinglePlayerSelectorArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
                     @NonNull List<@NonNull String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 new SinglePlayerSelectorParser<>(),
-                defaultValue,
                 SinglePlayerSelector.class,
                 suggestionsProvider,
                 defaultDescription
@@ -104,33 +100,7 @@ public final class SinglePlayerSelectorArgument<C> extends CommandArgument<C, Si
      * @return Created argument
      */
     public static <C> @NonNull SinglePlayerSelectorArgument<C> of(final @NonNull String name) {
-        return SinglePlayerSelectorArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional command argument
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull SinglePlayerSelectorArgument<C> optional(final @NonNull String name) {
-        return SinglePlayerSelectorArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new required command argument with a default value
-     *
-     * @param name                  Argument name
-     * @param defaultEntitySelector Default player
-     * @param <C>                   Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull SinglePlayerSelectorArgument<C> optional(
-            final @NonNull String name,
-            final @NonNull String defaultEntitySelector
-    ) {
-        return SinglePlayerSelectorArgument.<C>builder(name).asOptionalWithDefault(defaultEntitySelector).build();
+        return SinglePlayerSelectorArgument.<C>builder(name).build();
     }
 
 
@@ -148,9 +118,7 @@ public final class SinglePlayerSelectorArgument<C> extends CommandArgument<C, Si
         @Override
         public @NonNull SinglePlayerSelectorArgument<C> build() {
             return new SinglePlayerSelectorArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );

--- a/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/BungeePluginRegistrationHandler.java
+++ b/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/BungeePluginRegistrationHandler.java
@@ -46,7 +46,7 @@ final class BungeePluginRegistrationHandler<C> implements CommandRegistrationHan
     @Override
     public boolean registerCommand(final @NonNull Command<?> command) {
         /* We only care about the root command argument */
-        final CommandArgument<?, ?> commandArgument = command.getArguments().get(0);
+        final CommandArgument<?, ?> commandArgument = command.components().get(0).argument();
         if (this.registeredCommands.containsKey(commandArgument)) {
             return false;
         }

--- a/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/PlayerArgument.java
+++ b/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/PlayerArgument.java
@@ -54,19 +54,15 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class PlayerArgument<C> extends CommandArgument<C, ProxiedPlayer> {
 
     private PlayerArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>, @NonNull Queue<@NonNull String>,
                     @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
     ) {
         super(
-                required,
                 name,
                 new PlayerParser<>(),
-                defaultValue,
                 TypeToken.get(ProxiedPlayer.class),
                 suggestionProvider,
                 defaultDescription,
@@ -111,20 +107,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, ProxiedPlayer> {
     public static <C> CommandArgument<C, ProxiedPlayer> of(
             final @NonNull String name
     ) {
-        return PlayerArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional player argument
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     */
-    public static <C> CommandArgument<C, ProxiedPlayer> optional(
-            final @NonNull String name
-    ) {
-        return PlayerArgument.<C>builder(name).asOptional().build();
+        return PlayerArgument.<C>builder(name).build();
     }
 
 
@@ -139,9 +122,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, ProxiedPlayer> {
         @Override
         public @NonNull CommandArgument<@NonNull C, @NonNull ProxiedPlayer> build() {
             return new PlayerArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription(),
                     new LinkedList<>()

--- a/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/ServerArgument.java
+++ b/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/ServerArgument.java
@@ -54,19 +54,15 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class ServerArgument<C> extends CommandArgument<C, ServerInfo> {
 
     private ServerArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>, @NonNull Queue<@NonNull String>,
                     @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
     ) {
         super(
-                required,
                 name,
                 new ServerParser<>(),
-                defaultValue,
                 TypeToken.get(ServerInfo.class),
                 suggestionsProvider,
                 defaultDescription,
@@ -111,21 +107,9 @@ public final class ServerArgument<C> extends CommandArgument<C, ServerInfo> {
     public static <C> @NonNull CommandArgument<C, ServerInfo> of(
             final @NonNull String name
     ) {
-        return ServerArgument.<C>builder(name).asRequired().build();
+        return ServerArgument.<C>builder(name).build();
     }
 
-    /**
-     * Create a new optional server argument
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, ServerInfo> optional(
-            final @NonNull String name
-    ) {
-        return ServerArgument.<C>builder(name).asOptional().build();
-    }
 
     public static final class Builder<C> extends CommandArgument.Builder<C, ServerInfo> {
 
@@ -138,9 +122,7 @@ public final class ServerArgument<C> extends CommandArgument<C, ServerInfo> {
         @Override
         public @NonNull CommandArgument<@NonNull C, @NonNull ServerInfo> build() {
             return new ServerArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription(),
                     new LinkedList<>()

--- a/cloud-minecraft/cloud-cloudburst/src/main/java/cloud/commandframework/cloudburst/CloudburstPluginRegistrationHandler.java
+++ b/cloud-minecraft/cloud-cloudburst/src/main/java/cloud/commandframework/cloudburst/CloudburstPluginRegistrationHandler.java
@@ -50,7 +50,7 @@ class CloudburstPluginRegistrationHandler<C> implements CommandRegistrationHandl
     @SuppressWarnings("unchecked")
     public final boolean registerCommand(final @NonNull Command<?> command) {
         /* We only care about the root command argument */
-        final CommandArgument<?, ?> commandArgument = command.getArguments().get(0);
+        final CommandArgument<?, ?> commandArgument = command.components().get(0).argument();
         if (this.registeredCommands.containsKey(commandArgument)) {
             return false;
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/FabricCommandRegistrationHandler.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/FabricCommandRegistrationHandler.java
@@ -161,7 +161,7 @@ abstract class FabricCommandRegistrationHandler<C, S extends SharedSuggestionPro
                 final Command<C> command
         ) {
             final RootCommandNode<FabricClientCommandSource> rootNode = dispatcher.getRoot();
-            final StaticArgument<C> first = ((StaticArgument<C>) command.getArguments().get(0));
+            final StaticArgument<C> first = ((StaticArgument<C>) command.components().get(0).argument());
             final CommandNode<FabricClientCommandSource> baseNode = this.commandManager()
                     .brigadierManager()
                     .createLiteralCommandNode(
@@ -232,7 +232,7 @@ abstract class FabricCommandRegistrationHandler<C, S extends SharedSuggestionPro
         }
 
         private void registerCommand(final RootCommandNode<CommandSourceStack> dispatcher, final Command<C> command) {
-            @SuppressWarnings("unchecked") final StaticArgument<C> first = ((StaticArgument<C>) command.getArguments().get(0));
+            @SuppressWarnings("unchecked") final StaticArgument<C> first = ((StaticArgument<C>) command.components().get(0).argument());
             final CommandNode<CommandSourceStack> baseNode = this.commandManager().brigadierManager().createLiteralCommandNode(
                     first.getName(),
                     command,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/AngleArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/AngleArgument.java
@@ -41,17 +41,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class AngleArgument<C> extends CommandArgument<C, net.minecraft.commands.arguments.AngleArgument.SingleAngle> {
 
     AngleArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 new WrappedBrigadierParser<>(net.minecraft.commands.arguments.AngleArgument.angle()),
-                defaultValue,
                 net.minecraft.commands.arguments.AngleArgument.SingleAngle.class,
                 suggestionsProvider,
                 defaultDescription
@@ -79,35 +75,7 @@ public final class AngleArgument<C> extends CommandArgument<C, net.minecraft.com
      * @since 1.5.0
      */
     public static <C> @NonNull AngleArgument<C> of(final @NonNull String name) {
-        return AngleArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link AngleArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull AngleArgument<C> optional(final @NonNull String name) {
-        return AngleArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link AngleArgument} with the specified default value.
-     *
-     * @param name         Argument name
-     * @param defaultAngle Default angle, in degrees
-     * @param <C>          Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull AngleArgument<C> optional(
-            final @NonNull String name,
-            final float defaultAngle
-    ) {
-        return AngleArgument.<C>builder(name).asOptionalWithDefault(defaultAngle).build();
+        return AngleArgument.<C>builder(name).build();
     }
 
 
@@ -133,24 +101,10 @@ public final class AngleArgument<C> extends CommandArgument<C, net.minecraft.com
         @Override
         public @NonNull AngleArgument<C> build() {
             return new AngleArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );
-        }
-
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        public @NonNull Builder<C> asOptionalWithDefault(final float defaultValue) {
-            return this.asOptionalWithDefault(Float.toString(defaultValue));
         }
     }
 }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/AxisArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/AxisArgument.java
@@ -30,7 +30,6 @@ import cloud.commandframework.context.CommandContext;
 import io.leangen.geantyref.TypeToken;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Set;
 import java.util.function.BiFunction;
 import net.minecraft.commands.arguments.coordinates.SwizzleArgument;
 import net.minecraft.core.Direction;
@@ -49,17 +48,13 @@ public final class AxisArgument<C> extends CommandArgument<C, EnumSet<Direction.
     };
 
     AxisArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 new WrappedBrigadierParser<>(SwizzleArgument.swizzle()),
-                defaultValue,
                 TYPE,
                 suggestionsProvider,
                 defaultDescription
@@ -87,35 +82,7 @@ public final class AxisArgument<C> extends CommandArgument<C, EnumSet<Direction.
      * @since 1.5.0
      */
     public static <C> @NonNull AxisArgument<C> of(final @NonNull String name) {
-        return AxisArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link AxisArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull AxisArgument<C> optional(final @NonNull String name) {
-        return AxisArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link AxisArgument} with the specified default value.
-     *
-     * @param name         Argument name
-     * @param defaultValue Default axes to include
-     * @param <C>          Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull AxisArgument<C> optional(
-            final @NonNull String name,
-            final @NonNull Set<Direction.@NonNull Axis> defaultValue
-    ) {
-        return AxisArgument.<C>builder(name).asOptionalWithDefault(defaultValue).build();
+        return AxisArgument.<C>builder(name).build();
     }
 
 
@@ -140,31 +107,10 @@ public final class AxisArgument<C> extends CommandArgument<C, EnumSet<Direction.
         @Override
         public @NonNull AxisArgument<C> build() {
             return new AxisArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );
-        }
-
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        public @NonNull Builder<C> asOptionalWithDefault(final @NonNull Set<Direction.@NonNull Axis> defaultValue) {
-            if (defaultValue.isEmpty()) {
-                throw new IllegalArgumentException("Default value must include at least one Axis!");
-            }
-            final StringBuilder builder = new StringBuilder();
-            for (final Direction.Axis axis : defaultValue) {
-                builder.append(axis.getName());
-            }
-            return this.asOptionalWithDefault(builder.toString());
         }
     }
 }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/CompoundTagArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/CompoundTagArgument.java
@@ -42,17 +42,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class CompoundTagArgument<C> extends CommandArgument<C, CompoundTag> {
 
     CompoundTagArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 new WrappedBrigadierParser<>(net.minecraft.commands.arguments.CompoundTagArgument.compoundTag()),
-                defaultValue,
                 CompoundTag.class,
                 suggestionsProvider,
                 defaultDescription
@@ -80,35 +76,7 @@ public final class CompoundTagArgument<C> extends CommandArgument<C, CompoundTag
      * @since 1.5.0
      */
     public static <C> @NonNull CompoundTagArgument<C> of(final @NonNull String name) {
-        return CompoundTagArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link CompoundTagArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull CompoundTagArgument<C> optional(final @NonNull String name) {
-        return CompoundTagArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link CompoundTagArgument} with the specified default value.
-     *
-     * @param name       Component name
-     * @param defaultTag Default tag value
-     * @param <C>        Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull CompoundTagArgument<C> optional(
-            final @NonNull String name,
-            final @NonNull CompoundTag defaultTag
-    ) {
-        return CompoundTagArgument.<C>builder(name).asOptionalWithDefault(defaultTag).build();
+        return CompoundTagArgument.<C>builder(name).build();
     }
 
 
@@ -133,24 +101,10 @@ public final class CompoundTagArgument<C> extends CommandArgument<C, CompoundTag
         @Override
         public @NonNull CompoundTagArgument<C> build() {
             return new CompoundTagArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );
-        }
-
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        public @NonNull Builder<C> asOptionalWithDefault(final @NonNull CompoundTag defaultValue) {
-            return this.asOptionalWithDefault(defaultValue.toString());
         }
     }
 }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/EntityAnchorArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/EntityAnchorArgument.java
@@ -42,17 +42,13 @@ public final class EntityAnchorArgument<C> extends
         CommandArgument<C, net.minecraft.commands.arguments.EntityAnchorArgument.Anchor> {
 
     EntityAnchorArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 new WrappedBrigadierParser<>(net.minecraft.commands.arguments.EntityAnchorArgument.anchor()),
-                defaultValue,
                 net.minecraft.commands.arguments.EntityAnchorArgument.Anchor.class,
                 suggestionsProvider,
                 defaultDescription
@@ -80,35 +76,7 @@ public final class EntityAnchorArgument<C> extends
      * @since 1.5.0
      */
     public static <C> @NonNull EntityAnchorArgument<C> of(final @NonNull String name) {
-        return EntityAnchorArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link EntityAnchorArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull EntityAnchorArgument<C> optional(final @NonNull String name) {
-        return EntityAnchorArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link EntityAnchorArgument} with the specified default value.
-     *
-     * @param name         Argument name
-     * @param defaultValue Default value
-     * @param <C>          Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull EntityAnchorArgument<C> optional(
-            final @NonNull String name,
-            final net.minecraft.commands.arguments.EntityAnchorArgument.@NonNull Anchor defaultValue
-    ) {
-        return EntityAnchorArgument.<C>builder(name).asOptionalWithDefault(defaultValue).build();
+        return EntityAnchorArgument.<C>builder(name).build();
     }
 
 
@@ -134,26 +102,10 @@ public final class EntityAnchorArgument<C> extends
         @Override
         public @NonNull EntityAnchorArgument<C> build() {
             return new EntityAnchorArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );
-        }
-
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        public @NonNull Builder<C> asOptionalWithDefault(
-                final net.minecraft.commands.arguments.EntityAnchorArgument.@NonNull Anchor defaultValue
-        ) {
-            return this.asOptionalWithDefault(defaultValue.name());
         }
     }
 }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/FloatRangeArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/FloatRangeArgument.java
@@ -44,17 +44,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class FloatRangeArgument<C> extends CommandArgument<C, MinMaxBounds.Doubles> {
 
     FloatRangeArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 new WrappedBrigadierParser<>(RangeArgument.floatRange()),
-                defaultValue,
                 MinMaxBounds.Doubles.class,
                 suggestionsProvider,
                 defaultDescription
@@ -82,35 +78,7 @@ public final class FloatRangeArgument<C> extends CommandArgument<C, MinMaxBounds
      * @since 1.5.0
      */
     public static <C> @NonNull FloatRangeArgument<C> of(final @NonNull String name) {
-        return FloatRangeArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link FloatRangeArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull FloatRangeArgument<C> optional(final @NonNull String name) {
-        return FloatRangeArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link FloatRangeArgument} with the specified default value.
-     *
-     * @param name         Argument name
-     * @param defaultValue Default value
-     * @param <C>          Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull FloatRangeArgument<C> optional(
-            final @NonNull String name,
-            final MinMaxBounds.@NonNull Doubles defaultValue
-    ) {
-        return FloatRangeArgument.<C>builder(name).asOptionalWithDefault(defaultValue).build();
+        return FloatRangeArgument.<C>builder(name).build();
     }
 
 
@@ -135,32 +103,10 @@ public final class FloatRangeArgument<C> extends CommandArgument<C, MinMaxBounds
         @Override
         public @NonNull FloatRangeArgument<C> build() {
             return new FloatRangeArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );
-        }
-
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        public @NonNull Builder<C> asOptionalWithDefault(final MinMaxBounds.@NonNull Doubles defaultValue) {
-            final StringBuilder value = new StringBuilder(6);
-            if (defaultValue.getMin() != null) {
-                value.append(defaultValue.getMin());
-            }
-            value.append("..");
-            if (defaultValue.getMax() != null) {
-                value.append(defaultValue.getMax());
-            }
-            return this.asOptionalWithDefault(value.toString());
         }
     }
 }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/IntRangeArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/IntRangeArgument.java
@@ -44,17 +44,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class IntRangeArgument<C> extends CommandArgument<C, MinMaxBounds.Ints> {
 
     IntRangeArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 new WrappedBrigadierParser<>(RangeArgument.intRange()),
-                defaultValue,
                 MinMaxBounds.Ints.class,
                 suggestionsProvider,
                 defaultDescription
@@ -82,35 +78,7 @@ public final class IntRangeArgument<C> extends CommandArgument<C, MinMaxBounds.I
      * @since 1.5.0
      */
     public static <C> @NonNull IntRangeArgument<C> of(final @NonNull String name) {
-        return IntRangeArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link IntRangeArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull IntRangeArgument<C> optional(final @NonNull String name) {
-        return IntRangeArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link IntRangeArgument} with the specified default value.
-     *
-     * @param name         Argument name
-     * @param defaultValue Default value
-     * @param <C>          Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull IntRangeArgument<C> optional(
-            final @NonNull String name,
-            final MinMaxBounds.@NonNull Ints defaultValue
-    ) {
-        return IntRangeArgument.<C>builder(name).asOptionalWithDefault(defaultValue).build();
+        return IntRangeArgument.<C>builder(name).build();
     }
 
 
@@ -135,32 +103,10 @@ public final class IntRangeArgument<C> extends CommandArgument<C, MinMaxBounds.I
         @Override
         public @NonNull IntRangeArgument<C> build() {
             return new IntRangeArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );
-        }
-
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        public @NonNull Builder<C> asOptionalWithDefault(final MinMaxBounds.@NonNull Ints defaultValue) {
-            final StringBuilder value = new StringBuilder(6);
-            if (defaultValue.getMin() != null) {
-                value.append(defaultValue.getMin());
-            }
-            value.append("..");
-            if (defaultValue.getMax() != null) {
-                value.append(defaultValue.getMax());
-            }
-            return this.asOptionalWithDefault(value.toString());
         }
     }
 }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ItemInputArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ItemInputArgument.java
@@ -30,8 +30,6 @@ import java.util.List;
 import java.util.function.BiFunction;
 import net.minecraft.commands.arguments.item.ItemArgument;
 import net.minecraft.commands.arguments.item.ItemInput;
-import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.world.item.ItemStack;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -44,17 +42,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class ItemInputArgument<C> extends CommandArgument<C, ItemInput> {
 
     ItemInputArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 FabricArgumentParsers.contextual(ItemArgument::item),
-                defaultValue,
                 ItemInput.class,
                 suggestionsProvider,
                 defaultDescription
@@ -82,33 +76,9 @@ public final class ItemInputArgument<C> extends CommandArgument<C, ItemInput> {
      * @since 1.5.0
      */
     public static <C> @NonNull ItemInputArgument<C> of(final @NonNull String name) {
-        return ItemInputArgument.<C>builder(name).asRequired().build();
+        return ItemInputArgument.<C>builder(name).build();
     }
 
-    /**
-     * Create a new optional {@link ItemInputArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull ItemInputArgument<C> optional(final @NonNull String name) {
-        return ItemInputArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link ItemInputArgument} with the specified default value.
-     *
-     * @param name         Argument name
-     * @param defaultValue Default value
-     * @param <C>          Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull ItemInputArgument<C> optional(final @NonNull String name, final @NonNull ItemStack defaultValue) {
-        return ItemInputArgument.<C>builder(name).asOptionalWithDefault(defaultValue).build();
-    }
 
     /**
      * Builder for {@link ItemInputArgument}.
@@ -131,30 +101,10 @@ public final class ItemInputArgument<C> extends CommandArgument<C, ItemInput> {
         @Override
         public @NonNull ItemInputArgument<C> build() {
             return new ItemInputArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );
-        }
-
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        public @NonNull Builder<C> asOptionalWithDefault(final @NonNull ItemStack defaultValue) {
-            final String serializedDefault;
-            if (defaultValue.hasTag()) {
-                serializedDefault = BuiltInRegistries.ITEM.getKey(defaultValue.getItem()) + defaultValue.getTag().toString();
-            } else {
-                serializedDefault = BuiltInRegistries.ITEM.getKey(defaultValue.getItem()).toString();
-            }
-            return this.asOptionalWithDefault(serializedDefault);
         }
     }
 }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/MobEffectArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/MobEffectArgument.java
@@ -28,7 +28,6 @@ import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.context.CommandContext;
 import java.util.List;
 import java.util.function.BiFunction;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.effect.MobEffect;
 import org.apiguardian.api.API;
@@ -47,17 +46,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class MobEffectArgument<C> extends CommandArgument<C, MobEffect> {
 
     MobEffectArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 new RegistryEntryArgument.Parser<>(Registries.MOB_EFFECT),
-                defaultValue,
                 MobEffect.class,
                 suggestionsProvider,
                 defaultDescription
@@ -85,35 +80,7 @@ public final class MobEffectArgument<C> extends CommandArgument<C, MobEffect> {
      * @since 1.5.0
      */
     public static <C> @NonNull MobEffectArgument<C> of(final @NonNull String name) {
-        return MobEffectArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link MobEffectArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull MobEffectArgument<C> optional(final @NonNull String name) {
-        return MobEffectArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link MobEffectArgument} with the specified default value.
-     *
-     * @param name         Argument name
-     * @param defaultValue Default value
-     * @param <C>          Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull MobEffectArgument<C> optional(
-            final @NonNull String name,
-            final @NonNull MobEffect defaultValue
-    ) {
-        return MobEffectArgument.<C>builder(name).asOptionalWithDefault(defaultValue).build();
+        return MobEffectArgument.<C>builder(name).build();
     }
 
 
@@ -138,24 +105,10 @@ public final class MobEffectArgument<C> extends CommandArgument<C, MobEffect> {
         @Override
         public @NonNull MobEffectArgument<C> build() {
             return new MobEffectArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );
-        }
-
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        public @NonNull Builder<C> asOptionalWithDefault(final @NonNull MobEffect defaultValue) {
-            return this.asOptionalWithDefault(BuiltInRegistries.MOB_EFFECT.getKey(defaultValue).toString());
         }
     }
 }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/NamedColorArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/NamedColorArgument.java
@@ -42,17 +42,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class NamedColorArgument<C> extends CommandArgument<C, ChatFormatting> {
 
     NamedColorArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 new WrappedBrigadierParser<>(net.minecraft.commands.arguments.ColorArgument.color()),
-                defaultValue,
                 ChatFormatting.class,
                 suggestionsProvider,
                 defaultDescription
@@ -80,35 +76,7 @@ public final class NamedColorArgument<C> extends CommandArgument<C, ChatFormatti
      * @since 1.5.0
      */
     public static <C> @NonNull NamedColorArgument<C> of(final @NonNull String name) {
-        return NamedColorArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link NamedColorArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created component
-     * @since 1.5.0
-     */
-    public static <C> @NonNull NamedColorArgument<C> optional(final @NonNull String name) {
-        return NamedColorArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link NamedColorArgument} with the specified default value.
-     *
-     * @param name         Component name
-     * @param defaultColor Default colour, must be {@link ChatFormatting#isColor() a color}
-     * @param <C>          Command sender type
-     * @return Created component
-     * @since 1.5.0
-     */
-    public static <C> @NonNull NamedColorArgument<C> optional(
-            final @NonNull String name,
-            final @NonNull ChatFormatting defaultColor
-    ) {
-        return NamedColorArgument.<C>builder(name).asOptionalWithDefault(defaultColor).build();
+        return NamedColorArgument.<C>builder(name).build();
     }
 
 
@@ -133,27 +101,10 @@ public final class NamedColorArgument<C> extends CommandArgument<C, ChatFormatti
         @Override
         public @NonNull NamedColorArgument<C> build() {
             return new NamedColorArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );
-        }
-
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultColor default value, must be {@link ChatFormatting#isColor() a color}
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        public @NonNull Builder<C> asOptionalWithDefault(final @NonNull ChatFormatting defaultColor) {
-            if (!defaultColor.isColor()) {
-                throw new IllegalArgumentException("Only color types are allowed but " + defaultColor + " was provided");
-            }
-            return this.asOptionalWithDefault(defaultColor.toString());
         }
     }
 }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/NbtPathArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/NbtPathArgument.java
@@ -42,17 +42,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class NbtPathArgument<C> extends CommandArgument<C, net.minecraft.commands.arguments.NbtPathArgument.NbtPath> {
 
     NbtPathArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 new WrappedBrigadierParser<>(net.minecraft.commands.arguments.NbtPathArgument.nbtPath()),
-                defaultValue,
                 net.minecraft.commands.arguments.NbtPathArgument.NbtPath.class,
                 suggestionsProvider,
                 defaultDescription
@@ -80,35 +76,7 @@ public final class NbtPathArgument<C> extends CommandArgument<C, net.minecraft.c
      * @since 1.5.0
      */
     public static <C> @NonNull NbtPathArgument<C> of(final @NonNull String name) {
-        return NbtPathArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link NbtPathArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull NbtPathArgument<C> optional(final @NonNull String name) {
-        return NbtPathArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link NbtPathArgument} with the specified default value.
-     *
-     * @param name       Component name
-     * @param defaultTag Default tag value
-     * @param <C>        Command sender type
-     * @return Created component
-     * @since 1.5.0
-     */
-    public static <C> @NonNull NbtPathArgument<C> optional(
-            final @NonNull String name,
-            final net.minecraft.commands.arguments.NbtPathArgument.@NonNull NbtPath defaultTag
-    ) {
-        return NbtPathArgument.<C>builder(name).asOptionalWithDefault(defaultTag).build();
+        return NbtPathArgument.<C>builder(name).build();
     }
 
 
@@ -134,26 +102,10 @@ public final class NbtPathArgument<C> extends CommandArgument<C, net.minecraft.c
         @Override
         public @NonNull NbtPathArgument<C> build() {
             return new NbtPathArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );
-        }
-
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        public @NonNull Builder<C> asOptionalWithDefault(
-                final net.minecraft.commands.arguments.NbtPathArgument.@NonNull NbtPath defaultValue
-        ) {
-            return this.asOptionalWithDefault(defaultValue.toString());
         }
     }
 }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/NbtTagArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/NbtTagArgument.java
@@ -42,17 +42,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class NbtTagArgument<C> extends CommandArgument<C, Tag> {
 
     NbtTagArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 new WrappedBrigadierParser<>(net.minecraft.commands.arguments.NbtTagArgument.nbtTag()),
-                defaultValue,
                 Tag.class,
                 suggestionsProvider,
                 defaultDescription
@@ -80,32 +76,7 @@ public final class NbtTagArgument<C> extends CommandArgument<C, Tag> {
      * @since 1.5.0
      */
     public static <C> @NonNull NbtTagArgument<C> of(final @NonNull String name) {
-        return NbtTagArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link NbtTagArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull NbtTagArgument<C> optional(final @NonNull String name) {
-        return NbtTagArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link NbtTagArgument} with the specified default value.
-     *
-     * @param name       Component name
-     * @param defaultTag Default tag value
-     * @param <C>        Command sender type
-     * @return Created component
-     * @since 1.5.0
-     */
-    public static <C> @NonNull NbtTagArgument<C> optional(final @NonNull String name, final @NonNull Tag defaultTag) {
-        return NbtTagArgument.<C>builder(name).asOptionalWithDefault(defaultTag).build();
+        return NbtTagArgument.<C>builder(name).build();
     }
 
 
@@ -130,24 +101,10 @@ public final class NbtTagArgument<C> extends CommandArgument<C, Tag> {
         @Override
         public @NonNull NbtTagArgument<C> build() {
             return new NbtTagArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );
-        }
-
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        public @NonNull Builder<C> asOptionalWithDefault(final @NonNull Tag defaultValue) {
-            return this.asOptionalWithDefault(defaultValue.toString());
         }
     }
 }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ObjectiveCriteriaArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ObjectiveCriteriaArgument.java
@@ -42,17 +42,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class ObjectiveCriteriaArgument<C> extends CommandArgument<C, ObjectiveCriteria> {
 
     ObjectiveCriteriaArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 new WrappedBrigadierParser<>(net.minecraft.commands.arguments.ObjectiveCriteriaArgument.criteria()),
-                defaultValue,
                 ObjectiveCriteria.class,
                 suggestionsProvider,
                 defaultDescription
@@ -80,35 +76,7 @@ public final class ObjectiveCriteriaArgument<C> extends CommandArgument<C, Objec
      * @since 1.5.0
      */
     public static <C> @NonNull ObjectiveCriteriaArgument<C> of(final @NonNull String name) {
-        return ObjectiveCriteriaArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link ObjectiveCriteriaArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull ObjectiveCriteriaArgument<C> optional(final @NonNull String name) {
-        return ObjectiveCriteriaArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link ObjectiveCriteriaArgument} with the specified default value.
-     *
-     * @param name             Argument name
-     * @param defaultCriterion Default criterion
-     * @param <C>              Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull ObjectiveCriteriaArgument<C> optional(
-            final @NonNull String name,
-            final @NonNull ObjectiveCriteria defaultCriterion
-    ) {
-        return ObjectiveCriteriaArgument.<C>builder(name).asOptionalWithDefault(defaultCriterion).build();
+        return ObjectiveCriteriaArgument.<C>builder(name).build();
     }
 
 
@@ -133,24 +101,10 @@ public final class ObjectiveCriteriaArgument<C> extends CommandArgument<C, Objec
         @Override
         public @NonNull ObjectiveCriteriaArgument<C> build() {
             return new ObjectiveCriteriaArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );
-        }
-
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        public @NonNull Builder<C> asOptionalWithDefault(final @NonNull ObjectiveCriteria defaultValue) {
-            return this.asOptionalWithDefault(defaultValue.getName());
         }
     }
 }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ParticleArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ParticleArgument.java
@@ -41,17 +41,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class ParticleArgument<C> extends CommandArgument<C, ParticleOptions> {
 
     ParticleArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 FabricArgumentParsers.contextual(net.minecraft.commands.arguments.ParticleArgument::particle),
-                defaultValue,
                 ParticleOptions.class,
                 suggestionsProvider,
                 defaultDescription
@@ -79,35 +75,7 @@ public final class ParticleArgument<C> extends CommandArgument<C, ParticleOption
      * @since 1.5.0
      */
     public static <C> @NonNull ParticleArgument<C> of(final @NonNull String name) {
-        return ParticleArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link ParticleArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull ParticleArgument<C> optional(final @NonNull String name) {
-        return ParticleArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link ParticleArgument} with the specified default value.
-     *
-     * @param name         Argument name
-     * @param defaultValue Default particle effect value
-     * @param <C>          Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull ParticleArgument<C> optional(
-            final @NonNull String name,
-            final @NonNull ParticleOptions defaultValue
-    ) {
-        return ParticleArgument.<C>builder(name).asOptionalWithDefault(defaultValue).build();
+        return ParticleArgument.<C>builder(name).build();
     }
 
 
@@ -132,24 +100,10 @@ public final class ParticleArgument<C> extends CommandArgument<C, ParticleOption
         @Override
         public @NonNull ParticleArgument<C> build() {
             return new ParticleArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );
-        }
-
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        public @NonNull Builder<C> asOptionalWithDefault(final @NonNull ParticleOptions defaultValue) {
-            return this.asOptionalWithDefault(defaultValue.writeToString());
         }
     }
 }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/RegistryEntryArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/RegistryEntryArgument.java
@@ -64,19 +64,15 @@ public class RegistryEntryArgument<C, V> extends CommandArgument<C, V> {
     private static final String NAMESPACE_MINECRAFT = "minecraft";
 
     RegistryEntryArgument(
-            final boolean required,
             final @NonNull String name,
             final @NonNull ResourceKey<? extends Registry<V>> registry,
-            final @NonNull String defaultValue,
             final @NonNull TypeToken<V> valueType,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 new Parser<>(registry),
-                defaultValue,
                 valueType,
                 suggestionsProvider,
                 defaultDescription
@@ -137,50 +133,9 @@ public class RegistryEntryArgument<C, V> extends CommandArgument<C, V> {
             final @NonNull Class<V> type,
             final @NonNull ResourceKey<? extends Registry<V>> registry
     ) {
-        return RegistryEntryArgument.<C, V>newBuilder(name, type, registry).asRequired().build();
+        return RegistryEntryArgument.<C, V>newBuilder(name, type, registry).build();
     }
 
-    /**
-     * Create a new optional {@link RegistryEntryArgument}.
-     *
-     * @param name     Argument name
-     * @param type     The type of registry entry
-     * @param registry A key for the registry to get values from
-     * @param <C>      Command sender type
-     * @param <V>      Registry entry type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C, V> @NonNull RegistryEntryArgument<C, V> optional(
-            final @NonNull String name,
-            final @NonNull Class<V> type,
-            final @NonNull ResourceKey<? extends Registry<V>> registry
-    ) {
-        return RegistryEntryArgument.<C, V>newBuilder(name, type, registry).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link RegistryEntryArgument} with the specified default value.
-     *
-     * @param name         Argument name
-     * @param type         The type of registry entry
-     * @param registry     A key for the registry to get values from
-     * @param defaultValue Default value
-     * @param <C>          Command sender type
-     * @param <V>          Registry entry type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C, V> @NonNull RegistryEntryArgument<C, V> optional(
-            final @NonNull String name,
-            final @NonNull Class<V> type,
-            final @NonNull ResourceKey<? extends Registry<V>> registry,
-            final @NonNull ResourceKey<V> defaultValue
-    ) {
-        return RegistryEntryArgument.<C, V>newBuilder(name, type, registry)
-                .asOptionalWithDefault(defaultValue)
-                .build();
-    }
 
     /**
      * A parser for values stored in a {@link Registry}.
@@ -304,26 +259,12 @@ public class RegistryEntryArgument<C, V> extends CommandArgument<C, V> {
         @Override
         public @NonNull RegistryEntryArgument<@NonNull C, @NonNull V> build() {
             return new RegistryEntryArgument<>(
-                    this.isRequired(),
                     this.getName(),
                     this.registryIdent,
-                    this.getDefaultValue(),
                     this.getValueType(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );
-        }
-
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        public @NonNull Builder<C, V> asOptionalWithDefault(final @NonNull ResourceKey<V> defaultValue) {
-            return this.asOptionalWithDefault(defaultValue.location().toString());
         }
     }
 

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ResourceLocationArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ResourceLocationArgument.java
@@ -42,17 +42,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class ResourceLocationArgument<C> extends CommandArgument<C, ResourceLocation> {
 
     ResourceLocationArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 new WrappedBrigadierParser<>(net.minecraft.commands.arguments.ResourceLocationArgument.id()),
-                defaultValue,
                 ResourceLocation.class,
                 suggestionsProvider,
                 defaultDescription
@@ -80,35 +76,7 @@ public final class ResourceLocationArgument<C> extends CommandArgument<C, Resour
      * @since 1.5.0
      */
     public static <C> @NonNull ResourceLocationArgument<C> of(final @NonNull String name) {
-        return ResourceLocationArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link ResourceLocationArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull ResourceLocationArgument<C> optional(final @NonNull String name) {
-        return ResourceLocationArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link ResourceLocationArgument} with the specified default value.
-     *
-     * @param name         Argument name
-     * @param defaultValue Default value
-     * @param <C>          Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull ResourceLocationArgument<C> optional(
-            final @NonNull String name,
-            final @NonNull ResourceLocation defaultValue
-    ) {
-        return ResourceLocationArgument.<C>builder(name).asOptionalWithDefault(defaultValue).build();
+        return ResourceLocationArgument.<C>builder(name).build();
     }
 
 
@@ -133,24 +101,10 @@ public final class ResourceLocationArgument<C> extends CommandArgument<C, Resour
         @Override
         public @NonNull ResourceLocationArgument<C> build() {
             return new ResourceLocationArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );
-        }
-
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        public @NonNull Builder<C> asOptionalWithDefault(final @NonNull ResourceLocation defaultValue) {
-            return this.asOptionalWithDefault(defaultValue.toString());
         }
     }
 }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ScoreboardOperationArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ScoreboardOperationArgument.java
@@ -45,17 +45,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class ScoreboardOperationArgument<C> extends CommandArgument<C, Operation> {
 
     ScoreboardOperationArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 new WrappedBrigadierParser<>(OperationArgument.operation()),
-                defaultValue,
                 Operation.class,
                 suggestionsProvider,
                 defaultDescription
@@ -83,20 +79,9 @@ public final class ScoreboardOperationArgument<C> extends CommandArgument<C, Ope
      * @since 1.5.0
      */
     public static <C> @NonNull ScoreboardOperationArgument<C> of(final @NonNull String name) {
-        return ScoreboardOperationArgument.<C>builder(name).asRequired().build();
+        return ScoreboardOperationArgument.<C>builder(name).build();
     }
 
-    /**
-     * Create a new optional {@link ScoreboardOperationArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull ScoreboardOperationArgument<C> optional(final @NonNull String name) {
-        return ScoreboardOperationArgument.<C>builder(name).asOptional().build();
-    }
 
     /**
      * Builder for {@link ScoreboardOperationArgument}.
@@ -119,9 +104,7 @@ public final class ScoreboardOperationArgument<C> extends CommandArgument<C, Ope
         @Override
         public @NonNull ScoreboardOperationArgument<C> build() {
             return new ScoreboardOperationArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/TeamArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/TeamArgument.java
@@ -51,17 +51,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class TeamArgument<C> extends CommandArgument<C, PlayerTeam> {
 
     TeamArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 new TeamParser<>(),
-                defaultValue,
                 PlayerTeam.class,
                 suggestionsProvider,
                 defaultDescription
@@ -89,36 +85,9 @@ public final class TeamArgument<C> extends CommandArgument<C, PlayerTeam> {
      * @since 1.5.0
      */
     public static <C> @NonNull TeamArgument<C> of(final @NonNull String name) {
-        return TeamArgument.<C>builder(name).asRequired().build();
+        return TeamArgument.<C>builder(name).build();
     }
 
-    /**
-     * Create a new optional {@link TeamArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull TeamArgument<C> optional(final @NonNull String name) {
-        return TeamArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link TeamArgument} with the specified default value.
-     *
-     * @param name         Argument name
-     * @param defaultValue Default value
-     * @param <C>          Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull TeamArgument<C> optional(
-            final @NonNull String name,
-            final @NonNull PlayerTeam defaultValue
-    ) {
-        return TeamArgument.<C>builder(name).asOptionalWithDefault(defaultValue).build();
-    }
 
     /**
      * Argument parser for {@link PlayerTeam Teams}.
@@ -175,6 +144,7 @@ public final class TeamArgument<C> extends CommandArgument<C, PlayerTeam> {
         }
     }
 
+
     /**
      * Builder for {@link TeamArgument}.
      *
@@ -196,24 +166,10 @@ public final class TeamArgument<C> extends CommandArgument<C, PlayerTeam> {
         @Override
         public @NonNull TeamArgument<C> build() {
             return new TeamArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );
-        }
-
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        public @NonNull Builder<C> asOptionalWithDefault(final @NonNull PlayerTeam defaultValue) {
-            return this.asOptionalWithDefault(defaultValue.getName());
         }
     }
 

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/TimeArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/TimeArgument.java
@@ -41,17 +41,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class TimeArgument<C> extends CommandArgument<C, MinecraftTime> {
 
     TimeArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 FabricArgumentParsers.time(),
-                defaultValue,
                 MinecraftTime.class,
                 suggestionsProvider,
                 defaultDescription
@@ -79,35 +75,7 @@ public final class TimeArgument<C> extends CommandArgument<C, MinecraftTime> {
      * @since 1.5.0
      */
     public static <C> @NonNull TimeArgument<C> of(final @NonNull String name) {
-        return TimeArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link TimeArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull TimeArgument<C> optional(final @NonNull String name) {
-        return TimeArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link TimeArgument} with the specified default value.
-     *
-     * @param name        Argument name
-     * @param defaultTime Default time, in ticks
-     * @param <C>         Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull TimeArgument<C> optional(
-            final @NonNull String name,
-            final @NonNull MinecraftTime defaultTime
-    ) {
-        return TimeArgument.<C>builder(name).asOptionalWithDefault(defaultTime).build();
+        return TimeArgument.<C>builder(name).build();
     }
 
 
@@ -132,24 +100,10 @@ public final class TimeArgument<C> extends CommandArgument<C, MinecraftTime> {
         @Override
         public @NonNull TimeArgument<C> build() {
             return new TimeArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );
-        }
-
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        public @NonNull Builder<C> asOptionalWithDefault(final @NonNull MinecraftTime defaultValue) {
-            return this.asOptionalWithDefault(defaultValue.toString());
         }
     }
 }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/BlockPosArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/BlockPosArgument.java
@@ -30,7 +30,6 @@ import cloud.commandframework.fabric.argument.FabricArgumentParsers;
 import cloud.commandframework.fabric.data.Coordinates.BlockCoordinates;
 import java.util.List;
 import java.util.function.BiFunction;
-import net.minecraft.core.BlockPos;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -43,17 +42,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class BlockPosArgument<C> extends CommandArgument<C, BlockCoordinates> {
 
     BlockPosArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 FabricArgumentParsers.blockPos(),
-                defaultValue,
                 BlockCoordinates.class,
                 suggestionsProvider,
                 defaultDescription
@@ -81,35 +76,9 @@ public final class BlockPosArgument<C> extends CommandArgument<C, BlockCoordinat
      * @since 1.5.0
      */
     public static <C> @NonNull BlockPosArgument<C> of(final @NonNull String name) {
-        return BlockPosArgument.<C>builder(name).asRequired().build();
+        return BlockPosArgument.<C>builder(name).build();
     }
 
-    /**
-     * Create a new optional {@link BlockPosArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull BlockPosArgument<C> optional(final @NonNull String name) {
-        return BlockPosArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link BlockPosArgument} with the specified default value.
-     *
-     * @param name         Component name
-     * @param defaultValue default value
-     * @param <C>          Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull BlockPosArgument<C> optional(final @NonNull String name, final @NonNull BlockPos defaultValue) {
-        return BlockPosArgument.<C>builder(name)
-                .asOptionalWithDefault(defaultValue)
-                .build();
-    }
 
     /**
      * Builder for {@link BlockPosArgument}.
@@ -132,29 +101,10 @@ public final class BlockPosArgument<C> extends CommandArgument<C, BlockCoordinat
         @Override
         public @NonNull BlockPosArgument<C> build() {
             return new BlockPosArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );
-        }
-
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        public @NonNull Builder<C> asOptionalWithDefault(final @NonNull BlockPos defaultValue) {
-            return this.asOptionalWithDefault(String.format(
-                    "%s %s %s",
-                    defaultValue.getX(),
-                    defaultValue.getY(),
-                    defaultValue.getZ()
-            ));
         }
     }
 }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/ColumnPosArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/ColumnPosArgument.java
@@ -30,7 +30,6 @@ import cloud.commandframework.fabric.argument.FabricArgumentParsers;
 import cloud.commandframework.fabric.data.Coordinates.ColumnCoordinates;
 import java.util.List;
 import java.util.function.BiFunction;
-import net.minecraft.core.BlockPos;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -43,17 +42,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class ColumnPosArgument<C> extends CommandArgument<C, ColumnCoordinates> {
 
     ColumnPosArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 FabricArgumentParsers.columnPos(),
-                defaultValue,
                 ColumnCoordinates.class,
                 suggestionsProvider,
                 defaultDescription
@@ -81,35 +76,9 @@ public final class ColumnPosArgument<C> extends CommandArgument<C, ColumnCoordin
      * @since 1.5.0
      */
     public static <C> @NonNull ColumnPosArgument<C> of(final @NonNull String name) {
-        return ColumnPosArgument.<C>builder(name).asRequired().build();
+        return ColumnPosArgument.<C>builder(name).build();
     }
 
-    /**
-     * Create a new optional {@link ColumnPosArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull ColumnPosArgument<C> optional(final @NonNull String name) {
-        return ColumnPosArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link ColumnPosArgument} with the specified default value.
-     *
-     * @param name         Component name
-     * @param defaultValue default value, y coordinate will be ignored as it is always 0
-     * @param <C>          Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull ColumnPosArgument<C> optional(final @NonNull String name, final @NonNull BlockPos defaultValue) {
-        return ColumnPosArgument.<C>builder(name)
-                .asOptionalWithDefault(defaultValue)
-                .build();
-    }
 
     /**
      * Builder for {@link ColumnPosArgument}.
@@ -132,28 +101,10 @@ public final class ColumnPosArgument<C> extends CommandArgument<C, ColumnCoordin
         @Override
         public @NonNull ColumnPosArgument<C> build() {
             return new ColumnPosArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );
-        }
-
-        /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        public @NonNull Builder<C> asOptionalWithDefault(final @NonNull BlockPos defaultValue) {
-            return this.asOptionalWithDefault(String.format(
-                    "%s %s",
-                    defaultValue.getX(),
-                    defaultValue.getZ()
-            ));
         }
     }
 }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/MessageArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/MessageArgument.java
@@ -42,17 +42,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class MessageArgument<C> extends CommandArgument<C, Message> {
 
     MessageArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 FabricArgumentParsers.message(),
-                defaultValue,
                 Message.class,
                 suggestionsProvider,
                 defaultDescription
@@ -80,35 +76,7 @@ public final class MessageArgument<C> extends CommandArgument<C, Message> {
      * @since 1.5.0
      */
     public static <C> @NonNull MessageArgument<C> of(final @NonNull String name) {
-        return MessageArgument.<C>builder(name).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link MessageArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull MessageArgument<C> optional(final @NonNull String name) {
-        return MessageArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link MessageArgument} with the specified value.
-     *
-     * @param name         Argument name
-     * @param defaultValue Default value
-     * @param <C>          Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull MessageArgument<C> optional(
-            final @NonNull String name,
-            final @NonNull String defaultValue
-    ) {
-        return MessageArgument.<C>builder(name).asOptionalWithDefault(defaultValue).build();
+        return MessageArgument.<C>builder(name).build();
     }
 
 
@@ -133,9 +101,7 @@ public final class MessageArgument<C> extends CommandArgument<C, Message> {
         @Override
         public @NonNull MessageArgument<C> build() {
             return new MessageArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/MultipleEntitySelectorArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/MultipleEntitySelectorArgument.java
@@ -43,17 +43,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class MultipleEntitySelectorArgument<C> extends CommandArgument<C, MultipleEntitySelector> {
 
     MultipleEntitySelectorArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 FabricArgumentParsers.multipleEntitySelector(),
-                defaultValue,
                 MultipleEntitySelector.class,
                 suggestionsProvider,
                 defaultDescription
@@ -81,20 +77,9 @@ public final class MultipleEntitySelectorArgument<C> extends CommandArgument<C, 
      * @since 1.5.0
      */
     public static <C> @NonNull MultipleEntitySelectorArgument<C> of(final @NonNull String name) {
-        return MultipleEntitySelectorArgument.<C>builder(name).asRequired().build();
+        return MultipleEntitySelectorArgument.<C>builder(name).build();
     }
 
-    /**
-     * Create a new optional {@link MultipleEntitySelectorArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull MultipleEntitySelectorArgument<C> optional(final @NonNull String name) {
-        return MultipleEntitySelectorArgument.<C>builder(name).asOptional().build();
-    }
 
     /**
      * Builder for {@link MultipleEntitySelectorArgument}.
@@ -117,9 +102,7 @@ public final class MultipleEntitySelectorArgument<C> extends CommandArgument<C, 
         @Override
         public @NonNull MultipleEntitySelectorArgument<C> build() {
             return new MultipleEntitySelectorArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/MultiplePlayerSelectorArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/MultiplePlayerSelectorArgument.java
@@ -43,17 +43,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class MultiplePlayerSelectorArgument<C> extends CommandArgument<C, MultiplePlayerSelector> {
 
     MultiplePlayerSelectorArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 FabricArgumentParsers.multiplePlayerSelector(),
-                defaultValue,
                 MultiplePlayerSelector.class,
                 suggestionsProvider,
                 defaultDescription
@@ -81,20 +77,9 @@ public final class MultiplePlayerSelectorArgument<C> extends CommandArgument<C, 
      * @since 1.5.0
      */
     public static <C> @NonNull MultiplePlayerSelectorArgument<C> of(final @NonNull String name) {
-        return MultiplePlayerSelectorArgument.<C>builder(name).asRequired().build();
+        return MultiplePlayerSelectorArgument.<C>builder(name).build();
     }
 
-    /**
-     * Create a new optional {@link MultiplePlayerSelectorArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull MultiplePlayerSelectorArgument<C> optional(final @NonNull String name) {
-        return MultiplePlayerSelectorArgument.<C>builder(name).asOptional().build();
-    }
 
     /**
      * Builder for {@link MultiplePlayerSelectorArgument}.
@@ -117,9 +102,7 @@ public final class MultiplePlayerSelectorArgument<C> extends CommandArgument<C, 
         @Override
         public @NonNull MultiplePlayerSelectorArgument<C> build() {
             return new MultiplePlayerSelectorArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/SingleEntitySelectorArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/SingleEntitySelectorArgument.java
@@ -43,17 +43,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class SingleEntitySelectorArgument<C> extends CommandArgument<C, SingleEntitySelector> {
 
     SingleEntitySelectorArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 FabricArgumentParsers.singleEntitySelector(),
-                defaultValue,
                 SingleEntitySelector.class,
                 suggestionsProvider,
                 defaultDescription
@@ -81,20 +77,9 @@ public final class SingleEntitySelectorArgument<C> extends CommandArgument<C, Si
      * @since 1.5.0
      */
     public static <C> @NonNull SingleEntitySelectorArgument<C> of(final @NonNull String name) {
-        return SingleEntitySelectorArgument.<C>builder(name).asRequired().build();
+        return SingleEntitySelectorArgument.<C>builder(name).build();
     }
 
-    /**
-     * Create a new optional {@link SingleEntitySelectorArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull SingleEntitySelectorArgument<C> optional(final @NonNull String name) {
-        return SingleEntitySelectorArgument.<C>builder(name).asOptional().build();
-    }
 
     /**
      * Builder for {@link SingleEntitySelectorArgument}.
@@ -117,9 +102,7 @@ public final class SingleEntitySelectorArgument<C> extends CommandArgument<C, Si
         @Override
         public @NonNull SingleEntitySelectorArgument<C> build() {
             return new SingleEntitySelectorArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/SinglePlayerSelectorArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/SinglePlayerSelectorArgument.java
@@ -43,17 +43,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class SinglePlayerSelectorArgument<C> extends CommandArgument<C, SinglePlayerSelector> {
 
     SinglePlayerSelectorArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
-                required,
                 name,
                 FabricArgumentParsers.singlePlayerSelector(),
-                defaultValue,
                 SinglePlayerSelector.class,
                 suggestionsProvider,
                 defaultDescription
@@ -81,20 +77,9 @@ public final class SinglePlayerSelectorArgument<C> extends CommandArgument<C, Si
      * @since 1.5.0
      */
     public static <C> @NonNull SinglePlayerSelectorArgument<C> of(final @NonNull String name) {
-        return SinglePlayerSelectorArgument.<C>builder(name).asRequired().build();
+        return SinglePlayerSelectorArgument.<C>builder(name).build();
     }
 
-    /**
-     * Create a new optional {@link SinglePlayerSelectorArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull SinglePlayerSelectorArgument<C> optional(final @NonNull String name) {
-        return SinglePlayerSelectorArgument.<C>builder(name).asOptional().build();
-    }
 
     /**
      * Builder for {@link SinglePlayerSelectorArgument}.
@@ -117,9 +102,7 @@ public final class SinglePlayerSelectorArgument<C> extends CommandArgument<C, Si
         @Override
         public @NonNull SinglePlayerSelectorArgument<C> build() {
             return new SinglePlayerSelectorArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/Vec2dArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/Vec2dArgument.java
@@ -30,7 +30,6 @@ import cloud.commandframework.fabric.argument.FabricArgumentParsers;
 import cloud.commandframework.fabric.data.Coordinates;
 import java.util.List;
 import java.util.function.BiFunction;
-import net.minecraft.world.phys.Vec3;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -45,18 +44,14 @@ public final class Vec2dArgument<C> extends CommandArgument<C, Coordinates.Coord
     private final boolean centerIntegers;
 
     Vec2dArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final boolean centerIntegers
     ) {
         super(
-                required,
                 name,
                 FabricArgumentParsers.vec2(centerIntegers),
-                defaultValue,
                 Coordinates.CoordinatesXZ.class,
                 suggestionsProvider,
                 defaultDescription
@@ -95,7 +90,7 @@ public final class Vec2dArgument<C> extends CommandArgument<C, Coordinates.Coord
      * @since 1.5.0
      */
     public static <C> @NonNull Vec2dArgument<C> of(final @NonNull String name) {
-        return Vec2dArgument.<C>builder(name).asRequired().build();
+        return Vec2dArgument.<C>builder(name).build();
     }
 
     /**
@@ -108,64 +103,9 @@ public final class Vec2dArgument<C> extends CommandArgument<C, Coordinates.Coord
      * @since 1.5.0
      */
     public static <C> @NonNull Vec2dArgument<C> of(final @NonNull String name, final boolean centerIntegers) {
-        return Vec2dArgument.<C>builder(name).centerIntegers(centerIntegers).asRequired().build();
+        return Vec2dArgument.<C>builder(name).centerIntegers(centerIntegers).build();
     }
 
-    /**
-     * Create a new optional {@link Vec2dArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull Vec2dArgument<C> optional(final @NonNull String name) {
-        return Vec2dArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link Vec2dArgument}.
-     *
-     * @param name           Component name
-     * @param centerIntegers whether to center integers to x.5.
-     * @param <C>            Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull Vec2dArgument<C> optional(final @NonNull String name, final boolean centerIntegers) {
-        return Vec2dArgument.<C>builder(name).centerIntegers(centerIntegers).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link Vec2dArgument} with the specified default value.
-     *
-     * @param name         Component name
-     * @param defaultValue default value, y will be ignored as it is always 0
-     * @param <C>          Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull Vec2dArgument<C> optional(final @NonNull String name, final @NonNull Vec3 defaultValue) {
-        return Vec2dArgument.<C>builder(name).asOptionalWithDefault(defaultValue).build();
-    }
-
-    /**
-     * Create a new optional {@link Vec2dArgument} with the specified default value.
-     *
-     * @param name           Component name
-     * @param defaultValue   default value, y will be ignored as it is always 0
-     * @param centerIntegers whether to center integers to x.5.
-     * @param <C>            Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull Vec2dArgument<C> optional(
-            final @NonNull String name,
-            final boolean centerIntegers,
-            final @NonNull Vec3 defaultValue
-    ) {
-        return Vec2dArgument.<C>builder(name).centerIntegers(centerIntegers).asOptionalWithDefault(defaultValue).build();
-    }
 
     /**
      * Builder for {@link Vec2dArgument}.
@@ -204,22 +144,6 @@ public final class Vec2dArgument<C> extends CommandArgument<C, Coordinates.Coord
         }
 
         /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value, y will be ignored as it is always 0
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        public @NonNull Builder<C> asOptionalWithDefault(final @NonNull Vec3 defaultValue) {
-            return this.asOptionalWithDefault(String.format(
-                    "%.10f %.10f",
-                    defaultValue.x,
-                    defaultValue.z
-            ));
-        }
-
-        /**
          * Build a new {@link Vec2dArgument}.
          *
          * @return Constructed argument
@@ -228,9 +152,7 @@ public final class Vec2dArgument<C> extends CommandArgument<C, Coordinates.Coord
         @Override
         public @NonNull Vec2dArgument<C> build() {
             return new Vec2dArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription(),
                     this.centerIntegers()

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/Vec3dArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/Vec3dArgument.java
@@ -30,7 +30,6 @@ import cloud.commandframework.fabric.argument.FabricArgumentParsers;
 import cloud.commandframework.fabric.data.Coordinates;
 import java.util.List;
 import java.util.function.BiFunction;
-import net.minecraft.world.phys.Vec3;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -45,18 +44,14 @@ public final class Vec3dArgument<C> extends CommandArgument<C, Coordinates> {
     private final boolean centerIntegers;
 
     Vec3dArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final boolean centerIntegers
     ) {
         super(
-                required,
                 name,
                 FabricArgumentParsers.vec3(centerIntegers),
-                defaultValue,
                 Coordinates.class,
                 suggestionsProvider,
                 defaultDescription
@@ -95,77 +90,9 @@ public final class Vec3dArgument<C> extends CommandArgument<C, Coordinates> {
      * @since 1.5.0
      */
     public static <C> @NonNull Vec3dArgument<C> of(final @NonNull String name) {
-        return Vec3dArgument.<C>builder(name).asRequired().build();
+        return Vec3dArgument.<C>builder(name).build();
     }
 
-    /**
-     * Create a new required {@link Vec3dArgument}.
-     *
-     * @param name           Component name
-     * @param centerIntegers whether to center integers to x.5.
-     * @param <C>            Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull Vec3dArgument<C> of(final @NonNull String name, final boolean centerIntegers) {
-        return Vec3dArgument.<C>builder(name).centerIntegers(centerIntegers).asRequired().build();
-    }
-
-    /**
-     * Create a new optional {@link Vec3dArgument}.
-     *
-     * @param name Component name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull Vec3dArgument<C> optional(final @NonNull String name) {
-        return Vec3dArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link Vec3dArgument}.
-     *
-     * @param name           Component name
-     * @param centerIntegers whether to center integers to x.5.
-     * @param <C>            Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull Vec3dArgument<C> optional(final @NonNull String name, final boolean centerIntegers) {
-        return Vec3dArgument.<C>builder(name).centerIntegers(centerIntegers).asOptional().build();
-    }
-
-    /**
-     * Create a new optional {@link Vec3dArgument} with the specified default value.
-     *
-     * @param name         Component name
-     * @param defaultValue default value
-     * @param <C>          Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull Vec3dArgument<C> optional(final @NonNull String name, final @NonNull Vec3 defaultValue) {
-        return Vec3dArgument.<C>builder(name).asOptionalWithDefault(defaultValue).build();
-    }
-
-    /**
-     * Create a new optional {@link Vec3dArgument} with the specified default value.
-     *
-     * @param name           Component name
-     * @param defaultValue   default value
-     * @param centerIntegers whether to center integers to x.5.
-     * @param <C>            Command sender type
-     * @return Created argument
-     * @since 1.5.0
-     */
-    public static <C> @NonNull Vec3dArgument<C> optional(
-            final @NonNull String name,
-            final boolean centerIntegers,
-            final @NonNull Vec3 defaultValue
-    ) {
-        return Vec3dArgument.<C>builder(name).centerIntegers(centerIntegers).asOptionalWithDefault(defaultValue).build();
-    }
 
     /**
      * Builder for {@link Vec3dArgument}.
@@ -204,23 +131,6 @@ public final class Vec3dArgument<C> extends CommandArgument<C, Coordinates> {
         }
 
         /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.5.0
-         */
-        public @NonNull Builder<C> asOptionalWithDefault(final @NonNull Vec3 defaultValue) {
-            return this.asOptionalWithDefault(String.format(
-                    "%.10f %.10f %.10f",
-                    defaultValue.x,
-                    defaultValue.y,
-                    defaultValue.z
-            ));
-        }
-
-        /**
          * Build a new {@link Vec3dArgument}.
          *
          * @return Constructed argument
@@ -229,9 +139,7 @@ public final class Vec3dArgument<C> extends CommandArgument<C, Coordinates> {
         @Override
         public @NonNull Vec3dArgument<C> build() {
             return new Vec3dArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription(),
                     this.centerIntegers()

--- a/cloud-minecraft/cloud-fabric/src/testmod/java/cloud/commandframework/fabric/testmod/FabricClientExample.java
+++ b/cloud-minecraft/cloud-fabric/src/testmod/java/cloud/commandframework/fabric/testmod/FabricClientExample.java
@@ -95,7 +95,7 @@ public final class FabricClientExample implements ClientModInitializer {
                 }));
 
         commandManager.command(base.literal("say")
-                .argument(StringArgument.greedy("message"))
+                .required(StringArgument.greedy("message"))
                 .handler(ctx -> ctx.getSender().sendFeedback(
                         Component.literal("Cloud client commands says: " + ctx.get("message"))
                 )));
@@ -116,7 +116,7 @@ public final class FabricClientExample implements ClientModInitializer {
 
         // Test argument which requires CommandBuildContext/RegistryAccess
         commandManager.command(base.literal("show_item")
-                .argument(ItemInputArgument.of("item"))
+                .required(ItemInputArgument.of("item"))
                 .handler(ctx -> {
                     try {
                         ctx.getSender().sendFeedback(
@@ -128,7 +128,7 @@ public final class FabricClientExample implements ClientModInitializer {
                 }));
 
         commandManager.command(base.literal("flag_test")
-                .argument(StringArgument.optional("parameter"))
+                .optional(StringArgument.of("parameter"))
                 .flag(CommandFlag.builder("flag").withAliases("f"))
                 .handler(ctx -> ctx.getSender().sendFeedback(Component.literal("Had flag: " + ctx.flags().isPresent("flag")))));
     }

--- a/cloud-minecraft/cloud-fabric/src/testmod/java/cloud/commandframework/fabric/testmod/FabricExample.java
+++ b/cloud-minecraft/cloud-fabric/src/testmod/java/cloud/commandframework/fabric/testmod/FabricExample.java
@@ -78,14 +78,12 @@ public final class FabricExample implements ModInitializer {
         final Command.Builder<CommandSourceStack> base = manager.commandBuilder("cloudtest");
 
         final CommandArgument<CommandSourceStack, String> name = StringArgument.of("name");
-        final CommandArgument<CommandSourceStack, Integer> hugs = IntegerArgument.<CommandSourceStack>builder("hugs")
-                .asOptionalWithDefault("1")
-                .build();
+        final CommandArgument<CommandSourceStack, Integer> hugs = IntegerArgument.of("hugs");
 
         manager.command(base
                 .literal("hugs")
-                .argument(name)
-                .argument(hugs)
+                .required(name)
+                .optional(hugs, "1")
                 .handler(ctx -> {
                     ctx.getSender().sendSuccess(Component.literal("Hello, ")
                             .append(ctx.get(name))
@@ -107,7 +105,7 @@ public final class FabricExample implements ModInitializer {
 
         manager.command(base
                 .literal("land")
-                .argument(biomeArgument)
+                .required(biomeArgument)
                 .handler(ctx -> {
                     ctx.getSender().sendSuccess(Component.literal("Yes, the biome ")
                             .append(Component.literal(
@@ -125,8 +123,8 @@ public final class FabricExample implements ModInitializer {
         final CommandArgument<CommandSourceStack, ChatFormatting> textColor = NamedColorArgument.of("color");
 
         manager.command(base.literal("wave")
-                .argument(playerSelector)
-                .argument(textColor)
+                .required(playerSelector)
+                .required(textColor)
                 .handler(ctx -> {
                     final MultiplePlayerSelector selector = ctx.get(playerSelector);
                     final Collection<ServerPlayer> selected = selector.get();
@@ -146,11 +144,10 @@ public final class FabricExample implements ModInitializer {
 
         manager.command(base.literal("give")
                 .permission("cloud.give")
-                .argument(MultiplePlayerSelectorArgument.of("targets"))
-                .argument(ItemInputArgument.of("item"))
-                .argument(IntegerArgument.<CommandSourceStack>builder("amount")
-                        .withMin(1)
-                        .asOptionalWithDefault("1"))
+                .required(MultiplePlayerSelectorArgument.of("targets"))
+                .required(ItemInputArgument.of("item"))
+                .optional(IntegerArgument.<CommandSourceStack>builder("amount")
+                        .withMin(1), "1")
                 .handler(ctx -> {
                     final ItemInput item = ctx.get("item");
                     final MultiplePlayerSelector targets = ctx.get("targets");
@@ -223,7 +220,7 @@ public final class FabricExample implements ModInitializer {
                 })
                 .build();
 
-        manager.command(mods.argument(modMetadata)
+        manager.command(mods.required(modMetadata)
                 .handler(ctx -> {
                     final ModMetadata meta = ctx.get(modMetadata);
                     final MutableComponent text = Component.literal("")
@@ -252,8 +249,8 @@ public final class FabricExample implements ModInitializer {
 
         manager.command(base.literal("teleport")
                 .permission("cloud.teleport")
-                .argument(MultipleEntitySelectorArgument.of("targets"))
-                .argument(Vec3dArgument.of("location"))
+                .required(MultipleEntitySelectorArgument.of("targets"))
+                .required(Vec3dArgument.of("location"))
                 .handler(ctx -> {
                     final MultipleEntitySelector selector = ctx.get("targets");
                     final Vec3 location = ctx.<Coordinates>get("location").position();
@@ -263,7 +260,7 @@ public final class FabricExample implements ModInitializer {
 
         manager.command(base.literal("gotochunk")
                 .permission("cloud.gotochunk")
-                .argument(ColumnPosArgument.of("chunk_position"))
+                .required(ColumnPosArgument.of("chunk_position"))
                 .handler(ctx -> {
                     final ServerPlayer player;
                     try {

--- a/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/MinecraftHelp.java
+++ b/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/MinecraftHelp.java
@@ -472,7 +472,7 @@ public final class MinecraftHelp<C> {
         audience.sendMessage(this.basicHeader(sender));
         audience.sendMessage(this.showingResults(sender, query));
         final String command = this.commandManager.commandSyntaxFormatter()
-                .apply(helpTopic.getCommand().getArguments(), null);
+                .apply(helpTopic.getCommand().components(), null);
         audience.sendMessage(text()
                 .append(this.lastBranch())
                 .append(space())
@@ -495,7 +495,7 @@ public final class MinecraftHelp<C> {
             topicDescription = this.descriptionDecorator.apply(sender, helpTopic.getDescription());
         }
 
-        final boolean hasArguments = helpTopic.getCommand().getArguments().size() > 1;
+        final boolean hasArguments = helpTopic.getCommand().components().size() > 1;
         audience.sendMessage(text()
                 .append(text("   "))
                 .append(hasArguments ? this.branch() : this.lastBranch())
@@ -513,29 +513,29 @@ public final class MinecraftHelp<C> {
                     .append(text(":", this.colors.primary))
             );
 
-            final Iterator<CommandComponent<C>> iterator = helpTopic.getCommand().getComponents().iterator();
+            final Iterator<CommandComponent<C>> iterator = helpTopic.getCommand().components().iterator();
             /* Skip the first one because it's the command literal */
             iterator.next();
 
             while (iterator.hasNext()) {
                 final CommandComponent<C> component = iterator.next();
-                final CommandArgument<C, ?> argument = component.getArgument();
+                final CommandArgument<C, ?> argument = component.argument();
 
                 final String syntax = this.commandManager.commandSyntaxFormatter()
-                        .apply(Collections.singletonList(argument), null);
+                        .apply(Collections.singletonList(component), null);
 
                 final TextComponent.Builder textComponent = text()
                         .append(text("       "))
                         .append(iterator.hasNext() ? this.branch() : this.lastBranch())
                         .append(this.highlight(text(" " + syntax, this.colors.highlight)));
-                if (!argument.isRequired()) {
+                if (component.optional()) {
                     textComponent.append(text(" (", this.colors.alternateHighlight));
                     textComponent.append(
                             this.messageProvider.provide(sender, MESSAGE_OPTIONAL).color(this.colors.alternateHighlight)
                     );
                     textComponent.append(text(")", this.colors.alternateHighlight));
                 }
-                final ArgumentDescription description = component.getArgumentDescription();
+                final ArgumentDescription description = component.argumentDescription();
                 if (!description.isEmpty()) {
                     textComponent.append(text(" - ", this.colors.accent));
                     textComponent.append(this.formatDescription(sender, description).colorIfAbsent(this.colors.text));

--- a/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/TextColorArgument.java
+++ b/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/TextColorArgument.java
@@ -80,16 +80,10 @@ public final class TextColorArgument<C> extends CommandArgument<C, TextColor> {
             Pair.of('f', NamedTextColor.WHITE)
     );
 
-    private TextColorArgument(
-            final boolean required,
-            final @NonNull String name,
-            final @NonNull String defaultValue
-    ) {
+    private TextColorArgument(final @NonNull String name) {
         super(
-                required,
                 name,
                 new TextColorParser<>(),
-                defaultValue,
                 TypeToken.get(TextColor.class),
                 null,
                 new LinkedList<>()
@@ -104,45 +98,7 @@ public final class TextColorArgument<C> extends CommandArgument<C, TextColor> {
      * @return Created argument
      */
     public static <C> @NonNull TextColorArgument<C> of(final @NonNull String name) {
-        return new TextColorArgument<>(
-                true,
-                name,
-                ""
-        );
-    }
-
-    /**
-     * Create a new optional TextColor argument
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull TextColorArgument<C> optional(final @NonNull String name) {
-        return new TextColorArgument<>(
-                false,
-                name,
-                ""
-        );
-    }
-
-    /**
-     * Create a new optional TextColor argument
-     *
-     * @param name         Argument name
-     * @param defaultValue Default value
-     * @param <C>          Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull TextColorArgument<C> optionalWithDefault(
-            final @NonNull String name,
-            final @NonNull String defaultValue
-    ) {
-        return new TextColorArgument<>(
-                false,
-                name,
-                defaultValue
-        );
+        return new TextColorArgument<>(name);
     }
 
 

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperBrigadierListener.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperBrigadierListener.java
@@ -24,7 +24,6 @@
 package cloud.commandframework.paper;
 
 import cloud.commandframework.CommandTree;
-import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.brigadier.CloudBrigadierManager;
 import cloud.commandframework.bukkit.BukkitBrigadierMapper;
 import cloud.commandframework.bukkit.internal.BukkitBackwardsBrigadierSenderMapper;
@@ -100,7 +99,7 @@ class PaperBrigadierListener<C> implements Listener {
             label = event.getCommandLabel();
         }
 
-        final CommandTree.Node<CommandArgument<C, ?>> node = commandTree.getNamedNode(label);
+        final CommandTree.CommandNode<C> node = commandTree.getNamedNode(label);
         if (node == null) {
             return;
         }

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/argument/KeyedWorldArgument.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/argument/KeyedWorldArgument.java
@@ -53,13 +53,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class KeyedWorldArgument<C> extends CommandArgument<C, World> {
 
     KeyedWorldArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(required, name, new Parser<>(), defaultValue, World.class, suggestionsProvider, defaultDescription);
+        super(name, new Parser<>(), World.class, suggestionsProvider, defaultDescription);
     }
 
     /**
@@ -83,36 +81,9 @@ public final class KeyedWorldArgument<C> extends CommandArgument<C, World> {
      * @since 1.6.0
      */
     public static <C> @NonNull KeyedWorldArgument<C> of(final @NonNull String name) {
-        return KeyedWorldArgument.<C>builder(name).asRequired().build();
+        return KeyedWorldArgument.<C>builder(name).build();
     }
 
-    /**
-     * Create a new optional {@link KeyedWorldArgument}.
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     * @since 1.6.0
-     */
-    public static <C> @NonNull KeyedWorldArgument<C> optional(final @NonNull String name) {
-        return KeyedWorldArgument.<C>builder(name).asOptional().build();
-    }
-
-    /**
-     * Create a new {@link KeyedWorldArgument} with the specified default value.
-     *
-     * @param name         Argument name
-     * @param defaultValue Default value
-     * @param <C>          Command sender type
-     * @return Created argument
-     * @since 1.6.0
-     */
-    public static <C> @NonNull KeyedWorldArgument<C> optional(
-            final @NonNull String name,
-            final @NonNull NamespacedKey defaultValue
-    ) {
-        return KeyedWorldArgument.<C>builder(name).asOptionalWithDefault(defaultValue).build();
-    }
 
     /**
      * Builder for {@link KeyedWorldArgument}.
@@ -127,18 +98,6 @@ public final class KeyedWorldArgument<C> extends CommandArgument<C, World> {
         }
 
         /**
-         * Sets the command argument to be optional, with the specified default value.
-         *
-         * @param defaultValue default value
-         * @return this builder
-         * @see CommandArgument.Builder#asOptionalWithDefault(String)
-         * @since 1.6.0
-         */
-        public @NonNull Builder<C> asOptionalWithDefault(final @NonNull NamespacedKey defaultValue) {
-            return this.asOptionalWithDefault(defaultValue.toString());
-        }
-
-        /**
          * Build a new {@link KeyedWorldArgument}.
          *
          * @return constructed argument
@@ -147,9 +106,7 @@ public final class KeyedWorldArgument<C> extends CommandArgument<C, World> {
         @Override
         public @NonNull KeyedWorldArgument<C> build() {
             return new KeyedWorldArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription()
             );

--- a/cloud-minecraft/cloud-sponge7/src/main/java/cloud/commandframework/sponge7/SpongePluginRegistrationHandler.java
+++ b/cloud-minecraft/cloud-sponge7/src/main/java/cloud/commandframework/sponge7/SpongePluginRegistrationHandler.java
@@ -46,7 +46,7 @@ final class SpongePluginRegistrationHandler<C> implements CommandRegistrationHan
     @Override
     @SuppressWarnings("unchecked")
     public boolean registerCommand(final @NonNull Command<?> command) {
-        final StaticArgument<?> commandArgument = (StaticArgument<?>) command.getArguments().get(0);
+        final StaticArgument<?> commandArgument = (StaticArgument<?>) command.components().get(0).argument();
         if (this.registeredCommands.containsKey(commandArgument)) {
             return false;
         }

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/VelocityPluginRegistrationHandler.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/VelocityPluginRegistrationHandler.java
@@ -60,11 +60,11 @@ final class VelocityPluginRegistrationHandler<C> implements CommandRegistrationH
     @Override
     @SuppressWarnings("unchecked")
     public boolean registerCommand(final @NonNull Command<?> command) {
-        final CommandArgument<?, ?> argument = command.getArguments().get(0);
+        final CommandArgument<?, ?> argument = command.components().get(0).argument();
         final List<String> aliases = ((StaticArgument<C>) argument).getAlternativeAliases();
         final BrigadierCommand brigadierCommand = new BrigadierCommand(
                 this.brigadierManager.createLiteralCommandNode(
-                        command.getArguments().get(0).getName(),
+                        command.components().get(0).argument().getName(),
                         (Command<C>) command,
                         (c, p) -> this.manager.hasPermission(
                                 this.manager.commandSenderMapper().apply(c),

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/PlayerArgument.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/PlayerArgument.java
@@ -54,19 +54,15 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class PlayerArgument<C> extends CommandArgument<C, Player> {
 
     private PlayerArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>, @NonNull Queue<@NonNull String>,
                     @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
     ) {
         super(
-                required,
                 name,
                 new PlayerParser<>(),
-                defaultValue,
                 TypeToken.get(Player.class),
                 suggestionsProvider,
                 defaultDescription,
@@ -111,7 +107,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
     public static <C> @NonNull CommandArgument<C, Player> of(
             final @NonNull String name
     ) {
-        return PlayerArgument.<C>builder(name).asRequired().build();
+        return PlayerArgument.<C>builder(name).build();
     }
 
     /**
@@ -124,7 +120,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
     public static <C> @NonNull CommandArgument<C, Player> optional(
             final @NonNull String name
     ) {
-        return PlayerArgument.<C>builder(name).asOptional().build();
+        return PlayerArgument.<C>builder(name).build();
     }
 
 
@@ -137,9 +133,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
         @Override
         public @NonNull CommandArgument<@NonNull C, @NonNull Player> build() {
             return new PlayerArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription(),
                     new LinkedList<>()

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/ServerArgument.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/ServerArgument.java
@@ -54,19 +54,15 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class ServerArgument<C> extends CommandArgument<C, RegisteredServer> {
 
     private ServerArgument(
-            final boolean required,
             final @NonNull String name,
-            final @NonNull String defaultValue,
             final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>, @NonNull Queue<@NonNull String>,
                     @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
     ) {
         super(
-                required,
                 name,
                 new ServerParser<>(),
-                defaultValue,
                 TypeToken.get(RegisteredServer.class),
                 suggestionsProvider,
                 defaultDescription,
@@ -111,19 +107,9 @@ public final class ServerArgument<C> extends CommandArgument<C, RegisteredServer
     public static <C> @NonNull CommandArgument<C, RegisteredServer> of(
             final @NonNull String name
     ) {
-        return ServerArgument.<C>builder(name).asRequired().build();
+        return ServerArgument.<C>builder(name).build();
     }
 
-    /**
-     * Create a new optional server argument
-     *
-     * @param name Argument name
-     * @param <C>  Command sender type
-     * @return Created argument
-     */
-    public static <C> @NonNull CommandArgument<C, RegisteredServer> optional(final @NonNull String name) {
-        return ServerArgument.<C>builder(name).asOptional().build();
-    }
 
     public static final class Builder<C> extends CommandArgument.Builder<C, RegisteredServer> {
 
@@ -134,9 +120,7 @@ public final class ServerArgument<C> extends CommandArgument<C, RegisteredServer
         @Override
         public @NonNull CommandArgument<@NonNull C, @NonNull RegisteredServer> build() {
             return new ServerArgument<>(
-                    this.isRequired(),
                     this.getName(),
-                    this.getDefaultValue(),
                     this.getSuggestionsProvider(),
                     this.getDefaultDescription(),
                     new LinkedList<>()

--- a/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/ExamplePlugin.java
+++ b/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/ExamplePlugin.java
@@ -275,8 +275,8 @@ public final class ExamplePlugin extends JavaPlugin {
                         .literal("me")
                         // Require a player sender
                         .senderType(Player.class)
-                        .argument(worldArgument, ArgumentDescription.of("World name"))
-                        .argumentTriplet(
+                        .required(worldArgument, ArgumentDescription.of("World name"))
+                        .requiredArgumentTriplet(
                                 "coords",
                                 TypeToken.get(Vector.class),
                                 Triplet.of("x", "y", "z"),
@@ -297,7 +297,7 @@ public final class ExamplePlugin extends JavaPlugin {
                 .command(builder.literal("teleport")
                         .literal("entity")
                         .senderType(Player.class)
-                        .argument(
+                        .required(
                                 SingleEntitySelectorArgument.of("entity"),
                                 ArgumentDescription.of("Entity to teleport")
                         )
@@ -318,7 +318,7 @@ public final class ExamplePlugin extends JavaPlugin {
                         ))
                 .command(builder.literal("teleport")
                         .meta(CommandMeta.DESCRIPTION, "Teleport to a world")
-                        .argument(WorldArgument.of("world"), ArgumentDescription.of("World to teleport to"))
+                        .required(WorldArgument.of("world"), ArgumentDescription.of("World to teleport to"))
                         .handler(context -> this.manager.taskRecipe().begin(context).synchronous(ctx -> {
                             final Player player = (Player) ctx.getSender();
                             player.teleport(ctx.<World>get("world").getSpawnLocation());
@@ -338,8 +338,8 @@ public final class ExamplePlugin extends JavaPlugin {
                 ));
         this.manager.command(this.manager.commandBuilder("give")
                 .senderType(Player.class)
-                .argument(MaterialArgument.of("material"))
-                .argument(IntegerArgument.of("amount"))
+                .required(MaterialArgument.of("material"))
+                .required(IntegerArgument.of("amount"))
                 .handler(c -> {
                     final Material material = c.get("material");
                     final int amount = c.get("amount");
@@ -349,15 +349,15 @@ public final class ExamplePlugin extends JavaPlugin {
                 }));
         this.manager.command(builder.literal("summon")
                 .senderType(Player.class)
-                .argument(EnumArgument.of(EntityType.class, "type"))
+                .required(EnumArgument.of(EntityType.class, "type"))
                 .handler(c -> this.manager.taskRecipe().begin(c).synchronous(ctx -> {
                     final Location loc = ((Player) ctx.getSender()).getLocation();
                     loc.getWorld().spawnEntity(loc, ctx.get("type"));
                 }).execute()));
         this.manager.command(builder.literal("enchant")
                 .senderType(Player.class)
-                .argument(EnchantmentArgument.of("enchant"))
-                .argument(IntegerArgument.of("level"))
+                .required(EnchantmentArgument.of("enchant"))
+                .required(IntegerArgument.of("level"))
                 .handler(c -> this.manager.taskRecipe().begin(c).synchronous(ctx -> {
                     final Player player = ((Player) ctx.getSender());
                     player.getInventory().getItemInMainHand().addEnchantment(ctx.get("enchant"), ctx.get("level"));
@@ -369,23 +369,23 @@ public final class ExamplePlugin extends JavaPlugin {
         this.manager.command(builder
                 .meta(CommandMeta.DESCRIPTION, "Sets the color scheme for '/example help'")
                 .literal("helpcolors")
-                .argument(
+                .required(
                         TextColorArgument.of("primary"),
                         RichDescription.of(text("The primary color for the color scheme", Style.style(TextDecoration.ITALIC)))
                 )
-                .argument(
+                .required(
                         TextColorArgument.of("highlight"),
                         RichDescription.of(text("The primary color used to highlight commands and queries"))
                 )
-                .argument(
+                .required(
                         TextColorArgument.of("alternate_highlight"),
                         RichDescription.of(text("The secondary color used to highlight commands and queries"))
                 )
-                .argument(
+                .required(
                         TextColorArgument.of("text"),
                         RichDescription.of(text("The color used for description text"))
                 )
-                .argument(
+                .required(
                         TextColorArgument.of("accent"),
                         RichDescription.of(text("The color used for accents and symbols"))
                 )
@@ -412,8 +412,8 @@ public final class ExamplePlugin extends JavaPlugin {
                 this.manager.commandBuilder(
                         "arraycommand",
                         ArgumentDescription.of("Bukkit-esque cmmand")
-                ).argument(
-                        StringArrayArgument.optional(
+                ).optional(
+                        StringArrayArgument.of(
                                 "args",
                                 (context, lastString) -> {
                                     final List<String> allArgs = context.getRawInput();
@@ -442,7 +442,7 @@ public final class ExamplePlugin extends JavaPlugin {
         // compound itemstack arg
         this.manager.command(this.manager.commandBuilder("gib")
                 .senderType(Player.class)
-                .argumentPair(
+                .requiredArgumentPair(
                         "itemstack",
                         TypeToken.get(ItemStack.class),
                         Pair.of("item", "amount"),
@@ -460,7 +460,7 @@ public final class ExamplePlugin extends JavaPlugin {
                 }));
 
         this.manager.command(builder.literal("keyed_world")
-                .argument(KeyedWorldArgument.of("world"))
+                .required(KeyedWorldArgument.of("world"))
                 .senderType(Player.class)
                 .handler(ctx -> {
                     final World world = ctx.get("world");
@@ -483,7 +483,7 @@ public final class ExamplePlugin extends JavaPlugin {
 
         this.manager.command(this.manager.commandBuilder("example")
                 .literal("namespacedkey")
-                .argument(NamespacedKeyArgument.of("key"))
+                .required(NamespacedKeyArgument.of("key"))
                 .handler(ctx -> {
                     final NamespacedKey namespacedKey = ctx.get("key");
                     final String key = namespacedKey.getNamespace() + ":" + namespacedKey.getKey();

--- a/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/Mc113.java
+++ b/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/Mc113.java
@@ -58,16 +58,16 @@ final class Mc113 {
 
         this.manager.command(builder.literal("replace")
                 .senderType(Player.class)
-                .argument(BlockPredicateArgument.of("predicate"))
+                .required(BlockPredicateArgument.of("predicate"))
                 .literal("with")
-                .argument(MaterialArgument.of("block")) // todo: use BlockDataArgument
-                .argument(IntegerArgument.<CommandSender>builder("radius").withMin(1))
+                .required(MaterialArgument.of("block")) // todo: use BlockDataArgument
+                .required(IntegerArgument.<CommandSender>builder("radius").withMin(1))
                 .handler(this::executeReplace));
 
         this.manager.command(builder.literal("test_item")
-                .argument(ItemStackArgument.of("item"))
+                .required(ItemStackArgument.of("item"))
                 .literal("is")
-                .argument(ItemStackPredicateArgument.of("predicate"))
+                .required(ItemStackPredicateArgument.of("predicate"))
                 .handler(Mc113::executeTestItem));
     }
 

--- a/examples/example-bungee/src/main/java/cloud/commandframework/examples/bungee/ExamplePlugin.java
+++ b/examples/example-bungee/src/main/java/cloud/commandframework/examples/bungee/ExamplePlugin.java
@@ -122,7 +122,7 @@ public final class ExamplePlugin extends Plugin {
         this.manager.command(
                 this.manager.commandBuilder("player")
                         .senderType(ProxiedPlayer.class)
-                        .argument(playerArgument, RichDescription.of(text("Player ").append(text("name", NamedTextColor.GOLD))))
+                        .required(playerArgument, RichDescription.of(text("Player ").append(text("name", NamedTextColor.GOLD))))
                         .handler(context -> {
                             final ProxiedPlayer player = context.get("player");
                             this.bungeeAudiences.sender(context.getSender()).sendMessage(
@@ -138,7 +138,7 @@ public final class ExamplePlugin extends Plugin {
         this.manager.command(
                 this.manager.commandBuilder("server")
                         .senderType(ProxiedPlayer.class)
-                        .argument(serverArgument, ArgumentDescription.of("Server name"))
+                        .required(serverArgument, ArgumentDescription.of("Server name"))
                         .handler(context -> {
                             final ServerInfo server = context.get("server");
                             this.bungeeAudiences.sender(context.getSender()).sendMessage(

--- a/examples/example-jda/src/main/java/cloud/commandframework/examples/jda/ExampleBot.java
+++ b/examples/example-jda/src/main/java/cloud/commandframework/examples/jda/ExampleBot.java
@@ -112,8 +112,8 @@ public final class ExampleBot {
 
         commandManager.command(builder
                 .literal("add")
-                .argument(UserArgument.of("user"))
-                .argument(StringArgument.single("perm"))
+                .required(UserArgument.of("user"))
+                .required(StringArgument.single("perm"))
                 .handler(context -> {
                     final User user = context.get("user");
                     final String perm = context.get("perm");
@@ -124,8 +124,8 @@ public final class ExampleBot {
 
         commandManager.command(builder
                 .literal("remove")
-                .argument(UserArgument.of("user"))
-                .argument(StringArgument.single("perm"))
+                .required(UserArgument.of("user"))
+                .required(StringArgument.single("perm"))
                 .handler(context -> {
                     final User user = context.get("user");
                     final String perm = context.get("perm");
@@ -138,7 +138,7 @@ public final class ExampleBot {
                 .commandBuilder("kick")
                 .senderType(GuildUser.class)
                 .permission("kick")
-                .argument(UserArgument.of("user"))
+                .required(UserArgument.of("user"))
                 .handler(context -> {
                     final GuildUser guildUser = (GuildUser) context.getSender();
                     final TextChannel textChannel = guildUser.getTextChannel();

--- a/examples/example-velocity/src/main/java/cloud/commandframework/examples/velocity/ExampleVelocityPlugin.java
+++ b/examples/example-velocity/src/main/java/cloud/commandframework/examples/velocity/ExampleVelocityPlugin.java
@@ -88,7 +88,7 @@ public final class ExampleVelocityPlugin {
                 .apply(commandManager, AudienceProvider.nativeAudience());
         commandManager.command(
                 commandManager.commandBuilder("example")
-                        .argument(PlayerArgument.of("player"))
+                        .required(PlayerArgument.of("player"))
                         .handler(context -> {
                                     final Player player = context.get("player");
                                     context.getSender().sendMessage(
@@ -104,7 +104,7 @@ public final class ExampleVelocityPlugin {
         );
         commandManager.command(
                 commandManager.commandBuilder("example-server")
-                        .argument(ServerArgument.of("server"))
+                        .required(ServerArgument.of("server"))
                         .handler(context -> {
                             final RegisteredServer server = context.get("server");
                             context.getSender().sendMessage(


### PR DESCRIPTION
This moves `required` and `defaultValue` out of CommandArgument, into CommandComponent. This reduces the verbosity of the command arguments by no longer forcing multiple static methods to determine whether the argument is required.

Whether an argument is required is now specified when adding the argument to the command. The previous `argument` methods on the command builder have been replaced by `required`/`optional` methods with many different overloads. We no longer have the ability to pass typed default values to the arguments as the command arguments no longer store the default values. We will have to think of a suitable replacement.

To facilitate this movement of data we've had to replace many references to CommandArgument with CommandComponent. To make this easier the CommandTree.Node class has been made less generic and has also been renamed to CommandTree.CommandNode.

Many deprecated methods have been removed as there is no real point in updating them as we'll want to drop them before releasing v2 anyway.