### PR TITLE
feature: force typed argument builders

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/arguments/CommandArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/CommandArgument.java
@@ -479,7 +479,7 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
 
 
     /**
-     * Mutable builder for {@link CommandArgument} instances
+     * Mutable builder for {@link CommandArgument} instances. Builders should extend {@link TypedBuilder} instead of this class.
      *
      * @param <C> Command sender type
      * @param <T> Argument value type
@@ -498,7 +498,7 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
         private final Collection<BiFunction<@NonNull CommandContext<C>,
                 @NonNull String, @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors = new LinkedList<>();
 
-        protected Builder(
+        private Builder(
                 final @NonNull TypeToken<T> valueType,
                 final @NonNull String name
         ) {
@@ -506,7 +506,7 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
             this.name = name;
         }
 
-        protected Builder(
+        private Builder(
                 final @NonNull Class<T> valueType,
                 final @NonNull String name
         ) {

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/BooleanArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/BooleanArgument.java
@@ -109,7 +109,7 @@ public final class BooleanArgument<C> extends CommandArgument<C, Boolean> {
 
 
     @API(status = API.Status.STABLE)
-    public static final class Builder<C> extends CommandArgument.Builder<C, Boolean> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, Boolean, Builder<C>> {
 
         private boolean liberal = false;
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ByteArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ByteArgument.java
@@ -116,7 +116,7 @@ public final class ByteArgument<C> extends CommandArgument<C, Byte> {
 
 
     @API(status = API.Status.STABLE)
-    public static final class Builder<C> extends CommandArgument.Builder<C, Byte> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, Byte, Builder<C>> {
 
         private byte min = ByteParser.DEFAULT_MINIMUM;
         private byte max = ByteParser.DEFAULT_MAXIMUM;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/CharArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/CharArgument.java
@@ -91,7 +91,7 @@ public final class CharArgument<C> extends CommandArgument<C, Character> {
 
 
     @API(status = API.Status.STABLE)
-    public static final class Builder<C> extends CommandArgument.Builder<C, Character> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, Character, Builder<C>> {
 
         private Builder(final @NonNull String name) {
             super(Character.class, name);

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DoubleArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DoubleArgument.java
@@ -115,7 +115,7 @@ public final class DoubleArgument<C> extends CommandArgument<C, Double> {
 
 
     @API(status = API.Status.STABLE)
-    public static final class Builder<C> extends CommandArgument.Builder<C, Double> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, Double, Builder<C>> {
 
         private double min = DoubleParser.DEFAULT_MINIMUM;
         private double max = DoubleParser.DEFAULT_MAXIMUM;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/EnumArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/EnumArgument.java
@@ -116,7 +116,7 @@ public class EnumArgument<C, E extends Enum<E>> extends CommandArgument<C, E> {
 
 
     @API(status = API.Status.STABLE)
-    public static final class Builder<C, E extends Enum<E>> extends CommandArgument.Builder<C, E> {
+    public static final class Builder<C, E extends Enum<E>> extends CommandArgument.TypedBuilder<C, E, Builder<C, E>> {
 
         private final Class<E> enumClass;
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/FloatArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/FloatArgument.java
@@ -115,7 +115,7 @@ public final class FloatArgument<C> extends CommandArgument<C, Float> {
 
 
     @API(status = API.Status.STABLE)
-    public static final class Builder<C> extends CommandArgument.Builder<C, Float> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, Float, Builder<C>> {
 
         private float min = FloatParser.DEFAULT_MINIMUM;
         private float max = FloatParser.DEFAULT_MAXIMUM;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/IntegerArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/IntegerArgument.java
@@ -129,7 +129,7 @@ public final class IntegerArgument<C> extends CommandArgument<C, Integer> {
 
 
     @API(status = API.Status.STABLE)
-    public static final class Builder<C> extends CommandArgument.Builder<C, Integer> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, Integer, Builder<C>> {
 
         private int min = IntegerParser.DEFAULT_MINIMUM;
         private int max = IntegerParser.DEFAULT_MAXIMUM;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/LongArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/LongArgument.java
@@ -116,7 +116,7 @@ public final class LongArgument<C> extends CommandArgument<C, Long> {
 
 
     @API(status = API.Status.STABLE)
-    public static final class Builder<C> extends CommandArgument.Builder<C, Long> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, Long, Builder<C>> {
 
         private long min = LongParser.DEFAULT_MINIMUM;
         private long max = LongParser.DEFAULT_MAXIMUM;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ShortArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ShortArgument.java
@@ -116,7 +116,7 @@ public final class ShortArgument<C> extends CommandArgument<C, Short> {
 
 
     @API(status = API.Status.STABLE)
-    public static final class Builder<C> extends CommandArgument.Builder<C, Short> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, Short, Builder<C>> {
 
         private short min = ShortParser.DEFAULT_MINIMUM;
         private short max = ShortParser.DEFAULT_MAXIMUM;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringArgument.java
@@ -191,7 +191,7 @@ public final class StringArgument<C> extends CommandArgument<C, String> {
 
 
     @API(status = API.Status.STABLE)
-    public static final class Builder<C> extends CommandArgument.Builder<C, String> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, String, Builder<C>> {
 
         private StringMode stringMode = StringMode.SINGLE;
         private SuggestionProvider<C> suggestionProvider = (v1, v2) -> Collections.emptyList();

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/UUIDArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/UUIDArgument.java
@@ -92,7 +92,7 @@ public final class UUIDArgument<C> extends CommandArgument<C, UUID> {
 
 
     @API(status = API.Status.STABLE)
-    public static final class Builder<C> extends CommandArgument.Builder<C, UUID> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, UUID, Builder<C>> {
 
         private Builder(final @NonNull String name) {
             super(UUID.class, name);

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/ChannelArgument.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/ChannelArgument.java
@@ -123,7 +123,7 @@ public final class ChannelArgument<C> extends CommandArgument<C, MessageChannel>
     }
 
 
-    public static final class Builder<C> extends CommandArgument.Builder<C, MessageChannel> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, MessageChannel, Builder<C>> {
 
         private Set<ParserMode> modes = new HashSet<>();
 

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/RoleArgument.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/RoleArgument.java
@@ -116,7 +116,7 @@ public final class RoleArgument<C> extends CommandArgument<C, Role> {
     }
 
 
-    public static final class Builder<C> extends CommandArgument.Builder<C, Role> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, Role, Builder<C>> {
 
         private Set<ParserMode> modes = new HashSet<>();
 

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/UserArgument.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/UserArgument.java
@@ -134,7 +134,7 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
     }
 
 
-    public static final class Builder<C> extends CommandArgument.Builder<C, User> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, User, Builder<C>> {
 
         private Set<ParserMode> modes = new HashSet<>();
         private Isolation isolationLevel = Isolation.GLOBAL;

--- a/cloud-irc/cloud-pircbotx/src/main/java/cloud/commandframework/pircbotx/arguments/UserArgument.java
+++ b/cloud-irc/cloud-pircbotx/src/main/java/cloud/commandframework/pircbotx/arguments/UserArgument.java
@@ -103,7 +103,7 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
     }
 
 
-    public static final class Builder<C> extends CommandArgument.Builder<C, User> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, User, Builder<C>> {
 
         private Builder(
                 final @NonNull String name

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/EnchantmentArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/EnchantmentArgument.java
@@ -102,7 +102,7 @@ public class EnchantmentArgument<C> extends CommandArgument<C, Enchantment> {
     }
 
 
-    public static final class Builder<C> extends CommandArgument.Builder<C, Enchantment> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, Enchantment, Builder<C>> {
 
         private Builder(final @NonNull String name) {
             super(Enchantment.class, name);

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/MaterialArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/MaterialArgument.java
@@ -95,7 +95,7 @@ public class MaterialArgument<C> extends CommandArgument<C, Material> {
     }
 
 
-    public static final class Builder<C> extends CommandArgument.Builder<C, Material> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, Material, Builder<C>> {
 
         private Builder(final @NonNull String name) {
             super(Material.class, name);

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/OfflinePlayerArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/OfflinePlayerArgument.java
@@ -109,7 +109,7 @@ public final class OfflinePlayerArgument<C> extends CommandArgument<C, OfflinePl
     }
 
 
-    public static final class Builder<C> extends CommandArgument.Builder<C, OfflinePlayer> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, OfflinePlayer, Builder<C>> {
 
         private Builder(final @NonNull String name) {
             super(OfflinePlayer.class, name);

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/PlayerArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/PlayerArgument.java
@@ -99,7 +99,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
     }
 
 
-    public static final class Builder<C> extends CommandArgument.Builder<C, Player> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, Player, Builder<C>> {
 
         private Builder(final @NonNull String name) {
             super(Player.class, name);

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/WorldArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/WorldArgument.java
@@ -96,7 +96,7 @@ public class WorldArgument<C> extends CommandArgument<C, World> {
     }
 
 
-    public static final class Builder<C> extends CommandArgument.Builder<C, World> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, World, Builder<C>> {
 
         private Builder(final @NonNull String name) {
             super(World.class, name);

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/Location2DArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/Location2DArgument.java
@@ -114,7 +114,7 @@ public final class Location2DArgument<C> extends CommandArgument<C, Location2D> 
     }
 
 
-    public static final class Builder<C> extends CommandArgument.Builder<C, Location2D> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, Location2D, Builder<C>> {
 
         private Builder(
                 final @NonNull String name

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/LocationArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/LocationArgument.java
@@ -119,7 +119,7 @@ public final class LocationArgument<C> extends CommandArgument<C, Location> {
     }
 
 
-    public static final class Builder<C> extends CommandArgument.Builder<C, Location> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, Location, Builder<C>> {
 
         private Builder(
                 final @NonNull String name

--- a/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/PlayerArgument.java
+++ b/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/PlayerArgument.java
@@ -112,7 +112,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, ProxiedPlayer> {
     }
 
 
-    public static final class Builder<C> extends CommandArgument.Builder<C, ProxiedPlayer> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, ProxiedPlayer, Builder<C>> {
 
         private Builder(
                 final @NonNull String name

--- a/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/ServerArgument.java
+++ b/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/ServerArgument.java
@@ -112,7 +112,7 @@ public final class ServerArgument<C> extends CommandArgument<C, ServerInfo> {
     }
 
 
-    public static final class Builder<C> extends CommandArgument.Builder<C, ServerInfo> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, ServerInfo, Builder<C>> {
 
         private Builder(
                 final @NonNull String name

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/PlayerArgument.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/PlayerArgument.java
@@ -125,7 +125,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
     }
 
 
-    public static final class Builder<C> extends CommandArgument.Builder<C, Player> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, Player, Builder<C>> {
 
         private Builder(final @NonNull String name) {
             super(TypeToken.get(Player.class), name);

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/ServerArgument.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/ServerArgument.java
@@ -112,7 +112,7 @@ public final class ServerArgument<C> extends CommandArgument<C, RegisteredServer
     }
 
 
-    public static final class Builder<C> extends CommandArgument.Builder<C, RegisteredServer> {
+    public static final class Builder<C> extends CommandArgument.TypedBuilder<C, RegisteredServer, Builder<C>> {
 
         private Builder(final @NonNull String name) {
             super(TypeToken.get(RegisteredServer.class), name);


### PR DESCRIPTION
This PR prevents the non-typed argument builders from being extended from. All standard arguments now use typed builders.