### PR TITLE
feature: tooltip support

### DIFF
--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/AnnotationParser.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/AnnotationParser.java
@@ -77,6 +77,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -453,7 +454,7 @@ public final class AnnotationParser<C> {
                 method.setAccessible(true);
             }
             if (method.getParameterCount() != 2
-                    || !method.getReturnType().equals(List.class)
+                    || !(Collection.class.isAssignableFrom(method.getReturnType()) || method.getReturnType().equals(Stream.class))
                     || !method.getParameters()[0].getType().equals(CommandContext.class)
                     || !method.getParameters()[1].getType().equals(String.class)
             ) {
@@ -752,7 +753,7 @@ public final class AnnotationParser<C> {
         if (completions != null) {
             final List<Suggestion> suggestions = Arrays.stream(
                     completions.value().replace(" ", "").split(",")
-            ).map(Suggestion::simple).collect(Collectors.toList());
+            ).map(Suggestion::of).collect(Collectors.toList());
             argumentBuilder.withSuggestionProvider((commandContext, input) -> suggestions);
         } else if (!argument.suggestions().isEmpty()) { /* Check whether a suggestion provider should be set */
             final String suggestionProviderName = this.processString(argument.suggestions());

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/suggestions/MethodSuggestionProvider.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/suggestions/MethodSuggestionProvider.java
@@ -29,9 +29,12 @@ import cloud.commandframework.context.CommandContext;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -62,18 +65,36 @@ public final class MethodSuggestionProvider<C> implements SuggestionProvider<C> 
     @SuppressWarnings("unchecked")
     public @NonNull List<@NonNull Suggestion> suggestions(final @NonNull CommandContext<C> context, final @NonNull String input) {
         try {
-            final List<?> suggestions = (List<?>) this.methodHandle.invokeWithArguments(context, input);
+            final Object output = this.methodHandle.invokeWithArguments(context, input);
+
+            final List<?> suggestions;
+            if (output instanceof List) {
+                suggestions = (List<?>) output;
+            } else if (output instanceof Collection) {
+                suggestions = new ArrayList<>((Collection<?>) output);
+            } else if (output instanceof Stream) {
+                suggestions = ((Stream<?>) output).collect(Collectors.toList());
+            } else {
+                throw new IllegalArgumentException(
+                        String.format("Cannot handle suggestion output of type %s",
+                        output.getClass().getName())
+                );
+            }
+
             if (suggestions.isEmpty()) {
                 return Collections.emptyList();
             }
+
             final Object suggestion = suggestions.get(0);
             if (suggestion instanceof Suggestion) {
                 return (List<Suggestion>) suggestions;
             } else if (suggestion instanceof String) {
-                return suggestions.stream().map(Object::toString).map(Suggestion::simple).collect(Collectors.toList());
+                return suggestions.stream().map(Object::toString).map(Suggestion::of).collect(Collectors.toList());
             } else {
-                throw new IllegalArgumentException(String.format("Cannot handle suggestions of type: %s",
-                        suggestion.getClass().getName()));
+                throw new IllegalArgumentException(
+                        String.format("Cannot handle suggestions of type: %s",
+                        suggestion.getClass().getName())
+                );
             }
         } catch (final Throwable t) {
             throw new RuntimeException(t);

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/suggestions/Suggestions.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/suggestions/Suggestions.java
@@ -23,6 +23,8 @@
 //
 package cloud.commandframework.annotations.suggestions;
 
+import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.context.CommandContext;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -31,15 +33,18 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * This annotation allows you to create annotated methods that behave like suggestion providers.
- * The method must have a signature matching either: <pre>{@code
+ * <p>
+ * The method must take in the following parameters in the given order: {@link CommandContext} and
+ * {@link String}. The method must return a collection or stream of either {@link String} or {@link Suggestion}.
+ * Example signatures: <pre>{@code
  * ﹫Suggestions("name")
- * public List<String> methodName(CommandContext<YourSender> sender, String input) {
- * }}</pre>
- * or <pre>{@code
+ * public List<String> methodName(CommandContext<YourSender> sender, String input)}</pre>
+ * <pre>{@code
  * ﹫Suggestions("name")
- * public List<Suggestion> methodName(CommandContext<YourSender> sender, String input) {
- * }}</pre>
- *
+ * public List<Suggestion> methodName(CommandContext<YourSender> sender, String input)}</pre>
+ * <pre>{@code
+ * ﹫Suggestions("name")
+ * public Stream<Suggestion> methodName(CommandContext<YourSender> sender, String input)}</pre>
  *
  * @since 1.3.0
  */

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
@@ -65,7 +65,7 @@ import org.junit.jupiter.api.TestInstance;
 class AnnotationParserTest {
 
     private static final List<Suggestion> NAMED_SUGGESTIONS = Arrays.asList("Dancing-Queen", "Gimme!-Gimme!-Gimme!",
-            "Waterloo").stream().map(Suggestion::simple).collect(Collectors.toList());
+            "Waterloo").stream().map(Suggestion::of).collect(Collectors.toList());
 
     private CommandManager<TestCommandSender> manager;
     private AnnotationParser<TestCommandSender> annotationParser;
@@ -76,7 +76,7 @@ class AnnotationParserTest {
         manager = new TestCommandManager();
         annotationParser = new AnnotationParser<>(manager, TestCommandSender.class, p -> SimpleCommandMeta.empty());
         manager.parserRegistry().registerNamedParserSupplier("potato", p -> new StringArgument.StringParser<>(
-                StringArgument.StringMode.SINGLE, (c, s) -> Collections.singletonList(Suggestion.simple("potato"))));
+                StringArgument.StringMode.SINGLE, (c, s) -> Collections.singletonList(Suggestion.of("potato"))));
         /* Register a suggestion provider */
         manager.parserRegistry().registerSuggestionProvider(
                 "some-name",
@@ -162,7 +162,7 @@ class AnnotationParserTest {
                 this.manager.parserRegistry().getSuggestionProvider("cows").orElse(null);
         Assertions.assertNotNull(suggestionProvider);
         Assertions.assertTrue(suggestionProvider.suggestions(new CommandContext<>(new TestCommandSender(), manager), "")
-                .contains(Suggestion.simple("Stella")));
+                .contains(Suggestion.of("Stella")));
     }
 
     @Test
@@ -182,7 +182,7 @@ class AnnotationParserTest {
         Assertions.assertTrue(parser.suggestions(
                 context,
                 ""
-        ).contains(Suggestion.simple("Stella")));
+        ).contains(Suggestion.of("Stella")));
     }
 
     @Test

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/DelegatingCommandSuggestionEngine.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/DelegatingCommandSuggestionEngine.java
@@ -45,7 +45,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 public final class DelegatingCommandSuggestionEngine<C> implements CommandSuggestionEngine<C> {
 
     private static final List<Suggestion> SINGLE_EMPTY_SUGGESTION =
-            Collections.unmodifiableList(Collections.singletonList(Suggestion.simple("")));
+            Collections.unmodifiableList(Collections.singletonList(Suggestion.of("")));
 
     private final CommandManager<C> commandManager;
     private final CommandTree<C> commandTree;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/compound/FlagArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/compound/FlagArgument.java
@@ -231,7 +231,7 @@ public final class FlagArgument<C> extends CommandArgument<C, Object> {
                         continue;
                     }
 
-                    suggestions.add(Suggestion.simple(String.format("--%s", flag.getName())));
+                    suggestions.add(Suggestion.of(String.format("--%s", flag.getName())));
                 }
                 /* Recommend aliases */
                 final boolean suggestCombined = input.length() > 1 && input.charAt(0) == '-' && input.charAt(1) != '-';
@@ -245,15 +245,15 @@ public final class FlagArgument<C> extends CommandArgument<C, Object> {
 
                     for (final String alias : flag.getAliases()) {
                         if (suggestCombined && flag.getCommandArgument() == null) {
-                            suggestions.add(Suggestion.simple(String.format("%s%s", input, alias)));
+                            suggestions.add(Suggestion.of(String.format("%s%s", input, alias)));
                         } else {
-                            suggestions.add(Suggestion.simple(String.format("-%s", alias)));
+                            suggestions.add(Suggestion.of(String.format("-%s", alias)));
                         }
                     }
                 }
                 /* If we are suggesting the combined flag, then also suggest the current input */
                 if (suggestCombined) {
-                    suggestions.add(Suggestion.simple(input));
+                    suggestions.add(Suggestion.of(input));
                 }
                 return suggestions;
             } else {

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/parser/ArgumentParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/parser/ArgumentParser.java
@@ -116,7 +116,7 @@ public interface ArgumentParser<C, T> extends SuggestionProvider<C> {
             final @NonNull CommandContext<C> commandContext,
             final @NonNull String input
     ) {
-        return this.stringSuggestions(commandContext, input).stream().map(Suggestion::simple).collect(Collectors.toList());
+        return this.stringSuggestions(commandContext, input).stream().map(Suggestion::of).collect(Collectors.toList());
     }
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/parser/StandardParserRegistry.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/parser/StandardParserRegistry.java
@@ -177,7 +177,7 @@ public final class StandardParserRegistry<C> implements ParserRegistry<C> {
             return new StringArgument.StringParser<>(
                     stringMode,
                     (context, s) -> Arrays.stream(options.get(StandardParameters.COMPLETIONS, new String[0]))
-                            .map(Suggestion::simple)
+                            .map(Suggestion::of)
                             .collect(Collectors.toList())
             );
         });

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/SimpleTooltipSuggestion.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/SimpleTooltipSuggestion.java
@@ -26,22 +26,28 @@ package cloud.commandframework.arguments.suggestion;
 import java.util.Objects;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-class SimpleSuggestion implements Suggestion {
+class SimpleTooltipSuggestion<T> extends SimpleSuggestion implements TooltipSuggestion<T> {
 
-    private final String suggestion;
+    private final T tooltip;
 
-    SimpleSuggestion(final @NonNull String suggestion) {
-        this.suggestion = suggestion;
+    SimpleTooltipSuggestion(final @NonNull String suggestion, final @NonNull T tooltip) {
+        super(suggestion);
+        this.tooltip = tooltip;
     }
 
     @Override
-    public @NonNull String suggestion() {
-        return this.suggestion;
+    public @NonNull T tooltip() {
+        return this.tooltip;
     }
 
     @Override
-    public @NonNull Suggestion withSuggestion(@NonNull final String suggestion) {
-        return new SimpleSuggestion(suggestion);
+    public @NonNull TooltipSuggestion<T> withSuggestion(@NonNull final String suggestion) {
+        return new SimpleTooltipSuggestion<>(suggestion, this.tooltip());
+    }
+
+    @Override
+    public @NonNull <U> TooltipSuggestion<U> withTooltip(@NonNull final U tooltip) {
+        return new SimpleTooltipSuggestion<>(this.suggestion(), tooltip);
     }
 
     @Override
@@ -52,17 +58,20 @@ class SimpleSuggestion implements Suggestion {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        final SimpleSuggestion that = (SimpleSuggestion) o;
-        return Objects.equals(this.suggestion, that.suggestion);
+        if (!super.equals(o)) {
+            return false;
+        }
+        final SimpleTooltipSuggestion<?> that = (SimpleTooltipSuggestion<?>) o;
+        return Objects.equals(this.suggestion(), that.suggestion()) && Objects.equals(this.tooltip, that.tooltip);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.suggestion);
+        return Objects.hash(super.hashCode(), this.suggestion(), this.tooltip);
     }
 
     @Override
     public @NonNull String toString() {
-        return this.suggestion;
+        return String.format("%s (%s)", this.suggestion(), this.tooltip());
     }
 }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/Suggestion.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/Suggestion.java
@@ -35,8 +35,48 @@ public interface Suggestion {
      * @param suggestion the suggestion string
      * @return the created suggestion
      */
-    static @NonNull Suggestion simple(final @NonNull String suggestion) {
+    static @NonNull Suggestion of(final @NonNull String suggestion) {
         return new SimpleSuggestion(suggestion);
+    }
+
+    /**
+     * Returns a simple suggestion that returns the given {@code suggestion} together with the given {@code tooltip}
+     * <p>
+     * The supported types of tooltips depends on the platform. All platforms supporting tooltips should support
+     * string tooltips, but they may also offer support for platform-specific tooltip types
+     *
+     * @param suggestion the suggestion string
+     * @param tooltip    the suggestion tooltip
+     * @param <T> the tooltip type
+     * @return the created suggestion
+     */
+    static @NonNull <T> TooltipSuggestion<T> of(final @NonNull String suggestion, final @NonNull T tooltip) {
+        return new SimpleTooltipSuggestion<>(suggestion, tooltip);
+    }
+
+    /**
+     * Returns a simple suggestion that returns the given {@code suggestion}
+     *
+     * @param suggestion the suggestion string
+     * @return the created suggestion
+     */
+    static @NonNull Suggestion suggestion(final @NonNull String suggestion) {
+        return new SimpleSuggestion(suggestion);
+    }
+
+    /**
+     * Returns a simple suggestion that returns the given {@code suggestion} together with the given {@code tooltip}
+     * <p>
+     * The supported types of tooltips depends on the platform. All platforms supporting tooltips should support
+     * string tooltips, but they may also offer support for platform-specific tooltip types
+     *
+     * @param suggestion the suggestion string
+     * @param tooltip    the suggestion tooltip
+     * @param <T> the tooltip type
+     * @return the created suggestion
+     */
+    static @NonNull <T> TooltipSuggestion<T> suggestion(final @NonNull String suggestion, final @NonNull T tooltip) {
+        return new SimpleTooltipSuggestion<>(suggestion, tooltip);
     }
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/TooltipConverter.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/TooltipConverter.java
@@ -23,46 +23,40 @@
 //
 package cloud.commandframework.arguments.suggestion;
 
-import java.util.Objects;
+import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-class SimpleSuggestion implements Suggestion {
+/**
+ * Converter between a platform type {@link T} and an output type {@link U}
+ *
+ * @param <T> the input type
+ * @param <U> the output type
+ * @since 2.0.0
+ */
+@API(status = API.Status.STABLE, since = "2.0.0")
+public abstract class TooltipConverter<T, U> {
 
-    private final String suggestion;
+    private final Class<T> inputType;
 
-    SimpleSuggestion(final @NonNull String suggestion) {
-        this.suggestion = suggestion;
+    protected TooltipConverter(final @NonNull Class<T> inputType) {
+        this.inputType = inputType;
     }
 
-    @Override
-    public @NonNull String suggestion() {
-        return this.suggestion;
+    /**
+     * Returns whether this converter can convert the given {@code object}
+     *
+     * @param object the object
+     * @return {@code true} if this converter can convert the {@code object}, else {@code false}
+     */
+    public boolean canConvert(final @NonNull Object object) {
+        return this.inputType.isInstance(object);
     }
 
-    @Override
-    public @NonNull Suggestion withSuggestion(@NonNull final String suggestion) {
-        return new SimpleSuggestion(suggestion);
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        final SimpleSuggestion that = (SimpleSuggestion) o;
-        return Objects.equals(this.suggestion, that.suggestion);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(this.suggestion);
-    }
-
-    @Override
-    public @NonNull String toString() {
-        return this.suggestion;
-    }
+    /**
+     * Converts the given {@code tooltip} into the platform type
+     *
+     * @param tooltip the tooltip
+     * @return the converted tooltip
+     */
+    public abstract @NonNull U convert(@NonNull T tooltip);
 }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/TooltipSuggestion.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/TooltipSuggestion.java
@@ -23,46 +23,31 @@
 //
 package cloud.commandframework.arguments.suggestion;
 
-import java.util.Objects;
+import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-class SimpleSuggestion implements Suggestion {
+@API(status = API.Status.STABLE, since = "2.0.0")
+public interface TooltipSuggestion<T> extends Suggestion {
 
-    private final String suggestion;
+    /**
+     * Returns the tooltip
+     *
+     * @return the tooltip
+     */
+    @NonNull T tooltip();
 
-    SimpleSuggestion(final @NonNull String suggestion) {
-        this.suggestion = suggestion;
-    }
-
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public @NonNull String suggestion() {
-        return this.suggestion;
-    }
+    @NonNull TooltipSuggestion<T> withSuggestion(@NonNull String suggestion);
 
-    @Override
-    public @NonNull Suggestion withSuggestion(@NonNull final String suggestion) {
-        return new SimpleSuggestion(suggestion);
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        final SimpleSuggestion that = (SimpleSuggestion) o;
-        return Objects.equals(this.suggestion, that.suggestion);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(this.suggestion);
-    }
-
-    @Override
-    public @NonNull String toString() {
-        return this.suggestion;
-    }
+    /**
+     * Returns a copy of this suggestion instance using the given {@code tooltip}
+     *
+     * @param tooltip the new tooltip
+     * @param <U> the type of the new tooltip
+     * @return the new suggestion
+     */
+    @NonNull <U> TooltipSuggestion<U> withTooltip(@NonNull U tooltip);
 }

--- a/cloud-core/src/test/java/cloud/commandframework/CommandDeletionTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandDeletionTest.java
@@ -169,7 +169,7 @@ class CommandDeletionTest {
         );
         assertThat(completionException).hasCauseThat().isInstanceOf(NoSuchCommandException.class);
 
-        assertThat(this.commandManager.suggest(new TestCommandSender(), "")).contains(Suggestion.simple("test"));
+        assertThat(this.commandManager.suggest(new TestCommandSender(), "")).contains(Suggestion.of("test"));
         assertThat(this.commandManager.commandTree().getRootNodes()).hasSize(1);
     }
 }

--- a/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
@@ -168,7 +168,7 @@ class CommandTreeTest {
         );
 
         // Assert
-        assertThat(results).containsExactly(Suggestion.simple("a"), Suggestion.simple("b"));
+        assertThat(results).containsExactly(Suggestion.of("a"), Suggestion.of("b"));
     }
 
     @Test

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/ArgumentTestHelper.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/ArgumentTestHelper.java
@@ -41,6 +41,6 @@ public final class ArgumentTestHelper {
     public static @NonNull List<@NonNull Suggestion> suggestionList(
             final @NonNull String... strings
     ) {
-        return Arrays.stream(strings).map(Suggestion::simple).collect(Collectors.toList());
+        return Arrays.stream(strings).map(Suggestion::of).collect(Collectors.toList());
     }
 }

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/ByteParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/ByteParserTest.java
@@ -148,7 +148,7 @@ class ByteParserTest {
 
         final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Suggestion.simple(Byte.toString((byte) i)));
+            expectedSuggestions.add(Suggestion.of(Byte.toString((byte) i)));
         }
 
         // Act
@@ -171,7 +171,7 @@ class ByteParserTest {
 
         final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Suggestion.simple(Byte.toString((byte) -i)));
+            expectedSuggestions.add(Suggestion.of(Byte.toString((byte) -i)));
         }
 
         // Act

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationArgumentSuggestionsTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationArgumentSuggestionsTest.java
@@ -26,7 +26,6 @@ package cloud.commandframework.arguments.standard;
 import cloud.commandframework.CommandManager;
 import cloud.commandframework.TestCommandSender;
 import cloud.commandframework.arguments.suggestion.Suggestion;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
@@ -65,12 +64,12 @@ public class DurationArgumentSuggestionsTest {
         final String input4 = "duration 1d2";
         final List<Suggestion> suggestions4 = manager.suggest(new TestCommandSender(), input4);
         Assertions.assertTrue(suggestions4.containsAll(suggestionList("1d2h", "1d2m", "1d2s")));
-        Assertions.assertFalse(suggestions4.contains(Suggestion.simple("1d2d")));
+        Assertions.assertFalse(suggestions4.contains(Suggestion.of("1d2d")));
 
         final String input9 = "duration 1d22";
         final List<Suggestion> suggestions9 = manager.suggest(new TestCommandSender(), input9);
         Assertions.assertTrue(suggestions9.containsAll(suggestionList("1d22h", "1d22m", "1d22s")));
-        Assertions.assertFalse(suggestions9.contains(Suggestion.simple("1d22d")));
+        Assertions.assertFalse(suggestions9.contains(Suggestion.of("1d22d")));
 
         final String input5 = "duration d";
         final List<Suggestion> suggestions5 = manager.suggest(new TestCommandSender(), input5);

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/IntegerParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/IntegerParserTest.java
@@ -148,7 +148,7 @@ class IntegerParserTest {
 
         final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Suggestion.simple(Integer.toString(i)));
+            expectedSuggestions.add(Suggestion.of(Integer.toString(i)));
         }
 
         // Act
@@ -171,7 +171,7 @@ class IntegerParserTest {
 
         final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Suggestion.simple(Integer.toString(-i)));
+            expectedSuggestions.add(Suggestion.of(Integer.toString(-i)));
         }
 
         // Act

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/LongParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/LongParserTest.java
@@ -148,7 +148,7 @@ class LongParserTest {
 
         final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Suggestion.simple(Long.toString((long) i)));
+            expectedSuggestions.add(Suggestion.of(Long.toString((long) i)));
         }
 
         // Act
@@ -171,7 +171,7 @@ class LongParserTest {
 
         final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Suggestion.simple(Long.toString((long) -i)));
+            expectedSuggestions.add(Suggestion.of(Long.toString((long) -i)));
         }
 
         // Act

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/ShortParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/ShortParserTest.java
@@ -148,7 +148,7 @@ class ShortParserTest {
 
         final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Suggestion.simple(Short.toString((short) i)));
+            expectedSuggestions.add(Suggestion.of(Short.toString((short) i)));
         }
 
         // Act
@@ -171,7 +171,7 @@ class ShortParserTest {
 
         final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Suggestion.simple(Short.toString((short) -i)));
+            expectedSuggestions.add(Suggestion.of(Short.toString((short) -i)));
         }
 
         // Act

--- a/cloud-core/src/test/java/cloud/commandframework/feature/RepeatableFlagTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/feature/RepeatableFlagTest.java
@@ -107,6 +107,6 @@ class RepeatableFlagTest {
         );
 
         // Assert
-        assertThat(suggestions).containsExactly(Suggestion.simple("--flag"));
+        assertThat(suggestions).containsExactly(Suggestion.of("--flag"));
     }
 }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/CloudBukkitCapabilities.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/CloudBukkitCapabilities.java
@@ -42,6 +42,13 @@ public enum CloudBukkitCapabilities implements CloudCapability {
             && CraftBukkitReflection.findOBCClass("command.BukkitCommandWrapper") != null),
 
     /**
+     * Whether Brigadier is present and cloud can make use of advanced completions.
+     */
+    BRIGADIER_COMPLETIONS(
+            CraftBukkitReflection.classExists("com.destroystokyo.paper.event.server.AsyncTabCompleteEvent$Completion")
+    ),
+
+    /**
      * Whether support for native Brigadier command registration is available
      * through the Paper API ({@code PaperCommandManager#registerBrigadier} from {@code cloud-paper}).
      */

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SelectorUtils.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SelectorUtils.java
@@ -257,7 +257,7 @@ final class SelectorUtils {
                 if (bukkit instanceof Player && !((Player) bukkit).canSee(player)) {
                     continue;
                 }
-                suggestions.add(Suggestion.simple(player.getName()));
+                suggestions.add(Suggestion.of(player.getName()));
             }
 
             return suggestions;

--- a/cloud-minecraft/cloud-fabric/src/testmod/java/cloud/commandframework/fabric/testmod/FabricExample.java
+++ b/cloud-minecraft/cloud-fabric/src/testmod/java/cloud/commandframework/fabric/testmod/FabricExample.java
@@ -205,7 +205,7 @@ public final class FabricExample implements ModInitializer {
                 .withSuggestionProvider((ctx, input) -> FabricLoader.getInstance().getAllMods().stream()
                         .map(ModContainer::getMetadata)
                         .map(ModMetadata::getId)
-                        .map(Suggestion::simple)
+                        .map(Suggestion::of)
                         .collect(Collectors.toList()))
                 .withParser((ctx, inputQueue) -> {
                     final ModMetadata meta = FabricLoader.getInstance().getModContainer(inputQueue.peek())

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/BrigadierAsyncCommandSuggestionsListener.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/BrigadierAsyncCommandSuggestionsListener.java
@@ -1,0 +1,102 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.paper;
+
+import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.TooltipConverter;
+import cloud.commandframework.arguments.suggestion.TooltipSuggestion;
+import cloud.commandframework.bukkit.BukkitPluginRegistrationHandler;
+import com.destroystokyo.paper.event.server.AsyncTabCompleteEvent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import net.kyori.adventure.text.Component;
+import org.bukkit.command.CommandSender;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import static com.destroystokyo.paper.event.server.AsyncTabCompleteEvent.Completion.completion;
+
+final class BrigadierAsyncCommandSuggestionsListener<C> implements Listener {
+
+    private final PaperCommandManager<C> paperCommandManager;
+
+    BrigadierAsyncCommandSuggestionsListener(final @NonNull PaperCommandManager<C> paperCommandManager) {
+        this.paperCommandManager = paperCommandManager;
+    }
+
+    @EventHandler
+    void onTabCompletion(final @NonNull AsyncTabCompleteEvent event) {
+        // Strip leading slash
+        final String strippedBuffer = event.getBuffer().startsWith("/")
+                ? event.getBuffer().substring(1)
+                : event.getBuffer();
+        if (strippedBuffer.trim().isEmpty()) {
+            return;
+        }
+
+        @SuppressWarnings("unchecked")
+        final BukkitPluginRegistrationHandler<C> bukkitPluginRegistrationHandler =
+                (BukkitPluginRegistrationHandler<C>) this.paperCommandManager.commandRegistrationHandler();
+
+        /* Turn 'plugin:command arg1 arg2 ...' into 'plugin:command' */
+        final String commandLabel = strippedBuffer.split(" ")[0];
+        if (!bukkitPluginRegistrationHandler.isRecognized(commandLabel)) {
+            return;
+        }
+
+        final CommandSender sender = event.getSender();
+        final C cloudSender = this.paperCommandManager.getCommandSenderMapper().apply(sender);
+        final String inputBuffer = this.paperCommandManager.stripNamespace(event.getBuffer());
+
+        final List<AsyncTabCompleteEvent.Completion> suggestions = new ArrayList<>(this.paperCommandManager.suggest(
+                cloudSender,
+                inputBuffer
+        )).stream().map(this::convertSuggestion).collect(Collectors.toList());
+
+        event.completions(suggestions);
+        event.setHandled(true);
+    }
+
+    private AsyncTabCompleteEvent.@NonNull Completion convertSuggestion(final @NonNull Suggestion suggestion) {
+        if (suggestion instanceof TooltipSuggestion) {
+            return completion(suggestion.suggestion(), this.convertTooltip(((TooltipSuggestion<?>) suggestion).tooltip()));
+        }
+        return completion(suggestion.suggestion());
+    }
+
+    @SuppressWarnings("unchecked")
+    private @NonNull Component convertTooltip(final @NonNull Object tooltip) {
+        return Objects.requireNonNull(this.paperCommandManager.tooltipConverters())
+                .tooltipConverters()
+                .stream()
+                .filter(converter -> converter.canConvert(tooltip))
+                .findFirst()
+                .map(converter -> (TooltipConverter) converter)
+                .map(converter -> (Component) converter.convert(tooltip))
+                .orElseGet(() -> Component.text(tooltip.toString()));
+    }
+}

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/LegacyAsyncCommandSuggestionsListener.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/LegacyAsyncCommandSuggestionsListener.java
@@ -34,11 +34,11 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-final class AsyncCommandSuggestionsListener<C> implements Listener {
+final class LegacyAsyncCommandSuggestionsListener<C> implements Listener {
 
     private final PaperCommandManager<C> paperCommandManager;
 
-    AsyncCommandSuggestionsListener(final @NonNull PaperCommandManager<C> paperCommandManager) {
+    LegacyAsyncCommandSuggestionsListener(final @NonNull PaperCommandManager<C> paperCommandManager) {
         this.paperCommandManager = paperCommandManager;
     }
 

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperTooltipConverters.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperTooltipConverters.java
@@ -1,0 +1,69 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.paper;
+
+import cloud.commandframework.arguments.suggestion.TooltipConverter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import net.kyori.adventure.text.Component;
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+@API(status = API.Status.STABLE, since = "2.0.0")
+public final class PaperTooltipConverters {
+
+    private final List<@NonNull TooltipConverter<?, Component>> tooltipConverters = new ArrayList<>();
+
+    PaperTooltipConverters() {
+        this.registerTooltipConverter(new ComponentToComponentConverter());
+    }
+
+    /**
+     * Registers a {@code converter} that converts from {@link T} to a Brigadier {@link Component} for use in suggestion tooltips.
+     *
+     * @param converter the converter
+     * @param <T> the input type
+     */
+    public <T> void registerTooltipConverter(final @NonNull TooltipConverter<T, Component> converter) {
+        this.tooltipConverters.add(converter);
+    }
+
+    @API(status = API.Status.INTERNAL, since = "2.0.0")
+    @NonNull List<@NonNull TooltipConverter<?, Component>> tooltipConverters() {
+        return Collections.unmodifiableList(this.tooltipConverters);
+    }
+
+    private static final class ComponentToComponentConverter extends TooltipConverter<Component, Component> {
+
+        private ComponentToComponentConverter() {
+            super(Component.class);
+        }
+
+        @Override
+        public @NonNull Component convert(final @NonNull Component tooltip) {
+            return tooltip;
+        }
+    }
+}

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/argument/KeyedWorldArgument.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/argument/KeyedWorldArgument.java
@@ -181,9 +181,9 @@ public final class KeyedWorldArgument<C> extends CommandArgument<C, World> {
             for (final World world : worlds) {
                 final NamespacedKey key = world.getKey();
                 if (!input.isEmpty() && key.getNamespace().equals(NamespacedKey.MINECRAFT_NAMESPACE)) {
-                    completions.add(Suggestion.simple(key.getKey()));
+                    completions.add(Suggestion.of(key.getKey()));
                 }
-                completions.add(Suggestion.simple(key.getNamespace() + ':' + key.getKey()));
+                completions.add(Suggestion.of(key.getNamespace() + ':' + key.getKey()));
             }
             return completions;
         }

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/VelocityCommandManager.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/VelocityCommandManager.java
@@ -142,6 +142,9 @@ public class VelocityCommandManager<C> extends CommandManager<C> implements Brig
             );
         }
 
+        /* Adds support for Adventure components in tooltips. */
+        this.brigadierManager().registerTooltipConverter(new VelocityTooltipConverter());
+
         this.proxyServer.getEventManager().register(plugin, ServerPreConnectEvent.class, ev -> {
             this.lockRegistration();
         });

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/VelocityTooltipConverter.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/VelocityTooltipConverter.java
@@ -21,48 +21,29 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-package cloud.commandframework.arguments.suggestion;
+package cloud.commandframework.velocity;
 
-import java.util.Objects;
+import cloud.commandframework.arguments.suggestion.TooltipConverter;
+import com.mojang.brigadier.Message;
+import com.velocitypowered.api.command.VelocityBrigadierMessage;
+import net.kyori.adventure.text.Component;
+import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-class SimpleSuggestion implements Suggestion {
+/**
+ * Converts between Adventure {@link Component} and Brigadier {@link Message}.
+ *
+ * @since 2.0.0
+ */
+@API(status = API.Status.STABLE, since = "2.0.0")
+class VelocityTooltipConverter extends TooltipConverter<Component, Message> {
 
-    private final String suggestion;
-
-    SimpleSuggestion(final @NonNull String suggestion) {
-        this.suggestion = suggestion;
+    VelocityTooltipConverter() {
+        super(Component.class);
     }
 
     @Override
-    public @NonNull String suggestion() {
-        return this.suggestion;
-    }
-
-    @Override
-    public @NonNull Suggestion withSuggestion(@NonNull final String suggestion) {
-        return new SimpleSuggestion(suggestion);
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        final SimpleSuggestion that = (SimpleSuggestion) o;
-        return Objects.equals(this.suggestion, that.suggestion);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(this.suggestion);
-    }
-
-    @Override
-    public @NonNull String toString() {
-        return this.suggestion;
+    public @NonNull Message convert(final @NonNull Component tooltip) {
+        return VelocityBrigadierMessage.tooltip(tooltip);
     }
 }

--- a/examples/example-bukkit/build.gradle.kts
+++ b/examples/example-bukkit/build.gradle.kts
@@ -21,14 +21,14 @@ dependencies {
 
 tasks {
     shadowJar {
-        relocate("net.kyori", "cloud.commandframework.example.kyori")
+        // relocate("net.kyori", "cloud.commandframework.example.kyori")
         relocate("io.leangen.geantyref", "cloud.commandframework.example.geantyref")
     }
     assemble {
         dependsOn(shadowJar)
     }
     runServer {
-        minecraftVersion("1.19.4")
+        minecraftVersion("1.20.2")
         runDirectory(file("run/latest"))
         javaLauncher.set(
             project.javaToolchains.launcherFor {
@@ -41,7 +41,7 @@ tasks {
     mapOf(
         8 to setOf("1.8.8"),
         11 to setOf("1.9.4", "1.10.2", "1.11.2"),
-        17 to setOf("1.12.2", "1.13.2", "1.14.4", "1.15.2", "1.16.5", "1.17.1", "1.18.2", "1.19.4")
+        17 to setOf("1.12.2", "1.13.2", "1.14.4", "1.15.2", "1.16.5", "1.17.1", "1.18.2", "1.19.4", "1.20.2")
     ).forEach { (javaVersion, minecraftVersions) ->
         for (version in minecraftVersions) {
             createVersionedRun(version, javaVersion)

--- a/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/ExamplePlugin.java
+++ b/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/ExamplePlugin.java
@@ -56,6 +56,7 @@ import cloud.commandframework.bukkit.parsers.selector.SingleEntitySelectorArgume
 import cloud.commandframework.captions.Caption;
 import cloud.commandframework.captions.SimpleCaptionRegistry;
 import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.examples.bukkit.feature.Tooltip;
 import cloud.commandframework.execution.AsynchronousCommandExecutionCoordinator;
 import cloud.commandframework.execution.CommandExecutionCoordinator;
 import cloud.commandframework.execution.FilteringCommandSuggestionProcessor;
@@ -404,6 +405,10 @@ public final class ExamplePlugin extends JavaPlugin {
             new Mc113(this.manager).registerCommands();
         }
 
+        if (this.manager.hasCapability(CloudBukkitCapabilities.BRIGADIER_COMPLETIONS)) {
+            this.annotationParser.parse(new Tooltip());
+        }
+
         this.registerNamespacedKeyUsingCommand();
 
         //
@@ -419,7 +424,7 @@ public final class ExamplePlugin extends JavaPlugin {
                                 (context, lastString) -> {
                                     final List<String> allArgs = context.getRawInput();
                                     if (allArgs.size() > 1 && allArgs.get(1).equals("curry")) {
-                                        return Collections.singletonList(Suggestion.simple("hot"));
+                                        return Collections.singletonList(Suggestion.of("hot"));
                                     }
                                     return Collections.emptyList();
                                 }

--- a/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/feature/Tooltip.java
+++ b/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/feature/Tooltip.java
@@ -1,0 +1,83 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.examples.bukkit.feature;
+
+import cloud.commandframework.annotations.Argument;
+import cloud.commandframework.annotations.CommandMethod;
+import cloud.commandframework.annotations.suggestions.Suggestions;
+import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.context.CommandContext;
+import java.util.Arrays;
+import java.util.stream.Stream;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import org.bukkit.command.CommandSender;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import static cloud.commandframework.arguments.suggestion.Suggestion.suggestion;
+import static net.kyori.adventure.text.Component.text;
+
+public final class Tooltip {
+
+    @Suggestions("tooltip-suggestions")
+    public @NonNull Stream<@NonNull Suggestion> suggestions(
+            final @NonNull CommandContext<CommandSender> context,
+            final @NonNull String input
+    ) {
+        return Arrays.stream(Species.values()).map(species -> suggestion(
+                species.name().toLowerCase(),
+                text(species.description(), species.color())
+        ));
+    }
+
+    @CommandMethod("species <species>")
+    public void speciesCommand(
+            final @NonNull CommandSender sender,
+            @Argument(value = "species", suggestions = "tooltip-suggestions") final @NonNull Species species
+    ) {
+        sender.sendMessage(String.format("Information about %s: %s", species.name().toLowerCase(), species.description()));
+    }
+
+    public enum Species {
+        CAT("Cute cuddly animal", NamedTextColor.GOLD),
+        SPIDER("Very not cute and has too many legs", NamedTextColor.RED),
+        HORSE("A very tasty fruit", NamedTextColor.GREEN);
+
+        private final String description;
+        private final TextColor color;
+
+        Species(final @NonNull String description, final @NonNull TextColor color) {
+            this.description = description;
+            this.color = color;
+        }
+
+        private @NonNull String description() {
+            return this.description;
+        }
+
+        private @NonNull TextColor color() {
+            return this.color;
+        }
+    }
+}


### PR DESCRIPTION
The brigadier manager supports tooltips and allows for the registration of T->Message mappings.

cloud-paper makes use of the completion API and adds the ability to register T->Component mappings.

Velocity has a native Component->Message mapping so it will make use of that one.

I opted to rename the suggestion method from "simple" to "of" and added a static-import-friendly "suggestion" method alongside it.

This PR also relaxes the requirements for `@Suggestions` annotated method contracts.