### PR TITLE
feature(annotations): allow for more @Suggestions method types

### DIFF
--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/AnnotationParser.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/AnnotationParser.java
@@ -77,6 +77,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -453,7 +454,7 @@ public final class AnnotationParser<C> {
                 method.setAccessible(true);
             }
             if (method.getParameterCount() != 2
-                    || !method.getReturnType().equals(List.class)
+                    || !(Collection.class.isAssignableFrom(method.getReturnType()) || method.getReturnType().equals(Stream.class))
                     || !method.getParameters()[0].getType().equals(CommandContext.class)
                     || !method.getParameters()[1].getType().equals(String.class)
             ) {

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/suggestions/Suggestions.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/suggestions/Suggestions.java
@@ -23,6 +23,8 @@
 //
 package cloud.commandframework.annotations.suggestions;
 
+import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.context.CommandContext;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -31,15 +33,18 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * This annotation allows you to create annotated methods that behave like suggestion providers.
- * The method must have a signature matching either: <pre>{@code
+ * <p>
+ * The method must take in the following parameters in the given order: {@link CommandContext} and
+ * {@link String}. The method must return a collection or stream of either {@link String} or {@link Suggestion}.
+ * Example signatures: <pre>{@code
  * ﹫Suggestions("name")
- * public List<String> methodName(CommandContext<YourSender> sender, String input) {
- * }}</pre>
- * or <pre>{@code
+ * public List<String> methodName(CommandContext<YourSender> sender, String input)}</pre>
+ * <pre>{@code
  * ﹫Suggestions("name")
- * public List<Suggestion> methodName(CommandContext<YourSender> sender, String input) {
- * }}</pre>
- *
+ * public List<Suggestion> methodName(CommandContext<YourSender> sender, String input)}</pre>
+ * <pre>{@code
+ * ﹫Suggestions("name")
+ * public Stream<Suggestion> methodName(CommandContext<YourSender> sender, String input)}</pre>
  *
  * @since 1.3.0
  */

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/MethodSuggestionProviderTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/MethodSuggestionProviderTest.java
@@ -1,0 +1,139 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.annotations.feature;
+
+import cloud.commandframework.CommandManager;
+import cloud.commandframework.annotations.AnnotationParser;
+import cloud.commandframework.annotations.TestCommandManager;
+import cloud.commandframework.annotations.TestCommandSender;
+import cloud.commandframework.annotations.suggestions.Suggestions;
+import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.context.CommandContextFactory;
+import cloud.commandframework.context.StandardCommandContextFactory;
+import cloud.commandframework.meta.SimpleCommandMeta;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static com.google.common.truth.Truth.assertThat;
+
+class MethodSuggestionProviderTest {
+
+    private CommandManager<TestCommandSender> commandManager;
+    private AnnotationParser<TestCommandSender> annotationParser;
+    private CommandContextFactory<TestCommandSender> commandContextFactory;
+
+    @BeforeEach
+    void setup() {
+        this.commandContextFactory = new StandardCommandContextFactory<>();
+        this.commandManager = new TestCommandManager();
+        this.annotationParser = new AnnotationParser<>(
+                this.commandManager,
+                TestCommandSender.class,
+                p -> SimpleCommandMeta.empty()
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("testSuggestionsSource")
+    void testSuggestions(final @NonNull Object instance) {
+        // Arrange
+        this.annotationParser.parse(instance);
+        final CommandContext<TestCommandSender> context = this.commandContextFactory.create(
+                true,
+                new TestCommandSender(),
+                this.commandManager
+        );
+
+        // Act
+        final List<Suggestion> suggestions =
+                this.commandManager.parserRegistry()
+                        .getSuggestionProvider("suggestions")
+                        .orElseThrow(NullPointerException::new)
+                        .suggestions(context, "");
+
+        // Assert
+        assertThat(suggestions).containsExactly(Suggestion.simple("foo"));
+    }
+
+    static @NonNull Stream<@NonNull Object> testSuggestionsSource() {
+        return Stream.of(
+                new TestClassList(),
+                new TestClassSet(),
+                new TestClassStream(),
+                new TestClassListString()
+        );
+    }
+
+
+    public static final class TestClassList {
+
+        @Suggestions("suggestions")
+        public @NonNull List<@NonNull Suggestion> suggestions(
+                final @NonNull CommandContext<TestCommandSender> context,
+                final @NonNull String input
+        ) {
+            return Collections.singletonList(Suggestion.simple("foo"));
+        }
+    }
+
+    public static final class TestClassSet {
+
+        @Suggestions("suggestions")
+        public @NonNull Set<@NonNull Suggestion> suggestions(
+                final @NonNull CommandContext<TestCommandSender> context,
+                final @NonNull String input
+        ) {
+            return Collections.singleton(Suggestion.simple("foo"));
+        }
+    }
+
+    public static final class TestClassStream {
+
+        @Suggestions("suggestions")
+        public @NonNull Stream<@NonNull Suggestion> suggestions(
+                final @NonNull CommandContext<TestCommandSender> context,
+                final @NonNull String input
+        ) {
+            return Stream.of(Suggestion.simple("foo"));
+        }
+    }
+
+    public static final class TestClassListString {
+
+        @Suggestions("suggestions")
+        public @NonNull List<@NonNull String> suggestions(
+                final @NonNull CommandContext<TestCommandSender> context,
+                final @NonNull String input
+        ) {
+            return Collections.singletonList("foo");
+        }
+    }
+}


### PR DESCRIPTION
We can allow the suggestion methods to be more flexible with no real harm to the suggestion provider. This lets the methods return any collection types/a stream containing either suggestions, or strings that will get converted into simple suggestions.