### PR TITLE
feature: prepare for complex suggestions

### DIFF
--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/Argument.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/Argument.java
@@ -23,11 +23,11 @@
 //
 package cloud.commandframework.annotations;
 
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.function.BiFunction;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -58,13 +58,13 @@ public @interface Argument {
     @NonNull String parserName() default "";
 
     /**
-     * Name of the suggestions provider to use. If the string is left empty, the default
+     * Name of the suggestion provider to use. If the string is left empty, the default
      * provider for the argument parser will be used. Otherwise,
      * the {@link cloud.commandframework.arguments.parser.ParserRegistry} instance in the
      * {@link cloud.commandframework.CommandManager} will be queried for a matching suggestion provider.
      * <p>
      * For this to work, the suggestion needs to be registered in the parser registry. To do this, use
-     * {@link cloud.commandframework.arguments.parser.ParserRegistry#registerSuggestionProvider(String, BiFunction)}.
+     * {@link cloud.commandframework.arguments.parser.ParserRegistry#registerSuggestionProvider(String, SuggestionProvider)}.
      * The registry instance can be retrieved using {@link cloud.commandframework.CommandManager#parserRegistry()}.
      *
      * @return The name of the suggestion provider, or {@code ""} if the default suggestion provider for the argument parser

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/Flag.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/Flag.java
@@ -23,11 +23,11 @@
 //
 package cloud.commandframework.annotations;
 
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.function.BiFunction;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -66,13 +66,13 @@ public @interface Flag {
     @NonNull String parserName() default "";
 
     /**
-     * Name of the suggestions provider to use. If the string is left empty, the default
+     * Name of the suggestion provider to use. If the string is left empty, the default
      * provider for the argument parser will be used. Otherwise,
      * the {@link cloud.commandframework.arguments.parser.ParserRegistry} instance in the
      * {@link cloud.commandframework.CommandManager} will be queried for a matching suggestion provider.
      * <p>
      * For this to work, the suggestion needs to be registered in the parser registry. To do this, use
-     * {@link cloud.commandframework.arguments.parser.ParserRegistry#registerSuggestionProvider(String, BiFunction)}.
+     * {@link cloud.commandframework.arguments.parser.ParserRegistry#registerSuggestionProvider(String, SuggestionProvider)}.
      * The registry instance can be retrieved using {@link cloud.commandframework.CommandManager#parserRegistry()}.
      *
      * @return The name of the suggestion provider, or {@code ""} if the default suggestion provider for the argument parser

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagExtractor.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagExtractor.java
@@ -29,6 +29,7 @@ import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.flags.CommandFlag;
 import cloud.commandframework.arguments.parser.ArgumentParser;
 import cloud.commandframework.arguments.parser.ParserRegistry;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.permission.Permission;
 import io.leangen.geantyref.GenericTypeReflector;
 import io.leangen.geantyref.TypeToken;
@@ -38,8 +39,6 @@ import java.lang.reflect.Parameter;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
-import java.util.List;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -111,7 +110,7 @@ final class FlagExtractor implements Function<@NonNull Method, Collection<@NonNu
                                     parameter.getType().getCanonicalName(), flagName, method.getName()
                             ));
                 }
-                final BiFunction<?, @NonNull String, @NonNull List<String>> suggestionProvider;
+                final SuggestionProvider<?> suggestionProvider;
                 final String suggestions = this.annotationParser.processString(flag.suggestions());
                 if (!suggestions.isEmpty()) {
                     suggestionProvider = registry.getSuggestionProvider(suggestions).orElse(null);
@@ -127,7 +126,7 @@ final class FlagExtractor implements Function<@NonNull Method, Collection<@NonNu
                         .withParser(parser);
                 final CommandArgument argument;
                 if (suggestionProvider != null) {
-                    argument = argumentBuilder.withSuggestionsProvider(suggestionProvider).build();
+                    argument = argumentBuilder.withSuggestionProvider(suggestionProvider).build();
                 } else {
                     argument = argumentBuilder.build();
                 }

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/parsers/Parser.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/parsers/Parser.java
@@ -23,11 +23,11 @@
 //
 package cloud.commandframework.annotations.parsers;
 
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.function.BiFunction;
 
 /**
  * This annotation allows you to create annotated methods that behave like argument parsers.
@@ -54,13 +54,13 @@ public @interface Parser {
     String name() default "";
 
     /**
-     * Name of the suggestions provider to use. If the string is left empty, the default
+     * Name of the suggestion provider to use. If the string is left empty, the default
      * provider for the {@link cloud.commandframework.annotations.Argument} will be used. Otherwise,
      * the {@link cloud.commandframework.arguments.parser.ParserRegistry} instance in the
      * {@link cloud.commandframework.CommandManager} will be queried for a matching suggestion provider.
      * <p>
      * For this to work, the suggestion needs to be registered in the parser registry. To do this, use
-     * {@link cloud.commandframework.arguments.parser.ParserRegistry#registerSuggestionProvider(String, BiFunction)}.
+     * {@link cloud.commandframework.arguments.parser.ParserRegistry#registerSuggestionProvider(String, SuggestionProvider)}.
      * The registry instance can be retrieved using {@link cloud.commandframework.CommandManager#parserRegistry()}.
      *
      * @return The name of the suggestion provider, or {@code ""}

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/suggestions/Suggestions.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/suggestions/Suggestions.java
@@ -30,11 +30,16 @@ import java.lang.annotation.Target;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
- * This annotation allows you to create annotated methods that behave like suggestions providers.
- * The method must have this exact signature: <pre>{@code
+ * This annotation allows you to create annotated methods that behave like suggestion providers.
+ * The method must have a signature matching either: <pre>{@code
  * ﹫Suggestions("name")
  * public List<String> methodName(CommandContext<YourSender> sender, String input) {
  * }}</pre>
+ * or <pre>{@code
+ * ﹫Suggestions("name")
+ * public List<Suggestion> methodName(CommandContext<YourSender> sender, String input) {
+ * }}</pre>
+ *
  *
  * @since 1.3.0
  */
@@ -43,9 +48,9 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 public @interface Suggestions {
 
     /**
-     * Name of the suggestions provider. This should be the same as the name specified in your command arguments
+     * Name of the suggestion provider. This should be the same as the name specified in your command arguments
      *
-     * @return Suggestions provider name
+     * @return Suggestion provider name
      */
     @NonNull String value();
 }

--- a/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
@@ -35,6 +35,7 @@ import cloud.commandframework.arguments.parser.ArgumentParser;
 import cloud.commandframework.arguments.parser.ParserParameter;
 import cloud.commandframework.arguments.parser.ParserRegistry;
 import cloud.commandframework.arguments.parser.StandardParserRegistry;
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.captions.CaptionRegistry;
 import cloud.commandframework.captions.CaptionVariableReplacementHandler;
 import cloud.commandframework.captions.SimpleCaptionRegistryFactory;
@@ -206,8 +207,10 @@ public abstract class CommandManager<C> {
      * @param input         Input provided by the sender. Prefixes should be removed before the method is being called, and
      *                      the input here will be passed directly to the command parsing pipeline, after having been tokenized.
      * @return List of suggestions
+     * @since 2.0.0
      */
-    public @NonNull List<@NonNull String> suggest(
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    public @NonNull List<@NonNull Suggestion> suggest(
             final @NonNull C commandSender,
             final @NonNull String input
     ) {
@@ -984,19 +987,6 @@ public abstract class CommandManager<C> {
     }
 
     /**
-     * Get the command suggestions processor instance currently used in this command manager
-     *
-     * @return Command suggestions processor
-     * @see #commandSuggestionProcessor(CommandSuggestionProcessor) Setting the suggestion processor
-     * @deprecated for removal since 1.7.0. Use the non-prefixed getter {@link #commandSuggestionProcessor()} instead.
-     */
-    @Deprecated
-    @API(status = API.Status.DEPRECATED, since = "1.7.0")
-    public @NonNull CommandSuggestionProcessor<C> getCommandSuggestionProcessor() {
-        return this.commandSuggestionProcessor();
-    }
-
-    /**
      * Returns the command suggestion processor used in this command manager.
      *
      * @return the command suggestion processor
@@ -1006,21 +996,6 @@ public abstract class CommandManager<C> {
     @API(status = API.Status.STABLE, since = "1.7.0")
     public @NonNull CommandSuggestionProcessor<C> commandSuggestionProcessor() {
         return this.commandSuggestionProcessor;
-    }
-
-    /**
-     * Set the command suggestions processor for this command manager. This will be called every
-     * time {@link #suggest(Object, String)} is called, to process the list of suggestions
-     * before it's returned to the caller
-     *
-     * @param commandSuggestionProcessor New command suggestions processor
-     * @deprecated for removal since 1.7.0. Use the non-prefixed setter
-     * {@link #commandSuggestionProcessor(CommandSuggestionProcessor)} instead.
-     */
-    @Deprecated
-    @API(status = API.Status.DEPRECATED, since = "1.7.0")
-    public void setCommandSuggestionProcessor(final @NonNull CommandSuggestionProcessor<C> commandSuggestionProcessor) {
-        this.commandSuggestionProcessor(commandSuggestionProcessor);
     }
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/CommandSuggestionEngine.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/CommandSuggestionEngine.java
@@ -23,6 +23,7 @@
 //
 package cloud.commandframework.arguments;
 
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.context.CommandContext;
 import java.util.List;
 import org.apiguardian.api.API;
@@ -37,14 +38,16 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 public interface CommandSuggestionEngine<C> {
 
     /**
-     * Get command suggestions for the "next" argument that would yield a correctly
+     * Returns command suggestions for the "next" argument that would yield a correctly
      * parsing command input
      *
      * @param context Request context
      * @param input   Input provided by the sender
      * @return List of suggestions
+     * @since 2.0.0
      */
-    @NonNull List<@NonNull String> getSuggestions(
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    @NonNull List<@NonNull Suggestion> getSuggestions(
             @NonNull CommandContext<C> context,
             @NonNull String input
     );

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/DelegatingCommandSuggestionEngine.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/DelegatingCommandSuggestionEngine.java
@@ -25,6 +25,7 @@ package cloud.commandframework.arguments;
 
 import cloud.commandframework.CommandManager;
 import cloud.commandframework.CommandTree;
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.execution.preprocessor.CommandPreprocessingContext;
 import cloud.commandframework.internal.CommandInputTokenizer;
@@ -43,7 +44,8 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 @API(status = API.Status.INTERNAL, consumers = "cloud.commandframework.*")
 public final class DelegatingCommandSuggestionEngine<C> implements CommandSuggestionEngine<C> {
 
-    private static final List<String> SINGLE_EMPTY_SUGGESTION = Collections.unmodifiableList(Collections.singletonList(""));
+    private static final List<Suggestion> SINGLE_EMPTY_SUGGESTION =
+            Collections.unmodifiableList(Collections.singletonList(Suggestion.simple("")));
 
     private final CommandManager<C> commandManager;
     private final CommandTree<C> commandTree;
@@ -63,14 +65,14 @@ public final class DelegatingCommandSuggestionEngine<C> implements CommandSugges
     }
 
     @Override
-    public @NonNull List<@NonNull String> getSuggestions(
+    public @NonNull List<@NonNull Suggestion> getSuggestions(
             final @NonNull CommandContext<C> context,
             final @NonNull String input
     ) {
         final @NonNull LinkedList<@NonNull String> inputQueue = new CommandInputTokenizer(input).tokenize();
         /* Store a copy of the input queue in the context */
         context.store("__raw_input__", new LinkedList<>(inputQueue));
-        final List<String> suggestions;
+        final List<Suggestion> suggestions;
         if (this.commandManager.preprocessContext(context, inputQueue) == State.ACCEPTED) {
             suggestions = this.commandManager.commandSuggestionProcessor().apply(
                     new CommandPreprocessingContext<>(context, inputQueue),

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/StaticArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/StaticArgument.java
@@ -127,7 +127,7 @@ public final class StaticArgument<C> extends CommandArgument<C, String> {
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/compound/CompoundArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/compound/CompoundArgument.java
@@ -26,6 +26,7 @@ package cloud.commandframework.arguments.compound;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.types.tuples.Tuple;
 import io.leangen.geantyref.TypeToken;
@@ -157,7 +158,7 @@ public class CompoundArgument<T extends Tuple, C, O> extends CommandArgument<C, 
 
         @Override
         @SuppressWarnings("unchecked")
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull Suggestion> suggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/parser/ArgumentParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/parser/ArgumentParser.java
@@ -23,11 +23,14 @@
 //
 package cloud.commandframework.arguments.parser;
 
+import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.context.CommandContext;
 import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -41,7 +44,7 @@ import static java.util.Objects.requireNonNull;
  */
 @FunctionalInterface
 @API(status = API.Status.STABLE)
-public interface ArgumentParser<C, T> {
+public interface ArgumentParser<C, T> extends SuggestionProvider<C> {
 
     /**
      * Default amount of arguments that the parser expects to consume
@@ -77,7 +80,7 @@ public interface ArgumentParser<C, T> {
     );
 
     /**
-     * Get a list of suggested arguments that would be correctly parsed by this parser
+     * Returns a list of suggested arguments that would be correctly parsed by this parser
      * <p>
      * This method is likely to be called for every character provided by the sender and
      * so it may be necessary to cache results locally to prevent unnecessary computations
@@ -85,12 +88,35 @@ public interface ArgumentParser<C, T> {
      * @param commandContext Command context
      * @param input          Input string
      * @return List of suggestions
+     * @since 2.0.0
      */
-    default @NonNull List<@NonNull String> suggestions(
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    default @NonNull List<@NonNull String> stringSuggestions(
             final @NonNull CommandContext<C> commandContext,
             final @NonNull String input
     ) {
         return Collections.emptyList();
+    }
+
+    /**
+     * Returns a list of suggested arguments that would be correctly parsed by this parser
+     * <p>
+     * This method is likely to be called for every character provided by the sender and
+     * so it may be necessary to cache results locally to prevent unnecessary computations
+     *
+     * @param commandContext Command context
+     * @param input          Input string
+     * @return List of suggestions
+     * @since 2.0.0
+     */
+    @Override
+    @SuppressWarnings("FunctionalInterfaceMethodChanged")
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    default @NonNull List<@NonNull Suggestion> suggestions(
+            final @NonNull CommandContext<C> commandContext,
+            final @NonNull String input
+    ) {
+        return this.stringSuggestions(commandContext, input).stream().map(Suggestion::simple).collect(Collectors.toList());
     }
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/parser/MappedArgumentParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/parser/MappedArgumentParser.java
@@ -23,6 +23,7 @@
 //
 package cloud.commandframework.arguments.parser;
 
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.context.CommandContext;
 import java.util.List;
 import java.util.Queue;
@@ -72,7 +73,7 @@ public final class MappedArgumentParser<C, I, O> implements ArgumentParser<C, O>
     }
 
     @Override
-    public @NonNull List<@NonNull String> suggestions(
+    public @NonNull List<@NonNull Suggestion> suggestions(
             final @NonNull CommandContext<C> commandContext,
             final @NonNull String input
     ) {

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/parser/ParserRegistry.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/parser/ParserRegistry.java
@@ -23,11 +23,10 @@
 //
 package cloud.commandframework.arguments.parser;
 
-import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import io.leangen.geantyref.TypeToken;
 import java.lang.annotation.Annotation;
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -127,15 +126,15 @@ public interface ParserRegistry<C> {
     /**
      * Register a new named suggestion provider
      *
-     * @param name                Name of the suggestions provider. The name is case independent.
-     * @param suggestionsProvider The suggestions provider
+     * @param name               Name of the suggestion provider. The name is case independent.
+     * @param suggestionProvider The suggestion provider
      * @see #getSuggestionProvider(String) Get a suggestion provider
      * @since 1.1.0
      */
-    @API(status = API.Status.STABLE, since = "1.1.0")
+    @API(status = API.Status.STABLE, since = "2.0.0")
     void registerSuggestionProvider(
             @NonNull String name,
-            @NonNull BiFunction<@NonNull CommandContext<C>, @NonNull String, @NonNull List<String>> suggestionsProvider
+            @NonNull SuggestionProvider<C> suggestionProvider
     );
 
     /**
@@ -144,11 +143,11 @@ public interface ParserRegistry<C> {
      * @param name Suggestion provider name. The name is case independent.
      * @return Optional that either contains the suggestion provider, or is empty if no
      *         suggestion provider is registered with the given name
-     * @see #registerSuggestionProvider(String, BiFunction) Register a suggestion provider
-     * @since 1.1.0
+     * @see #registerSuggestionProvider(String, SuggestionProvider) Register a suggestion provider
+     * @since 2.0.0
      */
-    @API(status = API.Status.STABLE, since = "1.1.0")
-    @NonNull Optional<BiFunction<@NonNull CommandContext<C>, @NonNull String, @NonNull List<String>>> getSuggestionProvider(
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    @NonNull Optional<SuggestionProvider<C>> getSuggestionProvider(
             @NonNull String name
     );
 }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/BooleanArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/BooleanArgument.java
@@ -27,6 +27,7 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.captions.CaptionVariable;
 import cloud.commandframework.captions.StandardCaptionKeys;
 import cloud.commandframework.context.CommandContext;
@@ -37,7 +38,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -53,11 +53,10 @@ public final class BooleanArgument<C> extends CommandArgument<C, Boolean> {
     private BooleanArgument(
             final @NonNull String name,
             final boolean liberal,
-            final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
-                    @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription description
     ) {
-        super(name, new BooleanParser<>(liberal), Boolean.class, suggestionsProvider, description);
+        super(name, new BooleanParser<>(liberal), Boolean.class, suggestionProvider, description);
         this.liberal = liberal;
     }
 
@@ -139,7 +138,7 @@ public final class BooleanArgument<C> extends CommandArgument<C, Boolean> {
             return new BooleanArgument<>(
                     this.getName(),
                     this.liberal,
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }
@@ -213,7 +212,7 @@ public final class BooleanArgument<C> extends CommandArgument<C, Boolean> {
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ByteArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ByteArgument.java
@@ -27,13 +27,13 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import cloud.commandframework.exceptions.parsing.NumberParseException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -50,11 +50,10 @@ public final class ByteArgument<C> extends CommandArgument<C, Byte> {
             final @NonNull String name,
             final byte min,
             final byte max,
-            final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
-                    @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(name, new ByteParser<>(min, max), Byte.class, suggestionsProvider, defaultDescription);
+        super(name, new ByteParser<>(min, max), Byte.class, suggestionProvider, defaultDescription);
         this.min = min;
         this.max = max;
     }
@@ -155,7 +154,7 @@ public final class ByteArgument<C> extends CommandArgument<C, Byte> {
          */
         @Override
         public @NonNull ByteArgument<C> build() {
-            return new ByteArgument<>(this.getName(), this.min, this.max, this.getSuggestionsProvider(), this.getDefaultDescription());
+            return new ByteArgument<>(this.getName(), this.min, this.max, this.suggestionProvider(), this.getDefaultDescription());
         }
     }
 
@@ -220,7 +219,7 @@ public final class ByteArgument<C> extends CommandArgument<C, Byte> {
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/CharArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/CharArgument.java
@@ -27,15 +27,14 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.captions.CaptionVariable;
 import cloud.commandframework.captions.StandardCaptionKeys;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import cloud.commandframework.exceptions.parsing.ParserException;
-import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -46,11 +45,10 @@ public final class CharArgument<C> extends CommandArgument<C, Character> {
 
     private CharArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<@NonNull CommandContext<C>,
-                    @NonNull String, @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(name, new CharacterParser<>(), Character.class, suggestionsProvider, defaultDescription);
+        super(name, new CharacterParser<>(), Character.class, suggestionProvider, defaultDescription);
     }
 
     /**
@@ -106,7 +104,7 @@ public final class CharArgument<C> extends CommandArgument<C, Character> {
          */
         @Override
         public @NonNull CharArgument<C> build() {
-            return new CharArgument<>(this.getName(), this.getSuggestionsProvider(), this.getDefaultDescription());
+            return new CharArgument<>(this.getName(), this.suggestionProvider(), this.getDefaultDescription());
         }
     }
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DoubleArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DoubleArgument.java
@@ -27,13 +27,12 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import cloud.commandframework.exceptions.parsing.NumberParseException;
-import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -50,11 +49,10 @@ public final class DoubleArgument<C> extends CommandArgument<C, Double> {
             final @NonNull String name,
             final double min,
             final double max,
-            final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
-                    @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(name, new DoubleParser<>(min, max), Double.class, suggestionsProvider, defaultDescription);
+        super(name, new DoubleParser<>(min, max), Double.class, suggestionProvider, defaultDescription);
         this.min = min;
         this.max = max;
     }
@@ -159,7 +157,7 @@ public final class DoubleArgument<C> extends CommandArgument<C, Double> {
                     this.getName(),
                     this.min,
                     this.max,
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DurationArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DurationArgument.java
@@ -27,6 +27,7 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.captions.CaptionVariable;
 import cloud.commandframework.captions.StandardCaptionKeys;
 import cloud.commandframework.context.CommandContext;
@@ -37,7 +38,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -63,15 +63,14 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
 
     private DurationArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
-                    @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 new Parser<>(),
                 Duration.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -124,7 +123,7 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
         public @NonNull DurationArgument<C> build() {
             return new DurationArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }
@@ -188,7 +187,7 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/EnumArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/EnumArgument.java
@@ -27,6 +27,7 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.captions.CaptionVariable;
 import cloud.commandframework.captions.StandardCaptionKeys;
 import cloud.commandframework.context.CommandContext;
@@ -36,7 +37,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -55,11 +55,10 @@ public class EnumArgument<C, E extends Enum<E>> extends CommandArgument<C, E> {
     protected EnumArgument(
             final @NonNull Class<E> enumClass,
             final @NonNull String name,
-            final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
-                    @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(name, new EnumParser<>(enumClass), enumClass, suggestionsProvider, defaultDescription);
+        super(name, new EnumParser<>(enumClass), enumClass, suggestionProvider, defaultDescription);
     }
 
     /**
@@ -128,7 +127,7 @@ public class EnumArgument<C, E extends Enum<E>> extends CommandArgument<C, E> {
 
         @Override
         public @NonNull CommandArgument<C, E> build() {
-            return new EnumArgument<>(this.enumClass, this.getName(), this.getSuggestionsProvider(), this.getDefaultDescription());
+            return new EnumArgument<>(this.enumClass, this.getName(), this.suggestionProvider(), this.getDefaultDescription());
         }
     }
 
@@ -173,7 +172,7 @@ public class EnumArgument<C, E extends Enum<E>> extends CommandArgument<C, E> {
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/FloatArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/FloatArgument.java
@@ -27,13 +27,12 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import cloud.commandframework.exceptions.parsing.NumberParseException;
-import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -50,11 +49,10 @@ public final class FloatArgument<C> extends CommandArgument<C, Float> {
             final @NonNull String name,
             final float min,
             final float max,
-            final @Nullable BiFunction<@NonNull CommandContext<C>,
-                    @NonNull String, @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(name, new FloatParser<>(min, max), Float.class, suggestionsProvider, defaultDescription);
+        super(name, new FloatParser<>(min, max), Float.class, suggestionProvider, defaultDescription);
         this.min = min;
         this.max = max;
     }
@@ -154,7 +152,7 @@ public final class FloatArgument<C> extends CommandArgument<C, Float> {
                     this.getName(),
                     this.min,
                     this.max,
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/IntegerArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/IntegerArgument.java
@@ -27,6 +27,7 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import cloud.commandframework.exceptions.parsing.NumberParseException;
@@ -37,7 +38,6 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.function.BiFunction;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -57,15 +57,14 @@ public final class IntegerArgument<C> extends CommandArgument<C, Integer> {
             final @NonNull String name,
             final int min,
             final int max,
-            final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
-                    @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 new IntegerParser<>(min, max),
                 Integer.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
         this.min = min;
@@ -164,7 +163,7 @@ public final class IntegerArgument<C> extends CommandArgument<C, Integer> {
         @Override
         public @NonNull IntegerArgument<C> build() {
             return new IntegerArgument<>(this.getName(), this.min, this.max,
-                    this.getSuggestionsProvider(), this.getDefaultDescription()
+                    this.suggestionProvider(), this.getDefaultDescription()
             );
         }
     }
@@ -313,7 +312,7 @@ public final class IntegerArgument<C> extends CommandArgument<C, Integer> {
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/LongArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/LongArgument.java
@@ -27,13 +27,13 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import cloud.commandframework.exceptions.parsing.NumberParseException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -50,11 +50,10 @@ public final class LongArgument<C> extends CommandArgument<C, Long> {
             final @NonNull String name,
             final long min,
             final long max,
-            final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
-                    @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(name, new LongParser<>(min, max), Long.class, suggestionsProvider, defaultDescription);
+        super(name, new LongParser<>(min, max), Long.class, suggestionProvider, defaultDescription);
         this.min = min;
         this.max = max;
     }
@@ -151,7 +150,7 @@ public final class LongArgument<C> extends CommandArgument<C, Long> {
         @Override
         public @NonNull LongArgument<C> build() {
             return new LongArgument<>(this.getName(), this.min,
-                    this.max, this.getSuggestionsProvider(), this.getDefaultDescription()
+                    this.max, this.suggestionProvider(), this.getDefaultDescription()
             );
         }
     }
@@ -259,7 +258,7 @@ public final class LongArgument<C> extends CommandArgument<C, Long> {
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ShortArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ShortArgument.java
@@ -27,13 +27,13 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import cloud.commandframework.exceptions.parsing.NumberParseException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -50,11 +50,10 @@ public final class ShortArgument<C> extends CommandArgument<C, Short> {
             final @NonNull String name,
             final short min,
             final short max,
-            final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
-                    @NonNull List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(name, new ShortParser<>(min, max), Short.class, suggestionsProvider, defaultDescription);
+        super(name, new ShortParser<>(min, max), Short.class, suggestionProvider, defaultDescription);
         this.min = min;
         this.max = max;
     }
@@ -151,7 +150,7 @@ public final class ShortArgument<C> extends CommandArgument<C, Short> {
         @Override
         public @NonNull ShortArgument<C> build() {
             return new ShortArgument<>(this.getName(), this.min, this.max,
-                    this.getSuggestionsProvider(), this.getDefaultDescription()
+                    this.suggestionProvider(), this.getDefaultDescription()
             );
         }
     }
@@ -217,7 +216,7 @@ public final class ShortArgument<C> extends CommandArgument<C, Short> {
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringArrayArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringArrayArgument.java
@@ -27,12 +27,12 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.context.CommandContext;
 import io.leangen.geantyref.TypeToken;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import java.util.regex.Pattern;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -50,7 +50,7 @@ public final class StringArrayArgument<C> extends CommandArgument<C, String[]> {
 
     private StringArrayArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final boolean flagYielding
     ) {
@@ -58,7 +58,7 @@ public final class StringArrayArgument<C> extends CommandArgument<C, String[]> {
                 name,
                 new StringArrayParser<>(flagYielding),
                 TypeToken.get(String[].class),
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -66,18 +66,18 @@ public final class StringArrayArgument<C> extends CommandArgument<C, String[]> {
     /**
      * Create a new required string array argument
      *
-     * @param name                Argument name
-     * @param suggestionsProvider Suggestions provider
-     * @param <C>                 Command sender type
+     * @param name               Argument name
+     * @param suggestionProvider Suggestion provider
+     * @param <C>                Command sender type
      * @return Created argument
      */
     public static <C> @NonNull StringArrayArgument<C> of(
             final @NonNull String name,
-            final @NonNull BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider
+            final @NonNull SuggestionProvider<C> suggestionProvider
     ) {
         return new StringArrayArgument<>(
                 name,
-                suggestionsProvider,
+                suggestionProvider,
                 ArgumentDescription.empty(),
                 false /* flagYielding */
         );
@@ -86,10 +86,10 @@ public final class StringArrayArgument<C> extends CommandArgument<C, String[]> {
     /**
      * Create a new required string array argument
      *
-     * @param name                Argument name
-     * @param flagYielding        Whether the parser should stop parsing when encountering a potential flag
-     * @param suggestionsProvider Suggestions provider
-     * @param <C>                 Command sender type
+     * @param name               Argument name
+     * @param flagYielding       Whether the parser should stop parsing when encountering a potential flag
+     * @param suggestionProvider Suggestion provider
+     * @param <C>                Command sender type
      * @return Created argument
      * @since 1.7.0
      */
@@ -97,11 +97,11 @@ public final class StringArrayArgument<C> extends CommandArgument<C, String[]> {
     public static <C> @NonNull StringArrayArgument<C> of(
             final @NonNull String name,
             final boolean flagYielding,
-            final @NonNull BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider
+            final @NonNull SuggestionProvider<C> suggestionProvider
     ) {
         return new StringArrayArgument<>(
                 name,
-                suggestionsProvider,
+                suggestionProvider,
                 ArgumentDescription.empty(),
                 flagYielding
         );

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/UUIDArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/UUIDArgument.java
@@ -27,16 +27,15 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.captions.CaptionVariable;
 import cloud.commandframework.captions.StandardCaptionKeys;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import cloud.commandframework.exceptions.parsing.ParserException;
-import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.UUID;
-import java.util.function.BiFunction;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -47,11 +46,10 @@ public final class UUIDArgument<C> extends CommandArgument<C, UUID> {
 
     private UUIDArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<@NonNull CommandContext<C>,
-                    @NonNull String, @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(name, new UUIDParser<>(), UUID.class, suggestionsProvider, defaultDescription);
+        super(name, new UUIDParser<>(), UUID.class, suggestionProvider, defaultDescription);
     }
 
     /**
@@ -109,7 +107,7 @@ public final class UUIDArgument<C> extends CommandArgument<C, UUID> {
         public @NonNull UUIDArgument<C> build() {
             return new UUIDArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/SimpleSuggestion.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/SimpleSuggestion.java
@@ -21,34 +21,48 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-package cloud.commandframework.execution;
+package cloud.commandframework.arguments.suggestion;
 
-import cloud.commandframework.arguments.suggestion.Suggestion;
-import cloud.commandframework.execution.preprocessor.CommandPreprocessingContext;
-import java.util.List;
-import java.util.function.BiFunction;
-import org.apiguardian.api.API;
+import java.util.Objects;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-/**
- * Processor that formats command suggestions
- *
- * @param <C> Command sender type
- */
-@API(status = API.Status.STABLE)
-public interface CommandSuggestionProcessor<C> extends
-        BiFunction<@NonNull CommandPreprocessingContext<C>, @NonNull List<Suggestion>, @NonNull List<Suggestion>> {
+final class SimpleSuggestion implements Suggestion {
 
-    /**
-     * Create a pass through {@link CommandSuggestionProcessor} that simply returns
-     * the input.
-     *
-     * @param <C> sender type
-     * @return new processor
-     * @since 1.8.0
-     */
-    @API(status = API.Status.STABLE, since = "1.8.0")
-    static <C> @NonNull CommandSuggestionProcessor<C> passThrough() {
-        return (ctx, suggestions) -> suggestions;
+    private final String suggestion;
+
+    SimpleSuggestion(final @NonNull String suggestion) {
+        this.suggestion = suggestion;
+    }
+
+    @Override
+    public @NonNull String suggestion() {
+        return this.suggestion;
+    }
+
+    @Override
+    public @NonNull Suggestion withSuggestion(@NonNull final String suggestion) {
+        return new SimpleSuggestion(suggestion);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final SimpleSuggestion that = (SimpleSuggestion) o;
+        return Objects.equals(this.suggestion, that.suggestion);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.suggestion);
+    }
+
+    @Override
+    public String toString() {
+        return this.suggestion;
     }
 }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/Suggestion.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/Suggestion.java
@@ -21,36 +21,36 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-package cloud.commandframework.arguments;
+package cloud.commandframework.arguments.suggestion;
 
-import cloud.commandframework.arguments.parser.ArgumentParser;
-import cloud.commandframework.context.CommandContext;
-import java.util.List;
-import java.util.function.BiFunction;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-@API(status = API.Status.INTERNAL, consumers = "cloud.commandframework.*")
-final class DelegatingSuggestionsProvider<C> implements BiFunction<@NonNull CommandContext<C>,
-        @NonNull String, @NonNull List<String>> {
+@API(status = API.Status.STABLE, since = "2.0.0")
+public interface Suggestion {
 
-    private final String argumentName;
-    private final ArgumentParser<C, ?> parser;
-
-    DelegatingSuggestionsProvider(final @NonNull String argumentName, final @NonNull ArgumentParser<C, ?> parser) {
-        this.argumentName = argumentName;
-        this.parser = parser;
+    /**
+     * Returns a simple suggestion that returns the given {@code suggestion}
+     *
+     * @param suggestion the suggestion string
+     * @return the created suggestion
+     */
+    static @NonNull Suggestion simple(final @NonNull String suggestion) {
+        return new SimpleSuggestion(suggestion);
     }
 
-    @Override
-    public @NonNull List<@NonNull String> apply(final @NonNull CommandContext<C> context, final @NonNull String s) {
-        return this.parser.suggestions(context, s);
-    }
+    /**
+     * Returns a string representation of this suggestion, which can be parsed by the parser that suggested it
+     *
+     * @return the suggestions
+     */
+    @NonNull String suggestion();
 
-    @Override
-    public String toString() {
-        return String.format("DelegatingSuggestionsProvider{name='%s',parser='%s'}", this.argumentName,
-                this.parser.getClass().getCanonicalName()
-        );
-    }
+    /**
+     * Returns a copy of this suggestion instance using the given {@code suggestion}
+     *
+     * @param suggestion the suggestion string
+     * @return the new suggestion
+     */
+    @NonNull Suggestion withSuggestion(@NonNull String suggestion);
 }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/SuggestionProvider.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/SuggestionProvider.java
@@ -21,34 +21,29 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-package cloud.commandframework.execution;
+package cloud.commandframework.arguments.suggestion;
 
-import cloud.commandframework.arguments.suggestion.Suggestion;
-import cloud.commandframework.execution.preprocessor.CommandPreprocessingContext;
+import cloud.commandframework.context.CommandContext;
 import java.util.List;
-import java.util.function.BiFunction;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
- * Processor that formats command suggestions
+ * Provider of suggestions
  *
- * @param <C> Command sender type
+ * @param <C> command sender type
+ * @since 2.0.0
  */
-@API(status = API.Status.STABLE)
-public interface CommandSuggestionProcessor<C> extends
-        BiFunction<@NonNull CommandPreprocessingContext<C>, @NonNull List<Suggestion>, @NonNull List<Suggestion>> {
+@API(status = API.Status.STABLE, since = "2.0.0")
+@FunctionalInterface
+public interface SuggestionProvider<C> {
 
     /**
-     * Create a pass through {@link CommandSuggestionProcessor} that simply returns
-     * the input.
+     * Returns the suggestions for the given {@code input}
      *
-     * @param <C> sender type
-     * @return new processor
-     * @since 1.8.0
+     * @param context the context of the suggestion lookup
+     * @param input   the current input
+     * @return the suggestions
      */
-    @API(status = API.Status.STABLE, since = "1.8.0")
-    static <C> @NonNull CommandSuggestionProcessor<C> passThrough() {
-        return (ctx, suggestions) -> suggestions;
-    }
+    @NonNull List<@NonNull Suggestion> suggestions(@NonNull CommandContext<C> context, @NonNull String input);
 }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/package-info.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Command arguments that are used to build command parsing chains
+ */
+package cloud.commandframework.arguments.suggestion;

--- a/cloud-core/src/main/java/cloud/commandframework/execution/FilteringCommandSuggestionProcessor.java
+++ b/cloud-core/src/main/java/cloud/commandframework/execution/FilteringCommandSuggestionProcessor.java
@@ -23,6 +23,7 @@
 //
 package cloud.commandframework.execution;
 
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.execution.preprocessor.CommandPreprocessingContext;
 import java.util.ArrayList;
 import java.util.List;
@@ -65,9 +66,9 @@ public final class FilteringCommandSuggestionProcessor<C> implements CommandSugg
     }
 
     @Override
-    public @NonNull List<@NonNull String> apply(
+    public @NonNull List<@NonNull Suggestion> apply(
             final @NonNull CommandPreprocessingContext<C> context,
-            final @NonNull List<@NonNull String> strings
+            final @NonNull List<@NonNull Suggestion> inputSuggestions
     ) {
         final String input;
         if (context.getInputQueue().isEmpty()) {
@@ -75,11 +76,11 @@ public final class FilteringCommandSuggestionProcessor<C> implements CommandSugg
         } else {
             input = String.join(" ", context.getInputQueue());
         }
-        final List<String> suggestions = new ArrayList<>(strings.size());
-        for (final String suggestion : strings) {
-            final @Nullable String filtered = this.filter.filter(context, suggestion, input);
+        final List<Suggestion> suggestions = new ArrayList<>(inputSuggestions.size());
+        for (final Suggestion suggestion : inputSuggestions) {
+            final @Nullable String filtered = this.filter.filter(context, suggestion.suggestion(), input);
             if (filtered != null) {
-                suggestions.add(filtered);
+                suggestions.add(suggestion.withSuggestion(filtered));
             }
         }
         return suggestions;

--- a/cloud-core/src/test/java/cloud/commandframework/CommandDeletionTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandDeletionTest.java
@@ -24,6 +24,7 @@
 package cloud.commandframework;
 
 import cloud.commandframework.arguments.standard.StringArgument;
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.exceptions.NoSuchCommandException;
 import cloud.commandframework.execution.CommandExecutionCoordinator;
 import cloud.commandframework.execution.CommandExecutionHandler;
@@ -168,7 +169,7 @@ class CommandDeletionTest {
         );
         assertThat(completionException).hasCauseThat().isInstanceOf(NoSuchCommandException.class);
 
-        assertThat(this.commandManager.suggest(new TestCommandSender(), "")).contains("test");
+        assertThat(this.commandManager.suggest(new TestCommandSender(), "")).contains(Suggestion.simple("test"));
         assertThat(this.commandManager.commandTree().getRootNodes()).hasSize(1);
     }
 }

--- a/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
@@ -23,7 +23,6 @@
 //
 package cloud.commandframework;
 
-import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.compound.ArgumentTriplet;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.standard.BooleanArgument;
@@ -32,22 +31,21 @@ import cloud.commandframework.arguments.standard.EnumArgument;
 import cloud.commandframework.arguments.standard.IntegerArgument;
 import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.arguments.standard.StringArrayArgument;
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.execution.FilteringCommandSuggestionProcessor;
 import cloud.commandframework.types.tuples.Pair;
 import cloud.commandframework.types.tuples.Triplet;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Ignore;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import static cloud.commandframework.arguments.standard.ArgumentTestHelper.suggestionList;
 import static cloud.commandframework.util.TestUtils.createManager;
 import static com.google.common.truth.Truth.assertThat;
 
-public class CommandSuggestionsTest {
+class CommandSuggestionsTest {
 
     private static CommandManager<TestCommandSender> manager;
 
@@ -59,18 +57,18 @@ public class CommandSuggestionsTest {
         manager.command(manager.commandBuilder("test")
                 .literal("var")
                 .required(StringArgument.<TestCommandSender>builder("str")
-                        .withSuggestionsProvider((c, s) -> Arrays.asList("one", "two")))
+                        .withSuggestionProvider((c, s) -> suggestionList("one", "two")))
                 .required(EnumArgument.of(TestEnum.class, "enum")));
         manager.command(manager.commandBuilder("test")
                 .literal("comb")
                 .required(StringArgument.<TestCommandSender>builder("str")
-                        .withSuggestionsProvider((c, s) -> Arrays.asList("one", "two")))
+                        .withSuggestionProvider((c, s) -> suggestionList("one", "two")))
                 .optional(IntegerArgument.<TestCommandSender>builder("num")
                         .withMin(1).withMax(95)));
         manager.command(manager.commandBuilder("test")
                 .literal("alt")
                 .required(IntegerArgument.<TestCommandSender>builder("num")
-                        .withSuggestionsProvider((c, s) -> Arrays.asList("3", "33", "333"))));
+                        .withSuggestionProvider((c, s) -> suggestionList("3", "33", "333"))));
 
         manager.command(manager.commandBuilder("com")
                 .requiredArgumentPair("com", Pair.of("x", "y"), Pair.of(Integer.class, TestEnum.class),
@@ -122,7 +120,7 @@ public class CommandSuggestionsTest {
         manager.command(manager.commandBuilder("partial")
                 .required(
                         StringArgument.<TestCommandSender>builder("arg")
-                                .withSuggestionsProvider((contect, input) -> Arrays.asList("hi", "hey", "heya", "hai", "hello"))
+                                .withSuggestionProvider((contect, input) -> suggestionList("hi", "hey", "heya", "hai", "hello"))
                 )
                 .literal("literal")
                 .build());
@@ -130,7 +128,7 @@ public class CommandSuggestionsTest {
         manager.command(manager.commandBuilder("literal_with_variable")
                 .required(
                         StringArgument.<TestCommandSender>builder("arg")
-                                .withSuggestionsProvider((context, input) -> Arrays.asList("veni", "vidi")).build()
+                                .withSuggestionProvider((context, input) -> suggestionList("veni", "vidi")).build()
                 )
                 .literal("now"));
         manager.command(manager.commandBuilder("literal_with_variable")
@@ -153,196 +151,196 @@ public class CommandSuggestionsTest {
     @Test
     void testRootAliases() {
         final String input = "test ";
-        final List<String> suggestions = manager.suggest(new TestCommandSender(), input);
+        final List<Suggestion> suggestions = manager.suggest(new TestCommandSender(), input);
         final String input2 = "testalias ";
-        final List<String> suggestions2 = manager.suggest(new TestCommandSender(), input2);
+        final List<Suggestion> suggestions2 = manager.suggest(new TestCommandSender(), input2);
         Assertions.assertEquals(suggestions, suggestions2);
     }
 
     @Test
     void testSimple() {
         final String input = "test";
-        final List<String> suggestions = manager.suggest(new TestCommandSender(), input);
+        final List<Suggestion> suggestions = manager.suggest(new TestCommandSender(), input);
         Assertions.assertTrue(suggestions.isEmpty());
         final String input2 = "test ";
-        final List<String> suggestions2 = manager.suggest(new TestCommandSender(), input2);
-        Assertions.assertEquals(Arrays.asList("alt", "comb", "one", "two", "var"), suggestions2);
+        final List<Suggestion> suggestions2 = manager.suggest(new TestCommandSender(), input2);
+        Assertions.assertEquals(suggestionList("alt", "comb", "one", "two", "var"), suggestions2);
         final String input3 = "test a";
-        final List<String> suggestions3 = manager.suggest(new TestCommandSender(), input3);
-        Assertions.assertEquals(Collections.singletonList("alt"), suggestions3);
+        final List<Suggestion> suggestions3 = manager.suggest(new TestCommandSender(), input3);
+        Assertions.assertEquals(suggestionList("alt"), suggestions3);
     }
 
     @Test
     void testVar() {
         final String input = "test var";
-        final List<String> suggestions = manager.suggest(new TestCommandSender(), input);
+        final List<Suggestion> suggestions = manager.suggest(new TestCommandSender(), input);
         Assertions.assertTrue(suggestions.isEmpty());
         final String input2 = "test var one";
-        final List<String> suggestions2 = manager.suggest(new TestCommandSender(), input2);
-        Assertions.assertEquals(Collections.singletonList("one"), suggestions2);
+        final List<Suggestion> suggestions2 = manager.suggest(new TestCommandSender(), input2);
+        Assertions.assertEquals(suggestionList("one"), suggestions2);
         final String input3 = "test var one f";
-        final List<String> suggestions3 = manager.suggest(new TestCommandSender(), input3);
-        Assertions.assertEquals(Collections.singletonList("foo"), suggestions3);
+        final List<Suggestion> suggestions3 = manager.suggest(new TestCommandSender(), input3);
+        Assertions.assertEquals(suggestionList("foo"), suggestions3);
         final String input4 = "test var one ";
-        final List<String> suggestions4 = manager.suggest(new TestCommandSender(), input4);
-        Assertions.assertEquals(Arrays.asList("foo", "bar"), suggestions4);
+        final List<Suggestion> suggestions4 = manager.suggest(new TestCommandSender(), input4);
+        Assertions.assertEquals(suggestionList("foo", "bar"), suggestions4);
     }
 
     @Test
     void testEmpty() {
         final String input = "kenny";
-        final List<String> suggestions = manager.suggest(new TestCommandSender(), input);
+        final List<Suggestion> suggestions = manager.suggest(new TestCommandSender(), input);
         Assertions.assertTrue(suggestions.isEmpty());
     }
 
     @Test
     void testComb() {
         final String input = "test comb ";
-        final List<String> suggestions = manager.suggest(new TestCommandSender(), input);
-        Assertions.assertEquals(Arrays.asList("one", "two"), suggestions);
+        final List<Suggestion> suggestions = manager.suggest(new TestCommandSender(), input);
+        Assertions.assertEquals(suggestionList("one", "two"), suggestions);
         final String input2 = "test comb one ";
-        final List<String> suggestions2 = manager.suggest(new TestCommandSender(), input2);
-        Assertions.assertEquals(Arrays.asList("1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions2);
+        final List<Suggestion> suggestions2 = manager.suggest(new TestCommandSender(), input2);
+        Assertions.assertEquals(suggestionList("1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions2);
         final String input3 = "test comb one 9";
-        final List<String> suggestions3 = manager.suggest(new TestCommandSender(), input3);
-        Assertions.assertEquals(Arrays.asList("9", "90", "91", "92", "93", "94", "95"), suggestions3);
+        final List<Suggestion> suggestions3 = manager.suggest(new TestCommandSender(), input3);
+        Assertions.assertEquals(suggestionList("9", "90", "91", "92", "93", "94", "95"), suggestions3);
     }
 
     @Test
     void testAltered() {
         final String input = "test alt ";
-        final List<String> suggestions = manager.suggest(new TestCommandSender(), input);
-        Assertions.assertEquals(Arrays.asList("3", "33", "333"), suggestions);
+        final List<Suggestion> suggestions = manager.suggest(new TestCommandSender(), input);
+        Assertions.assertEquals(suggestionList("3", "33", "333"), suggestions);
     }
 
     @Test
     void testCompound() {
         final String input = "com ";
-        final List<String> suggestions = manager.suggest(new TestCommandSender(), input);
-        Assertions.assertEquals(Arrays.asList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions);
+        final List<Suggestion> suggestions = manager.suggest(new TestCommandSender(), input);
+        Assertions.assertEquals(suggestionList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions);
         final String input2 = "com 1 ";
-        final List<String> suggestions2 = manager.suggest(new TestCommandSender(), input2);
-        Assertions.assertEquals(Arrays.asList("foo", "bar"), suggestions2);
+        final List<Suggestion> suggestions2 = manager.suggest(new TestCommandSender(), input2);
+        Assertions.assertEquals(suggestionList("foo", "bar"), suggestions2);
         final String input3 = "com 1 foo ";
-        final List<String> suggestions3 = manager.suggest(new TestCommandSender(), input3);
-        Assertions.assertEquals(Arrays.asList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions3);
+        final List<Suggestion> suggestions3 = manager.suggest(new TestCommandSender(), input3);
+        Assertions.assertEquals(suggestionList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions3);
         final String input4 = "com2 1 ";
-        final List<String> suggestions4 = manager.suggest(new TestCommandSender(), input4);
-        Assertions.assertEquals(Arrays.asList("foo", "bar"), suggestions4);
+        final List<Suggestion> suggestions4 = manager.suggest(new TestCommandSender(), input4);
+        Assertions.assertEquals(suggestionList("foo", "bar"), suggestions4);
     }
 
     @Test
     void testFlags() {
         final String input = "flags 10 ";
-        final List<String> suggestions = manager.suggest(new TestCommandSender(), input);
-        Assertions.assertEquals(Arrays.asList("--enum", "--static"), suggestions);
+        final List<Suggestion> suggestions = manager.suggest(new TestCommandSender(), input);
+        Assertions.assertEquals(suggestionList("--enum", "--static"), suggestions);
         final String input2 = "flags 10 --enum ";
-        final List<String> suggestions2 = manager.suggest(new TestCommandSender(), input2);
-        Assertions.assertEquals(Arrays.asList("foo", "bar"), suggestions2);
+        final List<Suggestion> suggestions2 = manager.suggest(new TestCommandSender(), input2);
+        Assertions.assertEquals(suggestionList("foo", "bar"), suggestions2);
         final String input3 = "flags 10 --enum foo ";
-        final List<String> suggestions3 = manager.suggest(new TestCommandSender(), input3);
-        Assertions.assertEquals(Collections.singletonList("--static"), suggestions3);
+        final List<Suggestion> suggestions3 = manager.suggest(new TestCommandSender(), input3);
+        Assertions.assertEquals(suggestionList("--static"), suggestions3);
         final String input4 = "flags2 ";
-        final List<String> suggestions4 = manager.suggest(new TestCommandSender(), input4);
-        Assertions.assertEquals(Arrays.asList("--first", "--second", "--third", "-f", "-s", "-t"), suggestions4);
+        final List<Suggestion> suggestions4 = manager.suggest(new TestCommandSender(), input4);
+        Assertions.assertEquals(suggestionList("--first", "--second", "--third", "-f", "-s", "-t"), suggestions4);
         final String input5 = "flags2 -f";
-        final List<String> suggestions5 = manager.suggest(new TestCommandSender(), input5);
-        Assertions.assertEquals(Arrays.asList("-fs", "-ft", "-f"), suggestions5);
+        final List<Suggestion> suggestions5 = manager.suggest(new TestCommandSender(), input5);
+        Assertions.assertEquals(suggestionList("-fs", "-ft", "-f"), suggestions5);
         final String input6 = "flags2 -f -s";
-        final List<String> suggestions6 = manager.suggest(new TestCommandSender(), input6);
-        Assertions.assertEquals(Arrays.asList("-st", "-s"), suggestions6);
+        final List<Suggestion> suggestions6 = manager.suggest(new TestCommandSender(), input6);
+        Assertions.assertEquals(suggestionList("-st", "-s"), suggestions6);
 
         /* When an incorrect flag is specified, should resolve to listing flags */
         final String input7 = "flags2 --invalid ";
-        final List<String> suggestions7 = manager.suggest(new TestCommandSender(), input7);
-        Assertions.assertEquals(Arrays.asList("--first", "--second", "--third", "-f", "-s", "-t"), suggestions7);
+        final List<Suggestion> suggestions7 = manager.suggest(new TestCommandSender(), input7);
+        Assertions.assertEquals(suggestionList("--first", "--second", "--third", "-f", "-s", "-t"), suggestions7);
     }
 
     @Test
     void testCompoundFlags() {
         final String input = "flags3 ";
-        final List<String> suggestions = manager.suggest(new TestCommandSender(), input);
-        Assertions.assertEquals(Arrays.asList("--compound", "--presence", "--single", "-p"), suggestions);
+        final List<Suggestion> suggestions = manager.suggest(new TestCommandSender(), input);
+        Assertions.assertEquals(suggestionList("--compound", "--presence", "--single", "-p"), suggestions);
 
         final String input2 = "flags3 --c";
-        final List<String> suggestions2 = manager.suggest(new TestCommandSender(), input2);
-        Assertions.assertEquals(Collections.singletonList("--compound"), suggestions2);
+        final List<Suggestion> suggestions2 = manager.suggest(new TestCommandSender(), input2);
+        Assertions.assertEquals(suggestionList("--compound"), suggestions2);
 
         final String input3 = "flags3 --compound ";
-        final List<String> suggestions3 = manager.suggest(new TestCommandSender(), input3);
-        Assertions.assertEquals(Arrays.asList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions3);
+        final List<Suggestion> suggestions3 = manager.suggest(new TestCommandSender(), input3);
+        Assertions.assertEquals(suggestionList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions3);
 
         final String input4 = "flags3 --compound 1";
-        final List<String> suggestions4 = manager.suggest(new TestCommandSender(), input4);
-        Assertions.assertEquals(Arrays.asList("1", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"), suggestions4);
+        final List<Suggestion> suggestions4 = manager.suggest(new TestCommandSender(), input4);
+        Assertions.assertEquals(suggestionList("1", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"), suggestions4);
 
         final String input5 = "flags3 --compound 22 ";
-        final List<String> suggestions5 = manager.suggest(new TestCommandSender(), input5);
-        Assertions.assertEquals(Arrays.asList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions5);
+        final List<Suggestion> suggestions5 = manager.suggest(new TestCommandSender(), input5);
+        Assertions.assertEquals(suggestionList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions5);
 
         final String input6 = "flags3 --compound 22 1";
-        final List<String> suggestions6 = manager.suggest(new TestCommandSender(), input6);
-        Assertions.assertEquals(Arrays.asList("1", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"), suggestions6);
+        final List<Suggestion> suggestions6 = manager.suggest(new TestCommandSender(), input6);
+        Assertions.assertEquals(suggestionList("1", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"), suggestions6);
 
         /* We've typed compound already, so that flag should be omitted from the suggestions */
         final String input7 = "flags3 --compound 22 33 44 ";
-        final List<String> suggestions7 = manager.suggest(new TestCommandSender(), input7);
-        Assertions.assertEquals(Arrays.asList("--presence", "--single", "-p"), suggestions7);
+        final List<Suggestion> suggestions7 = manager.suggest(new TestCommandSender(), input7);
+        Assertions.assertEquals(suggestionList("--presence", "--single", "-p"), suggestions7);
 
         final String input8 = "flags3 --compound 22 33 44 --pres";
-        final List<String> suggestions8 = manager.suggest(new TestCommandSender(), input8);
-        Assertions.assertEquals(Collections.singletonList("--presence"), suggestions8);
+        final List<Suggestion> suggestions8 = manager.suggest(new TestCommandSender(), input8);
+        Assertions.assertEquals(suggestionList("--presence"), suggestions8);
 
         final String input9 = "flags3 --compound 22 33 44 --presence ";
-        final List<String> suggestions9 = manager.suggest(new TestCommandSender(), input9);
-        Assertions.assertEquals(Collections.singletonList("--single"), suggestions9);
+        final List<Suggestion> suggestions9 = manager.suggest(new TestCommandSender(), input9);
+        Assertions.assertEquals(suggestionList("--single"), suggestions9);
 
         final String input10 = "flags3 --compound 22 33 44 --single ";
-        final List<String> suggestions10 = manager.suggest(new TestCommandSender(), input10);
-        Assertions.assertEquals(Arrays.asList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions10);
+        final List<Suggestion> suggestions10 = manager.suggest(new TestCommandSender(), input10);
+        Assertions.assertEquals(suggestionList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions10);
     }
 
     @Test
     void testNumbers() {
         final String input = "numbers ";
-        final List<String> suggestions = manager.suggest(new TestCommandSender(), input);
-        Assertions.assertEquals(Arrays.asList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions);
+        final List<Suggestion> suggestions = manager.suggest(new TestCommandSender(), input);
+        Assertions.assertEquals(suggestionList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions);
         final String input2 = "numbers 1";
-        final List<String> suggestions2 = manager.suggest(new TestCommandSender(), input2);
-        Assertions.assertEquals(Arrays.asList("1", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"), suggestions2);
+        final List<Suggestion> suggestions2 = manager.suggest(new TestCommandSender(), input2);
+        Assertions.assertEquals(suggestionList("1", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"), suggestions2);
         final String input3 = "numbers -";
-        final List<String> suggestions3 = manager.suggest(new TestCommandSender(), input3);
-        Assertions.assertEquals(Arrays.asList("-1", "-2", "-3", "-4", "-5", "-6", "-7", "-8", "-9"), suggestions3);
+        final List<Suggestion> suggestions3 = manager.suggest(new TestCommandSender(), input3);
+        Assertions.assertEquals(suggestionList("-1", "-2", "-3", "-4", "-5", "-6", "-7", "-8", "-9"), suggestions3);
         final String input4 = "numbers -1";
-        final List<String> suggestions4 = manager.suggest(new TestCommandSender(), input4);
+        final List<Suggestion> suggestions4 = manager.suggest(new TestCommandSender(), input4);
         Assertions.assertEquals(
-                Arrays.asList("-1", "-10", "-11", "-12", "-13", "-14", "-15", "-16", "-17", "-18", "-19"),
+                suggestionList("-1", "-10", "-11", "-12", "-13", "-14", "-15", "-16", "-17", "-18", "-19"),
                 suggestions4
         );
         final String input5 = "numberswithmin ";
-        final List<String> suggestions5 = manager.suggest(new TestCommandSender(), input5);
-        Assertions.assertEquals(Arrays.asList("5", "6", "7", "8", "9"), suggestions5);
+        final List<Suggestion> suggestions5 = manager.suggest(new TestCommandSender(), input5);
+        Assertions.assertEquals(suggestionList("5", "6", "7", "8", "9"), suggestions5);
 
         final String input6 = "numbers 1 ";
-        final List<String> suggestions6 = manager.suggest(new TestCommandSender(), input6);
+        final List<Suggestion> suggestions6 = manager.suggest(new TestCommandSender(), input6);
         Assertions.assertEquals(Collections.emptyList(), suggestions6);
     }
 
     @Test
     void testNumbersWithFollowingArguments() {
         final String input = "numberswithfollowingargument ";
-        final List<String> suggestions = manager.suggest(new TestCommandSender(), input);
-        Assertions.assertEquals(Arrays.asList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions);
+        final List<Suggestion> suggestions = manager.suggest(new TestCommandSender(), input);
+        Assertions.assertEquals(suggestionList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions);
         final String input2 = "numberswithfollowingargument 1";
-        final List<String> suggestions2 = manager.suggest(new TestCommandSender(), input2);
-        Assertions.assertEquals(Arrays.asList("1", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"), suggestions2);
+        final List<Suggestion> suggestions2 = manager.suggest(new TestCommandSender(), input2);
+        Assertions.assertEquals(suggestionList("1", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"), suggestions2);
         final String input3 = "numberswithfollowingargument -";
-        final List<String> suggestions3 = manager.suggest(new TestCommandSender(), input3);
-        Assertions.assertEquals(Arrays.asList("-1", "-2", "-3", "-4", "-5", "-6", "-7", "-8", "-9"), suggestions3);
+        final List<Suggestion> suggestions3 = manager.suggest(new TestCommandSender(), input3);
+        Assertions.assertEquals(suggestionList("-1", "-2", "-3", "-4", "-5", "-6", "-7", "-8", "-9"), suggestions3);
         final String input4 = "numberswithfollowingargument -1";
-        final List<String> suggestions4 = manager.suggest(new TestCommandSender(), input4);
+        final List<Suggestion> suggestions4 = manager.suggest(new TestCommandSender(), input4);
         Assertions.assertEquals(
-                Arrays.asList("-1", "-10", "-11", "-12", "-13", "-14", "-15", "-16", "-17", "-18", "-19"),
+                suggestionList("-1", "-10", "-11", "-12", "-13", "-14", "-15", "-16", "-17", "-18", "-19"),
                 suggestions4
         );
     }
@@ -350,29 +348,29 @@ public class CommandSuggestionsTest {
     @Test
     void testDurations() {
         final String input = "duration ";
-        final List<String> suggestions = manager.suggest(new TestCommandSender(), input);
-        Assertions.assertEquals(Arrays.asList("1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions);
+        final List<Suggestion> suggestions = manager.suggest(new TestCommandSender(), input);
+        Assertions.assertEquals(suggestionList("1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions);
         final String input2 = "duration 5";
-        final List<String> suggestions2 = manager.suggest(new TestCommandSender(), input2);
-        Assertions.assertEquals(Arrays.asList("5d", "5h", "5m", "5s"), suggestions2);
+        final List<Suggestion> suggestions2 = manager.suggest(new TestCommandSender(), input2);
+        Assertions.assertEquals(suggestionList("5d", "5h", "5m", "5s"), suggestions2);
         final String input3 = "duration 5s";
-        final List<String> suggestions3 = manager.suggest(new TestCommandSender(), input3);
+        final List<Suggestion> suggestions3 = manager.suggest(new TestCommandSender(), input3);
         Assertions.assertEquals(Collections.emptyList(), suggestions3);
         final String input4 = "duration 5s ";
-        final List<String> suggestions4 = manager.suggest(new TestCommandSender(), input4);
+        final List<Suggestion> suggestions4 = manager.suggest(new TestCommandSender(), input4);
         Assertions.assertEquals(Collections.emptyList(), suggestions4);
     }
 
     @Test
     void testInvalidLiteralThenSpace() {
         final String input = "test o";
-        final List<String> suggestions = manager.suggest(new TestCommandSender(), input);
-        Assertions.assertEquals(Collections.singletonList("one"), suggestions);
+        final List<Suggestion> suggestions = manager.suggest(new TestCommandSender(), input);
+        Assertions.assertEquals(suggestionList("one"), suggestions);
         final String input2 = "test o ";
-        final List<String> suggestions2 = manager.suggest(new TestCommandSender(), input2);
+        final List<Suggestion> suggestions2 = manager.suggest(new TestCommandSender(), input2);
         Assertions.assertEquals(Collections.emptyList(), suggestions2);
         final String input3 = "test o abc123xyz";
-        final List<String> suggestions3 = manager.suggest(new TestCommandSender(), input3);
+        final List<Suggestion> suggestions3 = manager.suggest(new TestCommandSender(), input3);
         Assertions.assertEquals(Collections.emptyList(), suggestions3);
     }
 
@@ -390,86 +388,86 @@ public class CommandSuggestionsTest {
          * [/partial bonjour ] - should show the literal following the argument (not suggested)
          */
         final String input = "partial";
-        final List<String> suggestions = manager.suggest(new TestCommandSender(), input);
+        final List<Suggestion> suggestions = manager.suggest(new TestCommandSender(), input);
         Assertions.assertEquals(Collections.emptyList(), suggestions);
         final String input2 = "partial ";
-        final List<String> suggestions2 = manager.suggest(new TestCommandSender(), input2);
-        Assertions.assertEquals(Arrays.asList("hi", "hey", "heya", "hai", "hello"), suggestions2);
+        final List<Suggestion> suggestions2 = manager.suggest(new TestCommandSender(), input2);
+        Assertions.assertEquals(suggestionList("hi", "hey", "heya", "hai", "hello"), suggestions2);
         final String input3 = "partial h";
-        final List<String> suggestions3 = manager.suggest(new TestCommandSender(), input3);
-        Assertions.assertEquals(Arrays.asList("hi", "hey", "heya", "hai", "hello"), suggestions3);
+        final List<Suggestion> suggestions3 = manager.suggest(new TestCommandSender(), input3);
+        Assertions.assertEquals(suggestionList("hi", "hey", "heya", "hai", "hello"), suggestions3);
         final String input4 = "partial he";
-        final List<String> suggestions4 = manager.suggest(new TestCommandSender(), input4);
-        Assertions.assertEquals(Arrays.asList("hey", "heya", "hello"), suggestions4);
+        final List<Suggestion> suggestions4 = manager.suggest(new TestCommandSender(), input4);
+        Assertions.assertEquals(suggestionList("hey", "heya", "hello"), suggestions4);
         final String input5 = "partial hey";
-        final List<String> suggestions5 = manager.suggest(new TestCommandSender(), input5);
-        Assertions.assertEquals(Arrays.asList("hey", "heya"), suggestions5);
+        final List<Suggestion> suggestions5 = manager.suggest(new TestCommandSender(), input5);
+        Assertions.assertEquals(suggestionList("hey", "heya"), suggestions5);
         final String input6 = "partial hi";
-        final List<String> suggestions6 = manager.suggest(new TestCommandSender(), input6);
-        Assertions.assertEquals(Collections.singletonList("hi"), suggestions6);
+        final List<Suggestion> suggestions6 = manager.suggest(new TestCommandSender(), input6);
+        Assertions.assertEquals(suggestionList("hi"), suggestions6);
         final String input7 = "partial b";
-        final List<String> suggestions7 = manager.suggest(new TestCommandSender(), input7);
+        final List<Suggestion> suggestions7 = manager.suggest(new TestCommandSender(), input7);
         Assertions.assertEquals(Collections.emptyList(), suggestions7);
         final String input8 = "partial hello ";
-        final List<String> suggestions8 = manager.suggest(new TestCommandSender(), input8);
-        Assertions.assertEquals(Collections.singletonList("literal"), suggestions8);
+        final List<Suggestion> suggestions8 = manager.suggest(new TestCommandSender(), input8);
+        Assertions.assertEquals(suggestionList("literal"), suggestions8);
         final String input9 = "partial bonjour ";
-        final List<String> suggestions9 = manager.suggest(new TestCommandSender(), input9);
-        Assertions.assertEquals(Collections.singletonList("literal"), suggestions9);
+        final List<Suggestion> suggestions9 = manager.suggest(new TestCommandSender(), input9);
+        Assertions.assertEquals(suggestionList("literal"), suggestions9);
     }
 
     @Test
     void testLiteralWithVariable() {
         final String input = "literal_with_variable ";
-        final List<String> suggestions = manager.suggest(new TestCommandSender(), input);
-        Assertions.assertEquals(Arrays.asList("vici", "veni", "vidi"), suggestions);
+        final List<Suggestion> suggestions = manager.suggest(new TestCommandSender(), input);
+        Assertions.assertEquals(suggestionList("vici", "veni", "vidi"), suggestions);
         final String input2 = "literal_with_variable v";
-        final List<String> suggestions2 = manager.suggest(new TestCommandSender(), input2);
-        Assertions.assertEquals(Arrays.asList("vici", "veni", "vidi"), suggestions2);
+        final List<Suggestion> suggestions2 = manager.suggest(new TestCommandSender(), input2);
+        Assertions.assertEquals(suggestionList("vici", "veni", "vidi"), suggestions2);
         final String input3 = "literal_with_variable vi";
-        final List<String> suggestions3 = manager.suggest(new TestCommandSender(), input3);
-        Assertions.assertEquals(Arrays.asList("vici", "vidi"), suggestions3);
+        final List<Suggestion> suggestions3 = manager.suggest(new TestCommandSender(), input3);
+        Assertions.assertEquals(suggestionList("vici", "vidi"), suggestions3);
         final String input4 = "literal_with_variable vidi";
-        final List<String> suggestions4 = manager.suggest(new TestCommandSender(), input4);
-        Assertions.assertEquals(Collections.singletonList("vidi"), suggestions4);
+        final List<Suggestion> suggestions4 = manager.suggest(new TestCommandSender(), input4);
+        Assertions.assertEquals(suggestionList("vidi"), suggestions4);
         final String input5 = "literal_with_variable vidi ";
-        final List<String> suggestions5 = manager.suggest(new TestCommandSender(), input5);
-        Assertions.assertEquals(Collections.singletonList("now"), suggestions5);
+        final List<Suggestion> suggestions5 = manager.suggest(new TestCommandSender(), input5);
+        Assertions.assertEquals(suggestionList("now"), suggestions5);
         final String input6 = "literal_with_variable vici ";
-        final List<String> suggestions6 = manager.suggest(new TestCommandSender(), input6);
-        Assertions.assertEquals(Collections.singletonList("later"), suggestions6);
+        final List<Suggestion> suggestions6 = manager.suggest(new TestCommandSender(), input6);
+        Assertions.assertEquals(suggestionList("later"), suggestions6);
     }
 
     @Test
     void testInvalidArgumentShouldNotCauseFurtherCompletion() {
         // pass preprocess
         final String input = "cmd_with_multiple_args 512 ";
-        final List<String> suggestions = manager.suggest(new TestCommandSender(), input);
-        Assertions.assertEquals(Arrays.asList("foo", "bar"), suggestions);
+        final List<Suggestion> suggestions = manager.suggest(new TestCommandSender(), input);
+        Assertions.assertEquals(suggestionList("foo", "bar"), suggestions);
         final String input2 = "cmd_with_multiple_args 512 BAR ";
-        final List<String> suggestions2 = manager.suggest(new TestCommandSender(), input2);
-        Assertions.assertEquals(Collections.singletonList("world"), suggestions2);
+        final List<Suggestion> suggestions2 = manager.suggest(new TestCommandSender(), input2);
+        Assertions.assertEquals(suggestionList("world"), suggestions2);
         final String input3 = "cmd_with_multiple_args test ";
-        final List<String> suggestions3 = manager.suggest(new TestCommandSender(), input3);
+        final List<Suggestion> suggestions3 = manager.suggest(new TestCommandSender(), input3);
         Assertions.assertEquals(Collections.emptyList(), suggestions3);
         final String input4 = "cmd_with_multiple_args 512 f";
-        final List<String> suggestions4 = manager.suggest(new TestCommandSender(), input4);
-        Assertions.assertEquals(Collections.singletonList("foo"), suggestions4);
+        final List<Suggestion> suggestions4 = manager.suggest(new TestCommandSender(), input4);
+        Assertions.assertEquals(suggestionList("foo"), suggestions4);
         final String input5 = "cmd_with_multiple_args world f";
-        final List<String> suggestions5 = manager.suggest(new TestCommandSender(), input5);
+        final List<Suggestion> suggestions5 = manager.suggest(new TestCommandSender(), input5);
         Assertions.assertEquals(Collections.emptyList(), suggestions5);
         // trigger preprocess fail
         final String input6 = "cmd_with_multiple_args 1024";
-        final List<String> suggestions6 = manager.suggest(new TestCommandSender(), input6);
+        final List<Suggestion> suggestions6 = manager.suggest(new TestCommandSender(), input6);
         Assertions.assertEquals(11, suggestions6.size());
         final String input7 = "cmd_with_multiple_args 1024 ";
-        final List<String> suggestions7 = manager.suggest(new TestCommandSender(), input7);
+        final List<Suggestion> suggestions7 = manager.suggest(new TestCommandSender(), input7);
         Assertions.assertEquals(Collections.emptyList(), suggestions7);
         final String input8 = "cmd_with_multiple_args 1024 f";
-        final List<String> suggestions8 = manager.suggest(new TestCommandSender(), input8);
+        final List<Suggestion> suggestions8 = manager.suggest(new TestCommandSender(), input8);
         Assertions.assertEquals(Collections.emptyList(), suggestions8);
         final String input9 = "cmd_with_multiple_args 1024 foo w";
-        final List<String> suggestions9 = manager.suggest(new TestCommandSender(), input9);
+        final List<Suggestion> suggestions9 = manager.suggest(new TestCommandSender(), input9);
         Assertions.assertEquals(Collections.emptyList(), suggestions9);
     }
 
@@ -482,26 +480,26 @@ public class CommandSuggestionsTest {
                         .required(
                                 StringArgument.<TestCommandSender>builder("string")
                                         .greedyFlagYielding()
-                                        .withSuggestionsProvider((context, input) -> Collections.singletonList("hello"))
+                                        .withSuggestionProvider((context, input) -> suggestionList("hello"))
                                         .build()
                         ).flag(manager.flagBuilder("flag").withAliases("f").build())
                         .flag(manager.flagBuilder("flag2").build())
         );
 
         // Act
-        final List<String> suggestions1 = suggest(manager, "command ");
-        final List<String> suggestions2 = suggest(manager, "command hel");
-        final List<String> suggestions3 = suggest(manager, "command hello --");
-        final List<String> suggestions4 = suggest(manager, "command hello --f");
-        final List<String> suggestions5 = suggest(manager, "command hello -f");
-        final List<String> suggestions6 = suggest(manager, "command hello -");
+        final List<Suggestion> suggestions1 = suggest(manager, "command ");
+        final List<Suggestion> suggestions2 = suggest(manager, "command hel");
+        final List<Suggestion> suggestions3 = suggest(manager, "command hello --");
+        final List<Suggestion> suggestions4 = suggest(manager, "command hello --f");
+        final List<Suggestion> suggestions5 = suggest(manager, "command hello -f");
+        final List<Suggestion> suggestions6 = suggest(manager, "command hello -");
 
         // Assert
-        assertThat(suggestions1).containsExactly("hello");
-        assertThat(suggestions2).containsExactly("hello");
-        assertThat(suggestions3).containsExactly("--flag", "--flag2");
-        assertThat(suggestions4).containsExactly("--flag", "--flag2");
-        assertThat(suggestions5).containsExactly("-f");
+        assertThat(suggestions1).containsExactlyElementsIn(suggestionList("hello"));
+        assertThat(suggestions2).containsExactlyElementsIn(suggestionList("hello"));
+        assertThat(suggestions3).containsExactlyElementsIn(suggestionList("--flag", "--flag2"));
+        assertThat(suggestions4).containsExactlyElementsIn(suggestionList("--flag", "--flag2"));
+        assertThat(suggestions5).containsExactlyElementsIn(suggestionList("-f"));
         assertThat(suggestions6).isEmpty();
     }
 
@@ -522,19 +520,19 @@ public class CommandSuggestionsTest {
         );
 
         // Act
-        final List<String> suggestions1 = suggest(manager, "command ");
-        final List<String> suggestions2 = suggest(manager, "command hello");
-        final List<String> suggestions3 = suggest(manager, "command hello --");
-        final List<String> suggestions4 = suggest(manager, "command hello --f");
-        final List<String> suggestions5 = suggest(manager, "command hello -f");
-        final List<String> suggestions6 = suggest(manager, "command hello -");
+        final List<Suggestion> suggestions1 = suggest(manager, "command ");
+        final List<Suggestion> suggestions2 = suggest(manager, "command hello");
+        final List<Suggestion> suggestions3 = suggest(manager, "command hello --");
+        final List<Suggestion> suggestions4 = suggest(manager, "command hello --f");
+        final List<Suggestion> suggestions5 = suggest(manager, "command hello -f");
+        final List<Suggestion> suggestions6 = suggest(manager, "command hello -");
 
         // Assert
         assertThat(suggestions1).isEmpty();
         assertThat(suggestions2).isEmpty();
-        assertThat(suggestions3).containsExactly("--flag", "--flag2");
-        assertThat(suggestions4).containsExactly("--flag", "--flag2");
-        assertThat(suggestions5).containsExactly("-f");
+        assertThat(suggestions3).containsExactlyElementsIn(suggestionList("--flag", "--flag2"));
+        assertThat(suggestions4).containsExactlyElementsIn(suggestionList("--flag", "--flag2"));
+        assertThat(suggestions5).containsExactlyElementsIn(suggestionList("-f"));
         assertThat(suggestions6).isEmpty();
     }
 
@@ -547,7 +545,7 @@ public class CommandSuggestionsTest {
                         .required(
                                 StringArgument.<TestCommandSender>builder("string")
                                         .greedy()
-                                        .withSuggestionsProvider((context, input) -> Collections.singletonList("hello world"))
+                                        .withSuggestionProvider((context, input) -> suggestionList("hello world"))
                                         .build())
         );
         manager.commandSuggestionProcessor(
@@ -555,19 +553,19 @@ public class CommandSuggestionsTest {
                         FilteringCommandSuggestionProcessor.Filter.<TestCommandSender>startsWith(true).andTrimBeforeLastSpace()));
 
         // Act
-        final List<String> suggestions1 = suggest(manager, "command ");
-        final List<String> suggestions2 = suggest(manager, "command hello");
-        final List<String> suggestions3 = suggest(manager, "command hello ");
-        final List<String> suggestions4 = suggest(manager, "command hello wo");
-        final List<String> suggestions5 = suggest(manager, "command hello world");
-        final List<String> suggestions6 = suggest(manager, "command hello world ");
+        final List<Suggestion> suggestions1 = suggest(manager, "command ");
+        final List<Suggestion> suggestions2 = suggest(manager, "command hello");
+        final List<Suggestion> suggestions3 = suggest(manager, "command hello ");
+        final List<Suggestion> suggestions4 = suggest(manager, "command hello wo");
+        final List<Suggestion> suggestions5 = suggest(manager, "command hello world");
+        final List<Suggestion> suggestions6 = suggest(manager, "command hello world ");
 
         // Assert
-        assertThat(suggestions1).containsExactly("hello world");
-        assertThat(suggestions2).containsExactly("hello world");
-        assertThat(suggestions3).containsExactly("world");
-        assertThat(suggestions4).containsExactly("world");
-        assertThat(suggestions5).containsExactly("world");
+        assertThat(suggestions1).containsExactlyElementsIn(suggestionList("hello world"));
+        assertThat(suggestions2).containsExactlyElementsIn(suggestionList("hello world"));
+        assertThat(suggestions3).containsExactlyElementsIn(suggestionList("world"));
+        assertThat(suggestions4).containsExactlyElementsIn(suggestionList("world"));
+        assertThat(suggestions5).containsExactlyElementsIn(suggestionList("world"));
         assertThat(suggestions6).isEmpty();
     }
 
@@ -581,26 +579,26 @@ public class CommandSuggestionsTest {
                         .required(
                                 StringArgument.<TestCommandSender>builder("string")
                                         .greedyFlagYielding()
-                                        .withSuggestionsProvider((context, input) -> Collections.singletonList("hello"))
+                                        .withSuggestionProvider((context, input) -> suggestionList("hello"))
                                         .build()
                         ).flag(manager.flagBuilder("flag").withAliases("f").build())
                         .flag(manager.flagBuilder("flag2").build())
         );
 
         // Act
-        final List<String> suggestions1 = suggest(manager, "command ");
-        final List<String> suggestions2 = suggest(manager, "command hel");
-        final List<String> suggestions3 = suggest(manager, "command hello --");
-        final List<String> suggestions4 = suggest(manager, "command hello --f");
-        final List<String> suggestions5 = suggest(manager, "command hello -f");
-        final List<String> suggestions6 = suggest(manager, "command hello -");
+        final List<Suggestion> suggestions1 = suggest(manager, "command ");
+        final List<Suggestion> suggestions2 = suggest(manager, "command hel");
+        final List<Suggestion> suggestions3 = suggest(manager, "command hello --");
+        final List<Suggestion> suggestions4 = suggest(manager, "command hello --f");
+        final List<Suggestion> suggestions5 = suggest(manager, "command hello -f");
+        final List<Suggestion> suggestions6 = suggest(manager, "command hello -");
 
         // Assert
-        assertThat(suggestions1).containsExactly("hello", "--flag", "--flag2", "-f");
-        assertThat(suggestions2).containsExactly("hello");
-        assertThat(suggestions3).containsExactly("--flag", "--flag2");
-        assertThat(suggestions4).containsExactly("--flag", "--flag2");
-        assertThat(suggestions5).containsExactly("-f");
+        assertThat(suggestions1).containsExactlyElementsIn(suggestionList("hello", "--flag", "--flag2", "-f"));
+        assertThat(suggestions2).containsExactlyElementsIn(suggestionList("hello"));
+        assertThat(suggestions3).containsExactlyElementsIn(suggestionList("--flag", "--flag2"));
+        assertThat(suggestions4).containsExactlyElementsIn(suggestionList("--flag", "--flag2"));
+        assertThat(suggestions5).containsExactlyElementsIn(suggestionList("-f"));
         assertThat(suggestions6).isEmpty();
     }
 
@@ -622,19 +620,19 @@ public class CommandSuggestionsTest {
         );
 
         // Act
-        final List<String> suggestions1 = suggest(manager, "command ");
-        final List<String> suggestions2 = suggest(manager, "command hello");
-        final List<String> suggestions3 = suggest(manager, "command hello --");
-        final List<String> suggestions4 = suggest(manager, "command hello --f");
-        final List<String> suggestions5 = suggest(manager, "command hello -f");
-        final List<String> suggestions6 = suggest(manager, "command hello -");
+        final List<Suggestion> suggestions1 = suggest(manager, "command ");
+        final List<Suggestion> suggestions2 = suggest(manager, "command hello");
+        final List<Suggestion> suggestions3 = suggest(manager, "command hello --");
+        final List<Suggestion> suggestions4 = suggest(manager, "command hello --f");
+        final List<Suggestion> suggestions5 = suggest(manager, "command hello -f");
+        final List<Suggestion> suggestions6 = suggest(manager, "command hello -");
 
         // Assert
-        assertThat(suggestions1).containsExactly("--flag", "--flag2", "-f");
+        assertThat(suggestions1).containsExactlyElementsIn(suggestionList("--flag", "--flag2", "-f"));
         assertThat(suggestions2).isEmpty();
-        assertThat(suggestions3).containsExactly("--flag", "--flag2");
-        assertThat(suggestions4).containsExactly("--flag", "--flag2");
-        assertThat(suggestions5).containsExactly("-f");
+        assertThat(suggestions3).containsExactlyElementsIn(suggestionList("--flag", "--flag2"));
+        assertThat(suggestions4).containsExactlyElementsIn(suggestionList("--flag", "--flag2"));
+        assertThat(suggestions5).containsExactlyElementsIn(suggestionList("-f"));
         assertThat(suggestions6).isEmpty();
     }
 
@@ -651,29 +649,29 @@ public class CommandSuggestionsTest {
         );
 
         // Act
-        final List<String> suggestions1 = suggest(manager, "command ");
-        final List<String> suggestions2 = suggest(manager, "command --");
-        final List<String> suggestions3 = suggest(manager, "command --f");
-        final List<String> suggestions4 = suggest(manager, "command --fla");
-        final List<String> suggestions5 = suggest(manager, "command -f");
-        final List<String> suggestions6 = suggest(manager, "command -");
+        final List<Suggestion> suggestions1 = suggest(manager, "command ");
+        final List<Suggestion> suggestions2 = suggest(manager, "command --");
+        final List<Suggestion> suggestions3 = suggest(manager, "command --f");
+        final List<Suggestion> suggestions4 = suggest(manager, "command --fla");
+        final List<Suggestion> suggestions5 = suggest(manager, "command -f");
+        final List<Suggestion> suggestions6 = suggest(manager, "command -");
 
-        final List<String> suggestions7 = suggest(manager, "command -f ");
-        final List<String> suggestions8 = suggest(manager, "command -f b");
+        final List<Suggestion> suggestions7 = suggest(manager, "command -f ");
+        final List<Suggestion> suggestions8 = suggest(manager, "command -f b");
 
         // Assert
-        assertThat(suggestions1).containsExactly("--flag", "--flog", "-f");
-        assertThat(suggestions2).containsExactly("--flag", "--flog");
-        assertThat(suggestions3).containsExactly("--flag", "--flog");
-        assertThat(suggestions4).containsExactly("--flag");
-        assertThat(suggestions5).containsExactly("-f");
-        assertThat(suggestions6).containsExactly("--flag", "--flog", "-f");
-        assertThat(suggestions7).containsExactly("foo", "bar");
-        assertThat(suggestions8).containsExactly("bar");
+        assertThat(suggestions1).containsExactlyElementsIn(suggestionList("--flag", "--flog", "-f"));
+        assertThat(suggestions2).containsExactlyElementsIn(suggestionList("--flag", "--flog"));
+        assertThat(suggestions3).containsExactlyElementsIn(suggestionList("--flag", "--flog"));
+        assertThat(suggestions4).containsExactlyElementsIn(suggestionList("--flag"));
+        assertThat(suggestions5).containsExactlyElementsIn(suggestionList("-f"));
+        assertThat(suggestions6).containsExactlyElementsIn(suggestionList("--flag", "--flog", "-f"));
+        assertThat(suggestions7).containsExactlyElementsIn(suggestionList("foo", "bar"));
+        assertThat(suggestions8).containsExactlyElementsIn(suggestionList("bar"));
     }
 
 
-    private List<String> suggest(CommandManager<TestCommandSender> manager, String command) {
+    private List<Suggestion> suggest(CommandManager<TestCommandSender> manager, String command) {
         return manager.suggest(new TestCommandSender(), command);
     }
 

--- a/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
@@ -29,6 +29,7 @@ import cloud.commandframework.arguments.standard.EnumArgument;
 import cloud.commandframework.arguments.standard.FloatArgument;
 import cloud.commandframework.arguments.standard.IntegerArgument;
 import cloud.commandframework.arguments.standard.StringArgument;
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.AmbiguousNodeException;
 import cloud.commandframework.exceptions.NoPermissionException;
@@ -161,13 +162,13 @@ class CommandTreeTest {
         );
 
         // Act
-        final List<String> results = this.commandManager.commandTree().getSuggestions(
+        final List<Suggestion> results = this.commandManager.commandTree().getSuggestions(
                 new CommandContext<>(new TestCommandSender(), this.commandManager),
                 new LinkedList<>(Arrays.asList("test", ""))
         );
 
         // Assert
-        assertThat(results).containsExactly("a", "b");
+        assertThat(results).containsExactly(Suggestion.simple("a"), Suggestion.simple("b"));
     }
 
     @Test

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/ArgumentTestHelper.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/ArgumentTestHelper.java
@@ -23,15 +23,24 @@
 //
 package cloud.commandframework.arguments.standard;
 
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import java.util.Arrays;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-final class ArgumentTestHelper {
+public final class ArgumentTestHelper {
 
     static @NonNull LinkedList<@NonNull String> linkedListOf(
             final @NonNull String... strings
     ) {
         return new LinkedList<>(Arrays.asList(strings));
+    }
+
+    public static @NonNull List<@NonNull Suggestion> suggestionList(
+            final @NonNull String... strings
+    ) {
+        return Arrays.stream(strings).map(Suggestion::simple).collect(Collectors.toList());
     }
 }

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/BooleanParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/BooleanParserTest.java
@@ -25,6 +25,7 @@ package cloud.commandframework.arguments.standard;
 
 import cloud.commandframework.TestCommandSender;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.context.CommandContext;
 import java.util.List;
 import java.util.Locale;
@@ -132,12 +133,12 @@ class BooleanParserTest {
 
     @ParameterizedTest
     @MethodSource("Suggestions_ExpectedSuggestions_Source")
-    void Suggestions_ExpectedSuggestions(final boolean liberal, final List<String> expectedSuggestions) {
+    void Suggestions_ExpectedSuggestions(final boolean liberal, final List<Suggestion> expectedSuggestions) {
         // Arrange
         final BooleanArgument.BooleanParser<TestCommandSender> parser = new BooleanArgument.BooleanParser<>(liberal);
 
         // Act
-        final List<String> suggestions = parser.suggestions(
+        final List<Suggestion> suggestions = parser.suggestions(
                 this.context,
                 ""
         );
@@ -148,8 +149,8 @@ class BooleanParserTest {
 
     static Stream<Arguments> Suggestions_ExpectedSuggestions_Source() {
         return Stream.of(
-                Arguments.arguments(false, ArgumentTestHelper.linkedListOf("true", "false")),
-                Arguments.arguments(true, ArgumentTestHelper.linkedListOf("true", "yes", "on", "false", "no", "off"))
+                Arguments.arguments(false, ArgumentTestHelper.suggestionList("true", "false")),
+                Arguments.arguments(true, ArgumentTestHelper.suggestionList("true", "yes", "on", "false", "no", "off"))
         );
     }
 }

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/ByteParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/ByteParserTest.java
@@ -25,6 +25,7 @@ package cloud.commandframework.arguments.standard;
 
 import cloud.commandframework.TestCommandSender;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.context.CommandContext;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -145,13 +146,13 @@ class ByteParserTest {
                 ByteArgument.ByteParser.DEFAULT_MAXIMUM
         );
 
-        final List<String> expectedSuggestions = new ArrayList<>();
+        final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Byte.toString((byte) i));
+            expectedSuggestions.add(Suggestion.simple(Byte.toString((byte) i)));
         }
 
         // Act
-        final List<String> suggestions = parser.suggestions(
+        final List<Suggestion> suggestions = parser.suggestions(
                 this.context,
                 ""
         );
@@ -168,13 +169,13 @@ class ByteParserTest {
                 ByteArgument.ByteParser.DEFAULT_MAXIMUM
         );
 
-        final List<String> expectedSuggestions = new ArrayList<>();
+        final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Byte.toString((byte) -i));
+            expectedSuggestions.add(Suggestion.simple(Byte.toString((byte) -i)));
         }
 
         // Act
-        final List<String> suggestions = parser.suggestions(
+        final List<Suggestion> suggestions = parser.suggestions(
                 this.context,
                 "-"
         );

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationArgumentSuggestionsTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationArgumentSuggestionsTest.java
@@ -25,6 +25,7 @@ package cloud.commandframework.arguments.standard;
 
 import cloud.commandframework.CommandManager;
 import cloud.commandframework.TestCommandSender;
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static cloud.commandframework.arguments.standard.ArgumentTestHelper.suggestionList;
 import static cloud.commandframework.util.TestUtils.createManager;
 
 public class DurationArgumentSuggestionsTest {
@@ -49,41 +51,41 @@ public class DurationArgumentSuggestionsTest {
     @Test
     void testDurationSuggestions() {
         final String input = "duration ";
-        final List<String> suggestions = manager.suggest(new TestCommandSender(), input);
-        Assertions.assertEquals(Arrays.asList("1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions);
+        final List<Suggestion> suggestions = manager.suggest(new TestCommandSender(), input);
+        Assertions.assertEquals(suggestionList("1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions);
 
         final String input2 = "duration 1";
-        final List<String> suggestions2 = manager.suggest(new TestCommandSender(), input2);
-        Assertions.assertEquals(Arrays.asList("1d", "1h", "1m", "1s"), suggestions2);
+        final List<Suggestion> suggestions2 = manager.suggest(new TestCommandSender(), input2);
+        Assertions.assertEquals(suggestionList("1d", "1h", "1m", "1s"), suggestions2);
 
         final String input3 = "duration 1d";
-        final List<String> suggestions3 = manager.suggest(new TestCommandSender(), input3);
+        final List<Suggestion> suggestions3 = manager.suggest(new TestCommandSender(), input3);
         Assertions.assertEquals(Collections.emptyList(), suggestions3);
 
         final String input4 = "duration 1d2";
-        final List<String> suggestions4 = manager.suggest(new TestCommandSender(), input4);
-        Assertions.assertTrue(suggestions4.containsAll(Arrays.asList("1d2h", "1d2m", "1d2s")));
-        Assertions.assertFalse(suggestions4.contains("1d2d"));
+        final List<Suggestion> suggestions4 = manager.suggest(new TestCommandSender(), input4);
+        Assertions.assertTrue(suggestions4.containsAll(suggestionList("1d2h", "1d2m", "1d2s")));
+        Assertions.assertFalse(suggestions4.contains(Suggestion.simple("1d2d")));
 
         final String input9 = "duration 1d22";
-        final List<String> suggestions9 = manager.suggest(new TestCommandSender(), input9);
-        Assertions.assertTrue(suggestions9.containsAll(Arrays.asList("1d22h", "1d22m", "1d22s")));
-        Assertions.assertFalse(suggestions9.contains("1d22d"));
+        final List<Suggestion> suggestions9 = manager.suggest(new TestCommandSender(), input9);
+        Assertions.assertTrue(suggestions9.containsAll(suggestionList("1d22h", "1d22m", "1d22s")));
+        Assertions.assertFalse(suggestions9.contains(Suggestion.simple("1d22d")));
 
         final String input5 = "duration d";
-        final List<String> suggestions5 = manager.suggest(new TestCommandSender(), input5);
+        final List<Suggestion> suggestions5 = manager.suggest(new TestCommandSender(), input5);
         Assertions.assertEquals(Collections.emptyList(), suggestions5);
 
         final String input6 = "duration 1d2d";
-        final List<String> suggestions6 = manager.suggest(new TestCommandSender(), input6);
+        final List<Suggestion> suggestions6 = manager.suggest(new TestCommandSender(), input6);
         Assertions.assertEquals(Collections.emptyList(), suggestions6);
 
         final String input7 = "duration 1d2h3m4s";
-        final List<String> suggestions7 = manager.suggest(new TestCommandSender(), input7);
+        final List<Suggestion> suggestions7 = manager.suggest(new TestCommandSender(), input7);
         Assertions.assertEquals(Collections.emptyList(), suggestions7);
 
         final String input8 = "duration dd";
-        final List<String> suggestions8 = manager.suggest(new TestCommandSender(), input8);
+        final List<Suggestion> suggestions8 = manager.suggest(new TestCommandSender(), input8);
         Assertions.assertEquals(Collections.emptyList(), suggestions8);
     }
 }

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/EnumParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/EnumParserTest.java
@@ -25,6 +25,7 @@ package cloud.commandframework.arguments.standard;
 
 import cloud.commandframework.TestCommandSender;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.context.CommandContext;
 import java.util.LinkedList;
 import java.util.List;
@@ -96,13 +97,13 @@ class EnumParserTest {
         );
 
         // Act
-        final List<String> suggestions = parser.suggestions(
+        final List<Suggestion> suggestions = parser.suggestions(
                 this.context,
                 ""
         );
 
         // Assert
-        assertThat(suggestions).containsExactly("aaa", "bbb", "ccc");
+        assertThat(suggestions).containsExactlyElementsIn(ArgumentTestHelper.suggestionList("aaa", "bbb", "ccc"));
     }
 
     enum TestEnum {

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/IntegerParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/IntegerParserTest.java
@@ -25,6 +25,7 @@ package cloud.commandframework.arguments.standard;
 
 import cloud.commandframework.TestCommandSender;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.context.CommandContext;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -145,13 +146,13 @@ class IntegerParserTest {
                 IntegerArgument.IntegerParser.DEFAULT_MAXIMUM
         );
 
-        final List<String> expectedSuggestions = new ArrayList<>();
+        final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Integer.toString(i));
+            expectedSuggestions.add(Suggestion.simple(Integer.toString(i)));
         }
 
         // Act
-        final List<String> suggestions = parser.suggestions(
+        final List<Suggestion> suggestions = parser.suggestions(
                 this.context,
                 ""
         );
@@ -168,13 +169,13 @@ class IntegerParserTest {
                 IntegerArgument.IntegerParser.DEFAULT_MAXIMUM
         );
 
-        final List<String> expectedSuggestions = new ArrayList<>();
+        final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Integer.toString(-i));
+            expectedSuggestions.add(Suggestion.simple(Integer.toString(-i)));
         }
 
         // Act
-        final List<String> suggestions = parser.suggestions(
+        final List<Suggestion> suggestions = parser.suggestions(
                 this.context,
                 "-"
         );

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/LongParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/LongParserTest.java
@@ -25,6 +25,7 @@ package cloud.commandframework.arguments.standard;
 
 import cloud.commandframework.TestCommandSender;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.context.CommandContext;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -145,13 +146,13 @@ class LongParserTest {
                 LongArgument.LongParser.DEFAULT_MAXIMUM
         );
 
-        final List<String> expectedSuggestions = new ArrayList<>();
+        final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Long.toString((long) i));
+            expectedSuggestions.add(Suggestion.simple(Long.toString((long) i)));
         }
 
         // Act
-        final List<String> suggestions = parser.suggestions(
+        final List<Suggestion> suggestions = parser.suggestions(
                 this.context,
                 ""
         );
@@ -168,13 +169,13 @@ class LongParserTest {
                 LongArgument.LongParser.DEFAULT_MAXIMUM
         );
 
-        final List<String> expectedSuggestions = new ArrayList<>();
+        final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Long.toString((long) -i));
+            expectedSuggestions.add(Suggestion.simple(Long.toString((long) -i)));
         }
 
         // Act
-        final List<String> suggestions = parser.suggestions(
+        final List<Suggestion> suggestions = parser.suggestions(
                 this.context,
                 "-"
         );

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/ShortParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/ShortParserTest.java
@@ -25,6 +25,7 @@ package cloud.commandframework.arguments.standard;
 
 import cloud.commandframework.TestCommandSender;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.context.CommandContext;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -145,13 +146,13 @@ class ShortParserTest {
                 ShortArgument.ShortParser.DEFAULT_MAXIMUM
         );
 
-        final List<String> expectedSuggestions = new ArrayList<>();
+        final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Short.toString((short) i));
+            expectedSuggestions.add(Suggestion.simple(Short.toString((short) i)));
         }
 
         // Act
-        final List<String> suggestions = parser.suggestions(
+        final List<Suggestion> suggestions = parser.suggestions(
                 this.context,
                 ""
         );
@@ -168,13 +169,13 @@ class ShortParserTest {
                 ShortArgument.ShortParser.DEFAULT_MAXIMUM
         );
 
-        final List<String> expectedSuggestions = new ArrayList<>();
+        final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Short.toString((short) -i));
+            expectedSuggestions.add(Suggestion.simple(Short.toString((short) -i)));
         }
 
         // Act
-        final List<String> suggestions = parser.suggestions(
+        final List<Suggestion> suggestions = parser.suggestions(
                 this.context,
                 "-"
         );

--- a/cloud-core/src/test/java/cloud/commandframework/feature/RepeatableFlagTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/feature/RepeatableFlagTest.java
@@ -26,6 +26,7 @@ package cloud.commandframework.feature;
 import cloud.commandframework.CommandManager;
 import cloud.commandframework.TestCommandSender;
 import cloud.commandframework.arguments.standard.StringArgument;
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.execution.CommandResult;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -100,12 +101,12 @@ class RepeatableFlagTest {
         );
 
         // Act
-        final List<String> suggestions = this.commandManager.suggest(
+        final List<Suggestion> suggestions = this.commandManager.suggest(
                 new TestCommandSender(),
                 "test --flag --"
         );
 
         // Assert
-        assertThat(suggestions).containsExactly("--flag");
+        assertThat(suggestions).containsExactly(Suggestion.simple("--flag"));
     }
 }

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/ChannelArgument.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/ChannelArgument.java
@@ -27,13 +27,13 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
-import java.util.function.BiFunction;
 import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
@@ -54,8 +54,7 @@ public final class ChannelArgument<C> extends CommandArgument<C, MessageChannel>
 
     private ChannelArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<@NonNull CommandContext<C>,
-                    @NonNull String, @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final @NonNull Set<ParserMode> modes
     ) {
@@ -63,7 +62,7 @@ public final class ChannelArgument<C> extends CommandArgument<C, MessageChannel>
                 name,
                 new MessageParser<>(modes),
                 MessageChannel.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
         this.modes = modes;
@@ -152,7 +151,7 @@ public final class ChannelArgument<C> extends CommandArgument<C, MessageChannel>
         public @NonNull ChannelArgument<C> build() {
             return new ChannelArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription(),
                     this.modes
             );

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/RoleArgument.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/RoleArgument.java
@@ -27,13 +27,13 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
-import java.util.function.BiFunction;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import org.apiguardian.api.API;
@@ -53,12 +53,11 @@ public final class RoleArgument<C> extends CommandArgument<C, Role> {
 
     private RoleArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<@NonNull CommandContext<C>,
-                    @NonNull String, @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final @NonNull Set<ParserMode> modes
     ) {
-        super(name, new RoleParser<>(modes), Role.class, suggestionsProvider, defaultDescription);
+        super(name, new RoleParser<>(modes), Role.class, suggestionProvider, defaultDescription);
         this.modes = modes;
     }
 
@@ -145,7 +144,7 @@ public final class RoleArgument<C> extends CommandArgument<C, Role> {
         public @NonNull RoleArgument<C> build() {
             return new RoleArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription(),
                     this.modes
             );

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/UserArgument.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/UserArgument.java
@@ -27,6 +27,7 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import java.util.Collections;
@@ -34,7 +35,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.User;
@@ -58,8 +58,7 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
 
     private UserArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<@NonNull CommandContext<C>,
-                    @NonNull String, @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final @NonNull Set<ParserMode> modes,
             final @NonNull Isolation isolationLevel
@@ -68,7 +67,7 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
                 name,
                 new UserParser<>(modes, isolationLevel),
                 User.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
         this.modes = modes;
@@ -186,7 +185,7 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
         public @NonNull UserArgument<C> build() {
             return new UserArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription(),
                     this.modes,
                     this.isolationLevel

--- a/cloud-irc/cloud-pircbotx/src/main/java/cloud/commandframework/pircbotx/arguments/UserArgument.java
+++ b/cloud-irc/cloud-pircbotx/src/main/java/cloud/commandframework/pircbotx/arguments/UserArgument.java
@@ -27,15 +27,14 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.captions.CaptionVariable;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import cloud.commandframework.exceptions.parsing.ParserException;
 import cloud.commandframework.pircbotx.PircBotXCommandManager;
 import io.leangen.geantyref.TypeToken;
-import java.util.List;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -53,15 +52,14 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
 
     private UserArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<@NonNull CommandContext<C>,
-                    @NonNull String, @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 new UserArgumentParser<>(),
                 TypeToken.get(User.class),
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -120,7 +118,7 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
         public @NonNull CommandArgument<@NonNull C, @NonNull User> build() {
             return new UserArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/BrigadierMappingBuilder.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/BrigadierMappingBuilder.java
@@ -84,7 +84,7 @@ public interface BrigadierMappingBuilder<K extends ArgumentParser<?, ?>, S> {
     /**
      * Use a custom Brigadier suggestion provider for this parser.
      *
-     * @param provider the suggestions provider
+     * @param provider the suggestion provider
      * @return this builder
      * @since 1.5.0
      */
@@ -96,7 +96,7 @@ public interface BrigadierMappingBuilder<K extends ArgumentParser<?, ?>, S> {
     /**
      * Use a custom Brigadier suggestion provider for this parser.
      *
-     * @param provider the suggestions provider
+     * @param provider the suggestion provider
      * @return this builder
      * @since 1.5.0
      */

--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/argument/WrappedBrigadierParser.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/argument/WrappedBrigadierParser.java
@@ -170,7 +170,7 @@ public final class WrappedBrigadierParser<C, T> implements ArgumentParser<C, T> 
     }
 
     @Override
-    public @NonNull List<@NonNull String> suggestions(
+    public @NonNull List<@NonNull String> stringSuggestions(
             final @NonNull CommandContext<C> commandContext,
             final @NonNull String input
     ) {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommand.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommand.java
@@ -26,6 +26,7 @@ package cloud.commandframework.bukkit;
 import cloud.commandframework.Command;
 import cloud.commandframework.CommandTree;
 import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.exceptions.ArgumentParseException;
 import cloud.commandframework.exceptions.CommandExecutionException;
 import cloud.commandframework.exceptions.InvalidCommandSenderException;
@@ -40,6 +41,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletionException;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 import org.apiguardian.api.API;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -86,7 +88,7 @@ final class BukkitCommand<C> extends org.bukkit.command.Command implements Plugi
     }
 
     @Override
-    public @NonNull List<String> tabComplete(
+    public @NonNull List<@NonNull String> tabComplete(
             final @NonNull CommandSender sender,
             final @NonNull String alias,
             final @NonNull String @NonNull [] args
@@ -98,7 +100,7 @@ final class BukkitCommand<C> extends org.bukkit.command.Command implements Plugi
         return this.manager.suggest(
                 this.manager.getCommandSenderMapper().apply(sender),
                 builder.toString()
-        );
+        ).stream().map(Suggestion::suggestion).collect(Collectors.toList());
     }
 
     @Override

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/argument/NamespacedKeyArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/argument/NamespacedKeyArgument.java
@@ -27,6 +27,7 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.bukkit.BukkitCaptionKeys;
 import cloud.commandframework.bukkit.BukkitCommandManager;
 import cloud.commandframework.bukkit.BukkitParserParameters;
@@ -39,7 +40,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import org.bukkit.NamespacedKey;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -54,8 +54,7 @@ public final class NamespacedKeyArgument<C> extends CommandArgument<C, Namespace
 
     private NamespacedKeyArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
-                    @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final boolean requireExplicitNamespace,
             final String defaultNamespace
@@ -64,7 +63,7 @@ public final class NamespacedKeyArgument<C> extends CommandArgument<C, Namespace
                 name,
                 new Parser<>(requireExplicitNamespace, defaultNamespace),
                 NamespacedKey.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -147,7 +146,7 @@ public final class NamespacedKeyArgument<C> extends CommandArgument<C, Namespace
         public @NonNull NamespacedKeyArgument<C> build() {
             return new NamespacedKeyArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription(),
                     this.requireExplicitNamespace,
                     this.defaultNamespace
@@ -228,7 +227,7 @@ public final class NamespacedKeyArgument<C> extends CommandArgument<C, Namespace
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/BlockPredicateArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/BlockPredicateArgument.java
@@ -27,6 +27,8 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.brigadier.argument.WrappedBrigadierParser;
 import cloud.commandframework.bukkit.BukkitCommandManager;
 import cloud.commandframework.bukkit.data.BlockPredicate;
@@ -42,7 +44,6 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
@@ -64,11 +65,10 @@ public final class BlockPredicateArgument<C> extends CommandArgument<C, BlockPre
 
     private BlockPredicateArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
-                    @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(name, new Parser<>(), BlockPredicate.class, suggestionsProvider, defaultDescription);
+        super(name, new Parser<>(), BlockPredicate.class, suggestionProvider, defaultDescription);
     }
 
     /**
@@ -112,7 +112,7 @@ public final class BlockPredicateArgument<C> extends CommandArgument<C, BlockPre
         public @NonNull BlockPredicateArgument<C> build() {
             return new BlockPredicateArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }
@@ -261,7 +261,7 @@ public final class BlockPredicateArgument<C> extends CommandArgument<C, BlockPre
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull Suggestion> suggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/EnchantmentArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/EnchantmentArgument.java
@@ -27,6 +27,7 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.bukkit.BukkitCaptionKeys;
 import cloud.commandframework.captions.CaptionVariable;
 import cloud.commandframework.context.CommandContext;
@@ -35,7 +36,6 @@ import cloud.commandframework.exceptions.parsing.ParserException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import org.apiguardian.api.API;
 import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
@@ -51,15 +51,14 @@ public class EnchantmentArgument<C> extends CommandArgument<C, Enchantment> {
 
     protected EnchantmentArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
-                    @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 new EnchantmentParser<>(),
                 Enchantment.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -113,7 +112,7 @@ public class EnchantmentArgument<C> extends CommandArgument<C, Enchantment> {
         public @NonNull CommandArgument<C, Enchantment> build() {
             return new EnchantmentArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }
@@ -156,7 +155,7 @@ public class EnchantmentArgument<C> extends CommandArgument<C, Enchantment> {
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/ItemStackArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/ItemStackArgument.java
@@ -27,6 +27,8 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.brigadier.argument.WrappedBrigadierParser;
 import cloud.commandframework.bukkit.BukkitCommandManager;
 import cloud.commandframework.bukkit.data.ProtoItemStack;
@@ -44,7 +46,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -68,11 +69,10 @@ public final class ItemStackArgument<C> extends CommandArgument<C, ProtoItemStac
 
     private ItemStackArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
-                    @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(name, new Parser<>(), ProtoItemStack.class, suggestionsProvider, defaultDescription);
+        super(name, new Parser<>(), ProtoItemStack.class, suggestionProvider, defaultDescription);
     }
 
     /**
@@ -116,7 +116,7 @@ public final class ItemStackArgument<C> extends CommandArgument<C, ProtoItemStac
         public @NonNull ItemStackArgument<C> build() {
             return new ItemStackArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }
@@ -154,7 +154,7 @@ public final class ItemStackArgument<C> extends CommandArgument<C, ProtoItemStac
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull Suggestion> suggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {
@@ -255,7 +255,7 @@ public final class ItemStackArgument<C> extends CommandArgument<C, ProtoItemStac
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull Suggestion> suggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {
@@ -331,7 +331,7 @@ public final class ItemStackArgument<C> extends CommandArgument<C, ProtoItemStac
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/ItemStackPredicateArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/ItemStackPredicateArgument.java
@@ -27,6 +27,8 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.brigadier.argument.WrappedBrigadierParser;
 import cloud.commandframework.bukkit.BukkitCommandManager;
 import cloud.commandframework.bukkit.data.ItemStackPredicate;
@@ -43,7 +45,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
@@ -65,11 +66,10 @@ public final class ItemStackPredicateArgument<C> extends CommandArgument<C, Item
 
     private ItemStackPredicateArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
-                    @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(name, new Parser<>(), ItemStackPredicate.class, suggestionsProvider, defaultDescription);
+        super(name, new Parser<>(), ItemStackPredicate.class, suggestionProvider, defaultDescription);
     }
 
     /**
@@ -113,7 +113,7 @@ public final class ItemStackPredicateArgument<C> extends CommandArgument<C, Item
         public @NonNull ItemStackPredicateArgument<C> build() {
             return new ItemStackPredicateArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }
@@ -222,7 +222,7 @@ public final class ItemStackPredicateArgument<C> extends CommandArgument<C, Item
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull Suggestion> suggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/MaterialArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/MaterialArgument.java
@@ -27,6 +27,7 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.bukkit.BukkitCaptionKeys;
 import cloud.commandframework.captions.CaptionVariable;
 import cloud.commandframework.context.CommandContext;
@@ -35,7 +36,6 @@ import cloud.commandframework.exceptions.parsing.ParserException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import org.apiguardian.api.API;
 import org.bukkit.Material;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -50,11 +50,10 @@ public class MaterialArgument<C> extends CommandArgument<C, Material> {
 
     protected MaterialArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
-                    @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(name, new MaterialParser<>(), Material.class, suggestionsProvider, defaultDescription);
+        super(name, new MaterialParser<>(), Material.class, suggestionProvider, defaultDescription);
     }
 
     /**
@@ -106,7 +105,7 @@ public class MaterialArgument<C> extends CommandArgument<C, Material> {
         public @NonNull CommandArgument<C, Material> build() {
             return new MaterialArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }
@@ -137,7 +136,7 @@ public class MaterialArgument<C> extends CommandArgument<C, Material> {
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/OfflinePlayerArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/OfflinePlayerArgument.java
@@ -27,6 +27,7 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.bukkit.BukkitCaptionKeys;
 import cloud.commandframework.bukkit.BukkitCommandContextKeys;
 import cloud.commandframework.captions.CaptionVariable;
@@ -36,7 +37,6 @@ import cloud.commandframework.exceptions.parsing.ParserException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import org.apiguardian.api.API;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
@@ -58,15 +58,14 @@ public final class OfflinePlayerArgument<C> extends CommandArgument<C, OfflinePl
 
     private OfflinePlayerArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
-                    @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 new OfflinePlayerParser<>(),
                 OfflinePlayer.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -123,7 +122,7 @@ public final class OfflinePlayerArgument<C> extends CommandArgument<C, OfflinePl
          */
         @Override
         public @NonNull OfflinePlayerArgument<C> build() {
-            return new OfflinePlayerArgument<>(this.getName(), this.getSuggestionsProvider(), this.getDefaultDescription());
+            return new OfflinePlayerArgument<>(this.getName(), this.suggestionProvider(), this.getDefaultDescription());
         }
     }
 
@@ -155,7 +154,7 @@ public final class OfflinePlayerArgument<C> extends CommandArgument<C, OfflinePl
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/PlayerArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/PlayerArgument.java
@@ -27,6 +27,7 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.bukkit.BukkitCaptionKeys;
 import cloud.commandframework.bukkit.BukkitCommandContextKeys;
 import cloud.commandframework.captions.CaptionVariable;
@@ -36,7 +37,6 @@ import cloud.commandframework.exceptions.parsing.ParserException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import org.apiguardian.api.API;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
@@ -54,11 +54,10 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
 
     private PlayerArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
-                    @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(name, new PlayerParser<>(), Player.class, suggestionsProvider, defaultDescription);
+        super(name, new PlayerParser<>(), Player.class, suggestionProvider, defaultDescription);
     }
 
     /**
@@ -115,7 +114,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
         public @NonNull PlayerArgument<C> build() {
             return new PlayerArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }
@@ -149,7 +148,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/WorldArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/WorldArgument.java
@@ -27,6 +27,7 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.bukkit.BukkitCaptionKeys;
 import cloud.commandframework.captions.CaptionVariable;
 import cloud.commandframework.context.CommandContext;
@@ -34,7 +35,6 @@ import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import cloud.commandframework.exceptions.parsing.ParserException;
 import java.util.List;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import org.apiguardian.api.API;
 import org.bukkit.Bukkit;
@@ -51,10 +51,10 @@ public class WorldArgument<C> extends CommandArgument<C, World> {
 
     protected WorldArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(name, new WorldParser<>(), World.class, suggestionsProvider, defaultDescription);
+        super(name, new WorldParser<>(), World.class, suggestionProvider, defaultDescription);
     }
 
     /**
@@ -106,7 +106,7 @@ public class WorldArgument<C> extends CommandArgument<C, World> {
         public @NonNull CommandArgument<C, World> build() {
             return new WorldArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }
@@ -138,7 +138,10 @@ public class WorldArgument<C> extends CommandArgument<C, World> {
         }
 
         @Override
-        public @NonNull List<String> suggestions(final @NonNull CommandContext<C> commandContext, final @NonNull String input) {
+        public @NonNull List<@NonNull String> stringSuggestions(
+                final @NonNull CommandContext<C> commandContext,
+                final @NonNull String input
+        ) {
             return Bukkit.getWorlds().stream().map(World::getName).collect(Collectors.toList());
         }
     }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/Location2DArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/Location2DArgument.java
@@ -27,6 +27,7 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.bukkit.BukkitCommandContextKeys;
 import cloud.commandframework.bukkit.parsers.location.LocationArgument.LocationParseException;
 import cloud.commandframework.context.CommandContext;
@@ -58,7 +59,7 @@ public final class Location2DArgument<C> extends CommandArgument<C, Location2D> 
     private Location2DArgument(
             final @NonNull String name,
             final @NonNull ArgumentDescription defaultDescription,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>,
                     @NonNull Queue<@NonNull String>, @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
     ) {
@@ -66,7 +67,7 @@ public final class Location2DArgument<C> extends CommandArgument<C, Location2D> 
                 name,
                 new Location2DParser<>(),
                 TypeToken.get(Location2D.class),
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription,
                 argumentPreprocessors
         );
@@ -129,7 +130,7 @@ public final class Location2DArgument<C> extends CommandArgument<C, Location2D> 
             return new Location2DArgument<>(
                     this.getName(),
                     this.getDefaultDescription(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     new LinkedList<>()
             );
         }
@@ -226,7 +227,7 @@ public final class Location2DArgument<C> extends CommandArgument<C, Location2D> 
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/LocationArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/LocationArgument.java
@@ -28,6 +28,7 @@ import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
 import cloud.commandframework.arguments.standard.IntegerArgument;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.bukkit.BukkitCaptionKeys;
 import cloud.commandframework.bukkit.BukkitCommandContextKeys;
 import cloud.commandframework.captions.Caption;
@@ -62,7 +63,7 @@ public final class LocationArgument<C> extends CommandArgument<C, Location> {
 
     private LocationArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>,
                     @NonNull Queue<@NonNull String>, @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
@@ -71,7 +72,7 @@ public final class LocationArgument<C> extends CommandArgument<C, Location> {
                 name,
                 new LocationParser<>(),
                 TypeToken.get(Location.class),
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription,
                 argumentPreprocessors
         );
@@ -133,7 +134,7 @@ public final class LocationArgument<C> extends CommandArgument<C, Location> {
         public @NonNull CommandArgument<@NonNull C, @NonNull Location> build() {
             return new LocationArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription(),
                     new LinkedList<>()
             );
@@ -263,7 +264,7 @@ public final class LocationArgument<C> extends CommandArgument<C, Location> {
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultipleEntitySelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultipleEntitySelectorArgument.java
@@ -25,10 +25,9 @@ package cloud.commandframework.bukkit.parsers.selector;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.bukkit.arguments.selector.MultipleEntitySelector;
-import cloud.commandframework.context.CommandContext;
 import java.util.List;
-import java.util.function.BiFunction;
 import org.apiguardian.api.API;
 import org.bukkit.entity.Entity;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -47,12 +46,11 @@ public final class MultipleEntitySelectorArgument<C> extends CommandArgument<C, 
     private MultipleEntitySelectorArgument(
             final boolean allowEmpty,
             final @NonNull String name,
-            final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
-                    @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(name, new MultipleEntitySelectorParser<>(allowEmpty),
-                MultipleEntitySelector.class, suggestionsProvider, defaultDescription
+                MultipleEntitySelector.class, suggestionProvider, defaultDescription
         );
     }
 
@@ -126,7 +124,7 @@ public final class MultipleEntitySelectorArgument<C> extends CommandArgument<C, 
             return new MultipleEntitySelectorArgument<>(
                     this.allowEmpty,
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultiplePlayerSelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultiplePlayerSelectorArgument.java
@@ -26,6 +26,7 @@ package cloud.commandframework.bukkit.parsers.selector;
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.bukkit.arguments.selector.MultiplePlayerSelector;
 import cloud.commandframework.bukkit.parsers.PlayerArgument;
 import cloud.commandframework.context.CommandContext;
@@ -33,7 +34,6 @@ import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import org.apiguardian.api.API;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -53,12 +53,11 @@ public final class MultiplePlayerSelectorArgument<C> extends CommandArgument<C, 
     private MultiplePlayerSelectorArgument(
             final boolean allowEmpty,
             final @NonNull String name,
-            final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
-                    @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(name, new MultiplePlayerSelectorParser<>(allowEmpty), MultiplePlayerSelector.class,
-                suggestionsProvider, defaultDescription
+                suggestionProvider, defaultDescription
         );
     }
 
@@ -132,7 +131,7 @@ public final class MultiplePlayerSelectorArgument<C> extends CommandArgument<C, 
             return new MultiplePlayerSelectorArgument<>(
                     this.allowEmpty,
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SelectorUtils.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SelectorUtils.java
@@ -25,6 +25,7 @@ package cloud.commandframework.bukkit.parsers.selector;
 
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.brigadier.argument.WrappedBrigadierParser;
 import cloud.commandframework.bukkit.BukkitCommandContextKeys;
 import cloud.commandframework.bukkit.internal.CraftBukkitReflection;
@@ -175,7 +176,7 @@ final class SelectorUtils {
             ));
         }
 
-        protected List<String> legacySuggestions(
+        protected @NonNull List<@NonNull Suggestion> legacySuggestions(
                 final CommandContext<C> commandContext,
                 final String input
         ) {
@@ -194,9 +195,9 @@ final class SelectorUtils {
         }
 
         @Override
-        public List<String> suggestions(
-                final CommandContext<C> commandContext,
-                final String input
+        public List<@NonNull Suggestion> suggestions(
+                final @NonNull CommandContext<C> commandContext,
+                final @NonNull String input
         ) {
             if (this.modernParser != null) {
                 return this.modernParser.suggestions(commandContext, input);
@@ -245,18 +246,18 @@ final class SelectorUtils {
         }
 
         @Override
-        protected List<String> legacySuggestions(
+        protected @NonNull List<@NonNull Suggestion> legacySuggestions(
                 final CommandContext<C> commandContext,
                 final String input
         ) {
-            final List<String> suggestions = new ArrayList<>();
+            final List<Suggestion> suggestions = new ArrayList<>();
 
             for (final Player player : Bukkit.getOnlinePlayers()) {
                 final CommandSender bukkit = commandContext.get(BukkitCommandContextKeys.BUKKIT_COMMAND_SENDER);
                 if (bukkit instanceof Player && !((Player) bukkit).canSee(player)) {
                     continue;
                 }
-                suggestions.add(player.getName());
+                suggestions.add(Suggestion.simple(player.getName()));
             }
 
             return suggestions;
@@ -306,9 +307,9 @@ final class SelectorUtils {
         }
 
         @Override
-        public List<String> suggestions(
-                final CommandContext<C> commandContext,
-                final String input
+        public List<@NonNull Suggestion> suggestions(
+                final @NonNull CommandContext<C> commandContext,
+                final @NonNull String input
         ) {
             final Object commandSourceStack = commandContext.get(WrappedBrigadierParser.COMMAND_CONTEXT_BRIGADIER_NATIVE_SENDER);
             final @Nullable Field bypassField =

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SingleEntitySelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SingleEntitySelectorArgument.java
@@ -25,11 +25,9 @@ package cloud.commandframework.bukkit.parsers.selector;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.bukkit.arguments.selector.SingleEntitySelector;
-import cloud.commandframework.context.CommandContext;
 import java.util.Collections;
-import java.util.List;
-import java.util.function.BiFunction;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -46,15 +44,14 @@ public final class SingleEntitySelectorArgument<C> extends CommandArgument<C, Si
 
     private SingleEntitySelectorArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
-                    @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 new SingleEntitySelectorParser<>(),
                 SingleEntitySelector.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -113,7 +110,7 @@ public final class SingleEntitySelectorArgument<C> extends CommandArgument<C, Si
         public @NonNull SingleEntitySelectorArgument<C> build() {
             return new SingleEntitySelectorArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SinglePlayerSelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SinglePlayerSelectorArgument.java
@@ -26,14 +26,13 @@ package cloud.commandframework.bukkit.parsers.selector;
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.bukkit.arguments.selector.SinglePlayerSelector;
 import cloud.commandframework.bukkit.parsers.PlayerArgument;
 import cloud.commandframework.context.CommandContext;
 import com.google.common.collect.ImmutableList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import org.apiguardian.api.API;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -52,15 +51,14 @@ public final class SinglePlayerSelectorArgument<C> extends CommandArgument<C, Si
 
     private SinglePlayerSelectorArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<@NonNull CommandContext<C>, @NonNull String,
-                    @NonNull List<@NonNull String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 new SinglePlayerSelectorParser<>(),
                 SinglePlayerSelector.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -119,7 +117,7 @@ public final class SinglePlayerSelectorArgument<C> extends CommandArgument<C, Si
         public @NonNull SinglePlayerSelectorArgument<C> build() {
             return new SinglePlayerSelectorArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/BungeeCommand.java
+++ b/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/BungeeCommand.java
@@ -25,6 +25,7 @@ package cloud.commandframework.bungee;
 
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.StaticArgument;
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.exceptions.ArgumentParseException;
 import cloud.commandframework.exceptions.CommandExecutionException;
 import cloud.commandframework.exceptions.InvalidCommandSenderException;
@@ -33,6 +34,7 @@ import cloud.commandframework.exceptions.NoPermissionException;
 import cloud.commandframework.exceptions.NoSuchCommandException;
 import java.util.concurrent.CompletionException;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.chat.ComponentBuilder;
@@ -178,6 +180,6 @@ public final class BungeeCommand<C> extends Command implements TabExecutor {
         return this.manager.suggest(
                 this.manager.getCommandSenderMapper().apply(sender),
                 builder.toString()
-        );
+        ).stream().map(Suggestion::suggestion).collect(Collectors.toList());
     }
 }

--- a/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/PlayerArgument.java
+++ b/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/PlayerArgument.java
@@ -27,6 +27,7 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.bungee.BungeeCaptionKeys;
 import cloud.commandframework.captions.CaptionVariable;
 import cloud.commandframework.context.CommandContext;
@@ -55,7 +56,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, ProxiedPlayer> {
 
     private PlayerArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>, @NonNull Queue<@NonNull String>,
                     @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
@@ -123,7 +124,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, ProxiedPlayer> {
         public @NonNull CommandArgument<@NonNull C, @NonNull ProxiedPlayer> build() {
             return new PlayerArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription(),
                     new LinkedList<>()
             );
@@ -159,7 +160,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, ProxiedPlayer> {
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/ServerArgument.java
+++ b/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/ServerArgument.java
@@ -27,6 +27,7 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.bungee.BungeeCaptionKeys;
 import cloud.commandframework.captions.CaptionVariable;
 import cloud.commandframework.context.CommandContext;
@@ -55,7 +56,7 @@ public final class ServerArgument<C> extends CommandArgument<C, ServerInfo> {
 
     private ServerArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>, @NonNull Queue<@NonNull String>,
                     @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
@@ -64,7 +65,7 @@ public final class ServerArgument<C> extends CommandArgument<C, ServerInfo> {
                 name,
                 new ServerParser<>(),
                 TypeToken.get(ServerInfo.class),
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription,
                 argumentPreprocessors
         );
@@ -123,7 +124,7 @@ public final class ServerArgument<C> extends CommandArgument<C, ServerInfo> {
         public @NonNull CommandArgument<@NonNull C, @NonNull ServerInfo> build() {
             return new ServerArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription(),
                     new LinkedList<>()
             );
@@ -158,7 +159,7 @@ public final class ServerArgument<C> extends CommandArgument<C, ServerInfo> {
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/AngleArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/AngleArgument.java
@@ -25,10 +25,8 @@ package cloud.commandframework.fabric.argument;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.brigadier.argument.WrappedBrigadierParser;
-import cloud.commandframework.context.CommandContext;
-import java.util.List;
-import java.util.function.BiFunction;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -42,14 +40,14 @@ public final class AngleArgument<C> extends CommandArgument<C, net.minecraft.com
 
     AngleArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 new WrappedBrigadierParser<>(net.minecraft.commands.arguments.AngleArgument.angle()),
                 net.minecraft.commands.arguments.AngleArgument.SingleAngle.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -102,7 +100,7 @@ public final class AngleArgument<C> extends CommandArgument<C, net.minecraft.com
         public @NonNull AngleArgument<C> build() {
             return new AngleArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/AxisArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/AxisArgument.java
@@ -25,12 +25,10 @@ package cloud.commandframework.fabric.argument;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.brigadier.argument.WrappedBrigadierParser;
-import cloud.commandframework.context.CommandContext;
 import io.leangen.geantyref.TypeToken;
 import java.util.EnumSet;
-import java.util.List;
-import java.util.function.BiFunction;
 import net.minecraft.commands.arguments.coordinates.SwizzleArgument;
 import net.minecraft.core.Direction;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -49,14 +47,14 @@ public final class AxisArgument<C> extends CommandArgument<C, EnumSet<Direction.
 
     AxisArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 new WrappedBrigadierParser<>(SwizzleArgument.swizzle()),
                 TYPE,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -108,7 +106,7 @@ public final class AxisArgument<C> extends CommandArgument<C, EnumSet<Direction.
         public @NonNull AxisArgument<C> build() {
             return new AxisArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/CompoundTagArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/CompoundTagArgument.java
@@ -25,10 +25,8 @@ package cloud.commandframework.fabric.argument;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.brigadier.argument.WrappedBrigadierParser;
-import cloud.commandframework.context.CommandContext;
-import java.util.List;
-import java.util.function.BiFunction;
 import net.minecraft.nbt.CompoundTag;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -43,14 +41,14 @@ public final class CompoundTagArgument<C> extends CommandArgument<C, CompoundTag
 
     CompoundTagArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 new WrappedBrigadierParser<>(net.minecraft.commands.arguments.CompoundTagArgument.compoundTag()),
                 CompoundTag.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -102,7 +100,7 @@ public final class CompoundTagArgument<C> extends CommandArgument<C, CompoundTag
         public @NonNull CompoundTagArgument<C> build() {
             return new CompoundTagArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/EntityAnchorArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/EntityAnchorArgument.java
@@ -25,10 +25,8 @@ package cloud.commandframework.fabric.argument;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.brigadier.argument.WrappedBrigadierParser;
-import cloud.commandframework.context.CommandContext;
-import java.util.List;
-import java.util.function.BiFunction;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -43,14 +41,14 @@ public final class EntityAnchorArgument<C> extends
 
     EntityAnchorArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 new WrappedBrigadierParser<>(net.minecraft.commands.arguments.EntityAnchorArgument.anchor()),
                 net.minecraft.commands.arguments.EntityAnchorArgument.Anchor.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -103,7 +101,7 @@ public final class EntityAnchorArgument<C> extends
         public @NonNull EntityAnchorArgument<C> build() {
             return new EntityAnchorArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/FloatRangeArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/FloatRangeArgument.java
@@ -25,10 +25,8 @@ package cloud.commandframework.fabric.argument;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.brigadier.argument.WrappedBrigadierParser;
-import cloud.commandframework.context.CommandContext;
-import java.util.List;
-import java.util.function.BiFunction;
 import net.minecraft.advancements.critereon.MinMaxBounds;
 import net.minecraft.commands.arguments.RangeArgument;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -45,14 +43,14 @@ public final class FloatRangeArgument<C> extends CommandArgument<C, MinMaxBounds
 
     FloatRangeArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 new WrappedBrigadierParser<>(RangeArgument.floatRange()),
                 MinMaxBounds.Doubles.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -104,7 +102,7 @@ public final class FloatRangeArgument<C> extends CommandArgument<C, MinMaxBounds
         public @NonNull FloatRangeArgument<C> build() {
             return new FloatRangeArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/IntRangeArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/IntRangeArgument.java
@@ -25,10 +25,8 @@ package cloud.commandframework.fabric.argument;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.brigadier.argument.WrappedBrigadierParser;
-import cloud.commandframework.context.CommandContext;
-import java.util.List;
-import java.util.function.BiFunction;
 import net.minecraft.advancements.critereon.MinMaxBounds;
 import net.minecraft.commands.arguments.RangeArgument;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -45,14 +43,14 @@ public final class IntRangeArgument<C> extends CommandArgument<C, MinMaxBounds.I
 
     IntRangeArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 new WrappedBrigadierParser<>(RangeArgument.intRange()),
                 MinMaxBounds.Ints.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -104,7 +102,7 @@ public final class IntRangeArgument<C> extends CommandArgument<C, MinMaxBounds.I
         public @NonNull IntRangeArgument<C> build() {
             return new IntRangeArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ItemInputArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ItemInputArgument.java
@@ -25,9 +25,7 @@ package cloud.commandframework.fabric.argument;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
-import cloud.commandframework.context.CommandContext;
-import java.util.List;
-import java.util.function.BiFunction;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import net.minecraft.commands.arguments.item.ItemArgument;
 import net.minecraft.commands.arguments.item.ItemInput;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -43,14 +41,14 @@ public final class ItemInputArgument<C> extends CommandArgument<C, ItemInput> {
 
     ItemInputArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 FabricArgumentParsers.contextual(ItemArgument::item),
                 ItemInput.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -102,7 +100,7 @@ public final class ItemInputArgument<C> extends CommandArgument<C, ItemInput> {
         public @NonNull ItemInputArgument<C> build() {
             return new ItemInputArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/MobEffectArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/MobEffectArgument.java
@@ -25,9 +25,7 @@ package cloud.commandframework.fabric.argument;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
-import cloud.commandframework.context.CommandContext;
-import java.util.List;
-import java.util.function.BiFunction;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.effect.MobEffect;
 import org.apiguardian.api.API;
@@ -47,14 +45,14 @@ public final class MobEffectArgument<C> extends CommandArgument<C, MobEffect> {
 
     MobEffectArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 new RegistryEntryArgument.Parser<>(Registries.MOB_EFFECT),
                 MobEffect.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -106,7 +104,7 @@ public final class MobEffectArgument<C> extends CommandArgument<C, MobEffect> {
         public @NonNull MobEffectArgument<C> build() {
             return new MobEffectArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/NamedColorArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/NamedColorArgument.java
@@ -25,10 +25,8 @@ package cloud.commandframework.fabric.argument;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.brigadier.argument.WrappedBrigadierParser;
-import cloud.commandframework.context.CommandContext;
-import java.util.List;
-import java.util.function.BiFunction;
 import net.minecraft.ChatFormatting;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -43,14 +41,14 @@ public final class NamedColorArgument<C> extends CommandArgument<C, ChatFormatti
 
     NamedColorArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 new WrappedBrigadierParser<>(net.minecraft.commands.arguments.ColorArgument.color()),
                 ChatFormatting.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -102,7 +100,7 @@ public final class NamedColorArgument<C> extends CommandArgument<C, ChatFormatti
         public @NonNull NamedColorArgument<C> build() {
             return new NamedColorArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/NbtPathArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/NbtPathArgument.java
@@ -25,10 +25,8 @@ package cloud.commandframework.fabric.argument;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.brigadier.argument.WrappedBrigadierParser;
-import cloud.commandframework.context.CommandContext;
-import java.util.List;
-import java.util.function.BiFunction;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -43,14 +41,14 @@ public final class NbtPathArgument<C> extends CommandArgument<C, net.minecraft.c
 
     NbtPathArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 new WrappedBrigadierParser<>(net.minecraft.commands.arguments.NbtPathArgument.nbtPath()),
                 net.minecraft.commands.arguments.NbtPathArgument.NbtPath.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -103,7 +101,7 @@ public final class NbtPathArgument<C> extends CommandArgument<C, net.minecraft.c
         public @NonNull NbtPathArgument<C> build() {
             return new NbtPathArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/NbtTagArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/NbtTagArgument.java
@@ -25,10 +25,8 @@ package cloud.commandframework.fabric.argument;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.brigadier.argument.WrappedBrigadierParser;
-import cloud.commandframework.context.CommandContext;
-import java.util.List;
-import java.util.function.BiFunction;
 import net.minecraft.nbt.Tag;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -43,14 +41,14 @@ public final class NbtTagArgument<C> extends CommandArgument<C, Tag> {
 
     NbtTagArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 new WrappedBrigadierParser<>(net.minecraft.commands.arguments.NbtTagArgument.nbtTag()),
                 Tag.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -102,7 +100,7 @@ public final class NbtTagArgument<C> extends CommandArgument<C, Tag> {
         public @NonNull NbtTagArgument<C> build() {
             return new NbtTagArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ObjectiveCriteriaArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ObjectiveCriteriaArgument.java
@@ -25,10 +25,8 @@ package cloud.commandframework.fabric.argument;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.brigadier.argument.WrappedBrigadierParser;
-import cloud.commandframework.context.CommandContext;
-import java.util.List;
-import java.util.function.BiFunction;
 import net.minecraft.world.scores.criteria.ObjectiveCriteria;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -43,14 +41,14 @@ public final class ObjectiveCriteriaArgument<C> extends CommandArgument<C, Objec
 
     ObjectiveCriteriaArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 new WrappedBrigadierParser<>(net.minecraft.commands.arguments.ObjectiveCriteriaArgument.criteria()),
                 ObjectiveCriteria.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -102,7 +100,7 @@ public final class ObjectiveCriteriaArgument<C> extends CommandArgument<C, Objec
         public @NonNull ObjectiveCriteriaArgument<C> build() {
             return new ObjectiveCriteriaArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ParticleArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ParticleArgument.java
@@ -25,9 +25,7 @@ package cloud.commandframework.fabric.argument;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
-import cloud.commandframework.context.CommandContext;
-import java.util.List;
-import java.util.function.BiFunction;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import net.minecraft.core.particles.ParticleOptions;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -42,14 +40,14 @@ public final class ParticleArgument<C> extends CommandArgument<C, ParticleOption
 
     ParticleArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 FabricArgumentParsers.contextual(net.minecraft.commands.arguments.ParticleArgument::particle),
                 ParticleOptions.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -101,7 +99,7 @@ public final class ParticleArgument<C> extends CommandArgument<C, ParticleOption
         public @NonNull ParticleArgument<C> build() {
             return new ParticleArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/RegistryEntryArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/RegistryEntryArgument.java
@@ -27,6 +27,7 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.captions.CaptionVariable;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
@@ -40,7 +41,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
-import java.util.function.BiFunction;
 import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
@@ -67,14 +67,14 @@ public class RegistryEntryArgument<C, V> extends CommandArgument<C, V> {
             final @NonNull String name,
             final @NonNull ResourceKey<? extends Registry<V>> registry,
             final @NonNull TypeToken<V> valueType,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 new Parser<>(registry),
                 valueType,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -195,7 +195,7 @@ public class RegistryEntryArgument<C, V> extends CommandArgument<C, V> {
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {
@@ -262,7 +262,7 @@ public class RegistryEntryArgument<C, V> extends CommandArgument<C, V> {
                     this.getName(),
                     this.registryIdent,
                     this.getValueType(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ResourceLocationArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ResourceLocationArgument.java
@@ -25,10 +25,8 @@ package cloud.commandframework.fabric.argument;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.brigadier.argument.WrappedBrigadierParser;
-import cloud.commandframework.context.CommandContext;
-import java.util.List;
-import java.util.function.BiFunction;
 import net.minecraft.resources.ResourceLocation;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -43,14 +41,14 @@ public final class ResourceLocationArgument<C> extends CommandArgument<C, Resour
 
     ResourceLocationArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 new WrappedBrigadierParser<>(net.minecraft.commands.arguments.ResourceLocationArgument.id()),
                 ResourceLocation.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -102,7 +100,7 @@ public final class ResourceLocationArgument<C> extends CommandArgument<C, Resour
         public @NonNull ResourceLocationArgument<C> build() {
             return new ResourceLocationArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ScoreboardOperationArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ScoreboardOperationArgument.java
@@ -25,10 +25,8 @@ package cloud.commandframework.fabric.argument;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.brigadier.argument.WrappedBrigadierParser;
-import cloud.commandframework.context.CommandContext;
-import java.util.List;
-import java.util.function.BiFunction;
 import net.minecraft.commands.arguments.OperationArgument;
 import net.minecraft.commands.arguments.OperationArgument.Operation;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -46,14 +44,14 @@ public final class ScoreboardOperationArgument<C> extends CommandArgument<C, Ope
 
     ScoreboardOperationArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 new WrappedBrigadierParser<>(OperationArgument.operation()),
                 Operation.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -105,7 +103,7 @@ public final class ScoreboardOperationArgument<C> extends CommandArgument<C, Ope
         public @NonNull ScoreboardOperationArgument<C> build() {
             return new ScoreboardOperationArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/TeamArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/TeamArgument.java
@@ -26,6 +26,7 @@ package cloud.commandframework.fabric.argument;
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.captions.CaptionVariable;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
@@ -35,7 +36,6 @@ import cloud.commandframework.fabric.FabricCommandContextKeys;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.world.scores.PlayerTeam;
@@ -52,14 +52,14 @@ public final class TeamArgument<C> extends CommandArgument<C, PlayerTeam> {
 
     TeamArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 new TeamParser<>(),
                 PlayerTeam.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -98,7 +98,7 @@ public final class TeamArgument<C> extends CommandArgument<C, PlayerTeam> {
     public static final class TeamParser<C> extends SidedArgumentParser<C, String, PlayerTeam> {
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {
@@ -167,7 +167,7 @@ public final class TeamArgument<C> extends CommandArgument<C, PlayerTeam> {
         public @NonNull TeamArgument<C> build() {
             return new TeamArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/TimeArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/TimeArgument.java
@@ -25,10 +25,8 @@ package cloud.commandframework.fabric.argument;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
-import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.fabric.data.MinecraftTime;
-import java.util.List;
-import java.util.function.BiFunction;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -42,14 +40,14 @@ public final class TimeArgument<C> extends CommandArgument<C, MinecraftTime> {
 
     TimeArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 FabricArgumentParsers.time(),
                 MinecraftTime.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -101,7 +99,7 @@ public final class TimeArgument<C> extends CommandArgument<C, MinecraftTime> {
         public @NonNull TimeArgument<C> build() {
             return new TimeArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/BlockPosArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/BlockPosArgument.java
@@ -25,11 +25,9 @@ package cloud.commandframework.fabric.argument.server;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
-import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.fabric.argument.FabricArgumentParsers;
 import cloud.commandframework.fabric.data.Coordinates.BlockCoordinates;
-import java.util.List;
-import java.util.function.BiFunction;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -43,14 +41,14 @@ public final class BlockPosArgument<C> extends CommandArgument<C, BlockCoordinat
 
     BlockPosArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 FabricArgumentParsers.blockPos(),
                 BlockCoordinates.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -102,7 +100,7 @@ public final class BlockPosArgument<C> extends CommandArgument<C, BlockCoordinat
         public @NonNull BlockPosArgument<C> build() {
             return new BlockPosArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/ColumnPosArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/ColumnPosArgument.java
@@ -25,11 +25,9 @@ package cloud.commandframework.fabric.argument.server;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
-import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.fabric.argument.FabricArgumentParsers;
 import cloud.commandframework.fabric.data.Coordinates.ColumnCoordinates;
-import java.util.List;
-import java.util.function.BiFunction;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -43,14 +41,14 @@ public final class ColumnPosArgument<C> extends CommandArgument<C, ColumnCoordin
 
     ColumnPosArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 FabricArgumentParsers.columnPos(),
                 ColumnCoordinates.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -102,7 +100,7 @@ public final class ColumnPosArgument<C> extends CommandArgument<C, ColumnCoordin
         public @NonNull ColumnPosArgument<C> build() {
             return new ColumnPosArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/MessageArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/MessageArgument.java
@@ -25,11 +25,9 @@ package cloud.commandframework.fabric.argument.server;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
-import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.fabric.argument.FabricArgumentParsers;
 import cloud.commandframework.fabric.data.Message;
-import java.util.List;
-import java.util.function.BiFunction;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -43,14 +41,14 @@ public final class MessageArgument<C> extends CommandArgument<C, Message> {
 
     MessageArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 FabricArgumentParsers.message(),
                 Message.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -102,7 +100,7 @@ public final class MessageArgument<C> extends CommandArgument<C, Message> {
         public @NonNull MessageArgument<C> build() {
             return new MessageArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/MultipleEntitySelectorArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/MultipleEntitySelectorArgument.java
@@ -25,11 +25,9 @@ package cloud.commandframework.fabric.argument.server;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
-import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.fabric.argument.FabricArgumentParsers;
 import cloud.commandframework.fabric.data.MultipleEntitySelector;
-import java.util.List;
-import java.util.function.BiFunction;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -44,14 +42,14 @@ public final class MultipleEntitySelectorArgument<C> extends CommandArgument<C, 
 
     MultipleEntitySelectorArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 FabricArgumentParsers.multipleEntitySelector(),
                 MultipleEntitySelector.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -103,7 +101,7 @@ public final class MultipleEntitySelectorArgument<C> extends CommandArgument<C, 
         public @NonNull MultipleEntitySelectorArgument<C> build() {
             return new MultipleEntitySelectorArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/MultiplePlayerSelectorArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/MultiplePlayerSelectorArgument.java
@@ -25,11 +25,9 @@ package cloud.commandframework.fabric.argument.server;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
-import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.fabric.argument.FabricArgumentParsers;
 import cloud.commandframework.fabric.data.MultiplePlayerSelector;
-import java.util.List;
-import java.util.function.BiFunction;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -44,14 +42,14 @@ public final class MultiplePlayerSelectorArgument<C> extends CommandArgument<C, 
 
     MultiplePlayerSelectorArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 FabricArgumentParsers.multiplePlayerSelector(),
                 MultiplePlayerSelector.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -103,7 +101,7 @@ public final class MultiplePlayerSelectorArgument<C> extends CommandArgument<C, 
         public @NonNull MultiplePlayerSelectorArgument<C> build() {
             return new MultiplePlayerSelectorArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/SingleEntitySelectorArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/SingleEntitySelectorArgument.java
@@ -25,11 +25,9 @@ package cloud.commandframework.fabric.argument.server;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
-import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.fabric.argument.FabricArgumentParsers;
 import cloud.commandframework.fabric.data.SingleEntitySelector;
-import java.util.List;
-import java.util.function.BiFunction;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -44,14 +42,14 @@ public final class SingleEntitySelectorArgument<C> extends CommandArgument<C, Si
 
     SingleEntitySelectorArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 FabricArgumentParsers.singleEntitySelector(),
                 SingleEntitySelector.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -103,7 +101,7 @@ public final class SingleEntitySelectorArgument<C> extends CommandArgument<C, Si
         public @NonNull SingleEntitySelectorArgument<C> build() {
             return new SingleEntitySelectorArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/SinglePlayerSelectorArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/SinglePlayerSelectorArgument.java
@@ -25,11 +25,9 @@ package cloud.commandframework.fabric.argument.server;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
-import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.fabric.argument.FabricArgumentParsers;
 import cloud.commandframework.fabric.data.SinglePlayerSelector;
-import java.util.List;
-import java.util.function.BiFunction;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -44,14 +42,14 @@ public final class SinglePlayerSelectorArgument<C> extends CommandArgument<C, Si
 
     SinglePlayerSelectorArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
         super(
                 name,
                 FabricArgumentParsers.singlePlayerSelector(),
                 SinglePlayerSelector.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
     }
@@ -103,7 +101,7 @@ public final class SinglePlayerSelectorArgument<C> extends CommandArgument<C, Si
         public @NonNull SinglePlayerSelectorArgument<C> build() {
             return new SinglePlayerSelectorArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/Vec2dArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/Vec2dArgument.java
@@ -25,11 +25,9 @@ package cloud.commandframework.fabric.argument.server;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
-import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.fabric.argument.FabricArgumentParsers;
 import cloud.commandframework.fabric.data.Coordinates;
-import java.util.List;
-import java.util.function.BiFunction;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -45,7 +43,7 @@ public final class Vec2dArgument<C> extends CommandArgument<C, Coordinates.Coord
 
     Vec2dArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final boolean centerIntegers
     ) {
@@ -53,7 +51,7 @@ public final class Vec2dArgument<C> extends CommandArgument<C, Coordinates.Coord
                 name,
                 FabricArgumentParsers.vec2(centerIntegers),
                 Coordinates.CoordinatesXZ.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
         this.centerIntegers = centerIntegers;
@@ -153,7 +151,7 @@ public final class Vec2dArgument<C> extends CommandArgument<C, Coordinates.Coord
         public @NonNull Vec2dArgument<C> build() {
             return new Vec2dArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription(),
                     this.centerIntegers()
             );

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/Vec3dArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/Vec3dArgument.java
@@ -25,11 +25,9 @@ package cloud.commandframework.fabric.argument.server;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
-import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.fabric.argument.FabricArgumentParsers;
 import cloud.commandframework.fabric.data.Coordinates;
-import java.util.List;
-import java.util.function.BiFunction;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -45,7 +43,7 @@ public final class Vec3dArgument<C> extends CommandArgument<C, Coordinates> {
 
     Vec3dArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final boolean centerIntegers
     ) {
@@ -53,7 +51,7 @@ public final class Vec3dArgument<C> extends CommandArgument<C, Coordinates> {
                 name,
                 FabricArgumentParsers.vec3(centerIntegers),
                 Coordinates.class,
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription
         );
         this.centerIntegers = centerIntegers;
@@ -140,7 +138,7 @@ public final class Vec3dArgument<C> extends CommandArgument<C, Coordinates> {
         public @NonNull Vec3dArgument<C> build() {
             return new Vec3dArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription(),
                     this.centerIntegers()
             );

--- a/cloud-minecraft/cloud-fabric/src/testmod/java/cloud/commandframework/fabric/testmod/FabricExample.java
+++ b/cloud-minecraft/cloud-fabric/src/testmod/java/cloud/commandframework/fabric/testmod/FabricExample.java
@@ -28,6 +28,7 @@ import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.standard.IntegerArgument;
 import cloud.commandframework.arguments.standard.StringArgument;
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.execution.CommandExecutionCoordinator;
 import cloud.commandframework.fabric.FabricServerCommandManager;
 import cloud.commandframework.fabric.argument.ItemInputArgument;
@@ -201,9 +202,10 @@ public final class FabricExample implements ModInitializer {
         }));
 
         final CommandArgument<CommandSourceStack, ModMetadata> modMetadata = manager.argumentBuilder(ModMetadata.class, "mod")
-                .withSuggestionsProvider((ctx, input) -> FabricLoader.getInstance().getAllMods().stream()
+                .withSuggestionProvider((ctx, input) -> FabricLoader.getInstance().getAllMods().stream()
                         .map(ModContainer::getMetadata)
                         .map(ModMetadata::getId)
+                        .map(Suggestion::simple)
                         .collect(Collectors.toList()))
                 .withParser((ctx, inputQueue) -> {
                     final ModMetadata meta = FabricLoader.getInstance().getModContainer(inputQueue.peek())

--- a/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/TextColorArgument.java
+++ b/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/TextColorArgument.java
@@ -150,7 +150,7 @@ public final class TextColorArgument<C> extends CommandArgument<C, TextColor> {
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext, final @NonNull String input
         ) {
             final List<String> suggestions = new LinkedList<>();

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/AsyncCommandSuggestionsListener.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/AsyncCommandSuggestionsListener.java
@@ -23,10 +23,12 @@
 //
 package cloud.commandframework.paper;
 
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.bukkit.BukkitPluginRegistrationHandler;
 import com.destroystokyo.paper.event.server.AsyncTabCompleteEvent;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -67,7 +69,7 @@ final class AsyncCommandSuggestionsListener<C> implements Listener {
         final List<String> suggestions = new ArrayList<>(this.paperCommandManager.suggest(
                 cloudSender,
                 inputBuffer
-        ));
+        )).stream().map(Suggestion::suggestion).collect(Collectors.toList());
 
         event.setCompletions(suggestions);
         event.setHandled(true);

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/argument/KeyedWorldArgument.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/argument/KeyedWorldArgument.java
@@ -27,6 +27,8 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.bukkit.internal.CraftBukkitReflection;
 import cloud.commandframework.bukkit.parsers.WorldArgument;
 import cloud.commandframework.context.CommandContext;
@@ -34,7 +36,6 @@ import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
-import java.util.function.BiFunction;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.World;
@@ -54,10 +55,10 @@ public final class KeyedWorldArgument<C> extends CommandArgument<C, World> {
 
     KeyedWorldArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription
     ) {
-        super(name, new Parser<>(), World.class, suggestionsProvider, defaultDescription);
+        super(name, new Parser<>(), World.class, suggestionProvider, defaultDescription);
     }
 
     /**
@@ -107,7 +108,7 @@ public final class KeyedWorldArgument<C> extends CommandArgument<C, World> {
         public @NonNull KeyedWorldArgument<C> build() {
             return new KeyedWorldArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription()
             );
         }
@@ -167,7 +168,7 @@ public final class KeyedWorldArgument<C> extends CommandArgument<C, World> {
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull Suggestion> suggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {
@@ -176,13 +177,13 @@ public final class KeyedWorldArgument<C> extends CommandArgument<C, World> {
             }
 
             final List<World> worlds = Bukkit.getWorlds();
-            final List<String> completions = new ArrayList<>(worlds.size() * 2);
+            final List<Suggestion> completions = new ArrayList<>(worlds.size() * 2);
             for (final World world : worlds) {
                 final NamespacedKey key = world.getKey();
                 if (!input.isEmpty() && key.getNamespace().equals(NamespacedKey.MINECRAFT_NAMESPACE)) {
-                    completions.add(key.getKey());
+                    completions.add(Suggestion.simple(key.getKey()));
                 }
-                completions.add(key.getNamespace() + ':' + key.getKey());
+                completions.add(Suggestion.simple(key.getNamespace() + ':' + key.getKey()));
             }
             return completions;
         }

--- a/cloud-minecraft/cloud-sponge7/src/main/java/cloud/commandframework/sponge7/CloudCommandCallable.java
+++ b/cloud-minecraft/cloud-sponge7/src/main/java/cloud/commandframework/sponge7/CloudCommandCallable.java
@@ -25,6 +25,7 @@ package cloud.commandframework.sponge7;
 
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.exceptions.ArgumentParseException;
 import cloud.commandframework.exceptions.CommandExecutionException;
 import cloud.commandframework.exceptions.InvalidCommandSenderException;
@@ -36,6 +37,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.command.CommandCallable;
@@ -164,12 +166,14 @@ final class CloudCommandCallable<C> implements CommandCallable {
     }
 
     @Override
-    public List<String> getSuggestions(
+    public @NonNull List<@NonNull String> getSuggestions(
             final @NonNull CommandSource source,
             final @NonNull String arguments,
             final @Nullable Location<World> targetPosition
     ) {
-        return this.manager.suggest(this.manager.getCommandSourceMapper().apply(source), this.formatCommand(arguments));
+        return this.manager.suggest(this.manager.getCommandSourceMapper().apply(source), this.formatCommand(arguments))
+                .stream().map(Suggestion::suggestion)
+                .collect(Collectors.toList());
     }
 
     private String formatCommand(final String arguments) {

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/PlayerArgument.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/PlayerArgument.java
@@ -27,6 +27,7 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.captions.CaptionVariable;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
@@ -55,7 +56,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
 
     private PlayerArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>, @NonNull Queue<@NonNull String>,
                     @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
@@ -64,7 +65,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
                 name,
                 new PlayerParser<>(),
                 TypeToken.get(Player.class),
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription,
                 argumentPreprocessors
         );
@@ -134,7 +135,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
         public @NonNull CommandArgument<@NonNull C, @NonNull Player> build() {
             return new PlayerArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription(),
                     new LinkedList<>()
             );
@@ -170,7 +171,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/ServerArgument.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/ServerArgument.java
@@ -27,6 +27,7 @@ import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.captions.CaptionVariable;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
@@ -55,7 +56,7 @@ public final class ServerArgument<C> extends CommandArgument<C, RegisteredServer
 
     private ServerArgument(
             final @NonNull String name,
-            final @Nullable BiFunction<CommandContext<C>, String, List<String>> suggestionsProvider,
+            final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull ArgumentDescription defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>, @NonNull Queue<@NonNull String>,
                     @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
@@ -64,7 +65,7 @@ public final class ServerArgument<C> extends CommandArgument<C, RegisteredServer
                 name,
                 new ServerParser<>(),
                 TypeToken.get(RegisteredServer.class),
-                suggestionsProvider,
+                suggestionProvider,
                 defaultDescription,
                 argumentPreprocessors
         );
@@ -121,7 +122,7 @@ public final class ServerArgument<C> extends CommandArgument<C, RegisteredServer
         public @NonNull CommandArgument<@NonNull C, @NonNull RegisteredServer> build() {
             return new ServerArgument<>(
                     this.getName(),
-                    this.getSuggestionsProvider(),
+                    this.suggestionProvider(),
                     this.getDefaultDescription(),
                     new LinkedList<>()
             );
@@ -156,7 +157,7 @@ public final class ServerArgument<C> extends CommandArgument<C, RegisteredServer
         }
 
         @Override
-        public @NonNull List<@NonNull String> suggestions(
+        public @NonNull List<@NonNull String> stringSuggestions(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -223,7 +223,7 @@ String arguments can be constructed using:
 * `StringArgument.optional(name, mode)`: Optional string argument of specified type
 
 Furthermore, a string argument builder can be constructed using `StringArgument.newBuilder(name)`.
-This allows you to provide a custom suggestion generator, using `StringArgument.Builder#withSuggestionsProvider(BiFunction<CommandContext<C>, List<String>>)`.
+This allows you to provide a custom suggestion generator, using `StringArgument.Builder#withSuggestionProvider(BiFunction<CommandContext<C>, List<String>>)`.
 
 ===== byte/short/int/long
 
@@ -245,7 +245,9 @@ Integer arguments can be constructed using:
 
 * `IntegerArgument.optional(name, default)`: Optional integer argument without a range, with a default value
 
-Furthermore, an integer argument builder can be constructed using `IntegerArgument.newBuilder(name)`. This allows you to provide a custom suggestion generator, using `IntegerArgument.Builder#withSuggestionsProvider(BiFunction<CommandContext<C>, List<String>>)`, and set minimum and maximum values.
+Furthermore, an integer argument builder can be constructed using `IntegerArgument.newBuilder(name)`. This allows you to provide a
+ custom suggestion generator, using `IntegerArgument.Builder#withSuggestionProvider(SuggestionProvider<C>)`, and set minimum and
+ maximum values.
 
 ===== float/double
 
@@ -265,7 +267,9 @@ Floating point arguments can be constructed using:
 
 * `FloatArgument.optional(name, default)`: Optional float argument without a range, with a default value
 
-Furthermore, a floating-point argument builder can be constructed using `FloatArgument.newBuilder(name)`. This allows you to provide a custom suggestion generator, using `FloatArgument.Builder#withSuggestionsProvider(BiFunction<CommandContext<C>, List<String>>)`, and set minimum and maximum values.
+Furthermore, a floating-point argument builder can be constructed using `FloatArgument.newBuilder(name)`. This allows you to
+provide a custom suggestion generator, using `FloatArgument.Builder#withSuggestionProvider(SuggestionProvider<C>)`, and set
+minimum and maximum values.
 
 ===== enums
 
@@ -510,7 +514,7 @@ public @NonNull List<@NonNull String> suggestions(
 
 or by specifying a suggestion function in a command argument builder
 using
-https://javadoc.io/doc/cloud.commandframework/cloud-core/latest/cloud/commandframework/arguments/CommandArgument.Builder.html#withSuggestionsProvider(java.util.function.BiFunction)[CommandArgument.Builder#withSuggestionProvider].
+https://javadoc.io/doc/cloud.commandframework/cloud-core/latest/cloud/commandframework/arguments/CommandArgument.Builder.html#withSuggestionProvider(java.util.function.BiFunction)[CommandArgument.Builder#withSuggestionProvider].
 
 You also register a standalone suggestions to the parser registry,
 using
@@ -814,7 +818,7 @@ Ordering of the methods arguments does not matter,
 instead Cloud will match arguments based on the names supplied to the annotation. This also means that
 Cloud doesn't care about the names of the method parameters.
 
-You may also specify a named argument parser, named suggestions provider, default value
+You may also specify a named argument parser, named suggestion provider, default value
 and description using the `@Argument` annotation.
 
 === @Flag
@@ -893,15 +897,15 @@ public ParsedType methodName(CommandContext<YourSender> sender, Queue<String> in
 The method can throw exceptions, and the thrown exceptions will automatically
 be wrapped in an argument parse result.
 
-It is also possibly to specify the suggestions provider that should be used by
+It is also possibly to specify the suggestion provider that should be used by
 default by the generated parser. This is done by specifying a name in the annotation,
-such as `@Parser(suggestions="yourSuggestionsProvider")`. For this to work
+such as `@Parser(suggestions="yourSuggestionProvider")`. For this to work
 the suggestion provider must be registered in the parser registry.
 
 === @Suggestions
 
 `@Suggestions` can be used to create suggestion provider from instance methods.
-The annotation value is the name of the suggestions provider.
+The annotation value is the name of the suggestion provider.
 
 The signature of the method should be:
 [source,java]

--- a/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/ExamplePlugin.java
+++ b/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/ExamplePlugin.java
@@ -43,6 +43,7 @@ import cloud.commandframework.arguments.parser.StandardParameters;
 import cloud.commandframework.arguments.standard.EnumArgument;
 import cloud.commandframework.arguments.standard.IntegerArgument;
 import cloud.commandframework.arguments.standard.StringArrayArgument;
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.bukkit.BukkitCommandManager;
 import cloud.commandframework.bukkit.CloudBukkitCapabilities;
 import cloud.commandframework.bukkit.argument.NamespacedKeyArgument;
@@ -418,7 +419,7 @@ public final class ExamplePlugin extends JavaPlugin {
                                 (context, lastString) -> {
                                     final List<String> allArgs = context.getRawInput();
                                     if (allArgs.size() > 1 && allArgs.get(1).equals("curry")) {
-                                        return Collections.singletonList("hot");
+                                        return Collections.singletonList(Suggestion.simple("hot"));
                                     }
                                     return Collections.emptyList();
                                 }


### PR DESCRIPTION
This PR prepares for more complex suggestions by replacing the string suggestions with an interface. The default parsers can still supply string suggestions, but they'll be wrapped in `Suggestion#simple`.

The idea is that there can be another suggestion implementation that offers tooltip support, etc.