### PR TITLE
feature: make AnnotationParser more modular

### DIFF
--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/AnnotationParser.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/AnnotationParser.java
@@ -58,7 +58,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -95,9 +94,6 @@ public final class AnnotationParser<C> {
      */
     public static final String INFERRED_ARGUMENT_NAME = "__INFERRED_ARGUMENT_NAME__";
 
-    private final SyntaxParser syntaxParser = new SyntaxParser();
-    private final ArgumentExtractor argumentExtractor = new ArgumentExtractor();
-
     private final CommandManager<C> manager;
     private final Map<Class<? extends Annotation>, Function<? extends Annotation, ParserParameters>> annotationMappers;
     private final Map<Class<? extends Annotation>, Function<? extends Annotation, BiFunction<@NonNull CommandContext<C>,
@@ -108,9 +104,13 @@ public final class AnnotationParser<C> {
             MethodCommandExecutionHandler<C>>> commandMethodFactories;
     private final TypeToken<C> commandSenderType;
     private final MetaFactory metaFactory;
-    private final FlagExtractor flagExtractor;
 
     private StringProcessor stringProcessor;
+    private SyntaxParser syntaxParser;
+    private ArgumentExtractor argumentExtractor;
+    private FlagExtractor flagExtractor;
+    private FlagAssembler flagAssembler;
+    private CommandExtractor commandExtractor;
 
     /**
      * Construct a new annotation parser
@@ -154,7 +154,11 @@ public final class AnnotationParser<C> {
         this.preprocessorMappers = new HashMap<>();
         this.builderModifiers = new HashMap<>();
         this.commandMethodFactories = new HashMap<>();
-        this.flagExtractor = new FlagExtractor(manager, this);
+        this.flagExtractor = new FlagExtractorImpl(this);
+        this.flagAssembler = new FlagAssemblerImpl(manager);
+        this.syntaxParser = new SyntaxParserImpl();
+        this.argumentExtractor = new ArgumentExtractorImpl();
+        this.commandExtractor = new CommandExtractorImpl(this);
         this.registerAnnotationMapper(CommandDescription.class, d ->
                 ParserParameters.single(StandardParameters.DESCRIPTION, this.processString(d.value())));
         this.registerPreprocessorMapper(Regex.class, annotation -> RegexPreprocessor.of(
@@ -239,7 +243,7 @@ public final class AnnotationParser<C> {
      * Registers a new command execution method factory. This allows for the registration of
      * custom command method execution strategies.
      *
-     * @param predicate The predicate that decides whether or not to apply the custom execution handler to the given method
+     * @param predicate The predicate that decides whether to apply the custom execution handler to the given method
      * @param function  The function that produces the command execution handler
      * @since 1.6.0
      */
@@ -353,6 +357,127 @@ public final class AnnotationParser<C> {
     }
 
     /**
+     * Processes the input {@code strings} and returns the processed result.
+     *
+     * @param strings the input strings
+     * @return the processed strings
+     * @since 2.0.0
+     */
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    public @NonNull List<@NonNull String> processStrings(final @NonNull Collection<@NonNull String> strings) {
+        return strings.stream().map(this::processString).collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the syntax parser.
+     *
+     * @return the syntax parser
+     * @since 2.0.0
+     */
+    public @NonNull SyntaxParser syntaxParser() {
+        return this.syntaxParser;
+    }
+
+    /**
+     * Sets the syntax parser.
+     *
+     * @param syntaxParser new syntax parser
+     * @since 2.0.0
+     */
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    public void syntaxParser(final @NonNull SyntaxParser syntaxParser) {
+        this.syntaxParser = syntaxParser;
+    }
+
+    /**
+     * Returns the argument extractor.
+     *
+     * @return the argument extractor
+     * @since 2.0.0
+     */
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    public @NonNull ArgumentExtractor argumentExtractor() {
+        return this.argumentExtractor;
+    }
+
+    /**
+     * Sets the argument extractor.
+     *
+     * @param argumentExtractor new argument extractor
+     * @since 2.0.0
+     */
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    public void argumentExtractor(final @NonNull ArgumentExtractor argumentExtractor) {
+        this.argumentExtractor = argumentExtractor;
+    }
+
+    /**
+     * Returns the flag extractor.
+     *
+     * @return the flag extractor
+     * @since 2.0.0
+     */
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    public @NonNull FlagExtractor flagExtractor() {
+        return this.flagExtractor;
+    }
+
+    /**
+     * Sets the flag extractor.
+     *
+     * @param flagExtractor new flag extractor
+     * @since 2.0.0
+     */
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    public void flagExtractor(final @NonNull FlagExtractor flagExtractor) {
+        this.flagExtractor = flagExtractor;
+    }
+
+    /**
+     * Returns the flag assembler.
+     *
+     * @return the flag assembler
+     * @since 2.0.0
+     */
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    public @NonNull FlagAssembler flagAssembler() {
+        return this.flagAssembler;
+    }
+
+    /**
+     * Sets the flag assembler
+     *
+     * @param flagAssembler new flag assembler
+     * @since 2.0.0
+     */
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    public void flagAssembler(final @NonNull FlagAssembler flagAssembler) {
+        this.flagAssembler = flagAssembler;
+    }
+
+    /**
+     * Returns the command extractor.
+     *
+     * @return the command extractor
+     * @since 2.0.0
+     */
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    public @NonNull CommandExtractor commandExtractor() {
+        return this.commandExtractor;
+    }
+
+    /**
+     * Sets the command extractor.
+     *
+     * @param commandExtractor new command extractor
+     * @since 2.0.0
+     */
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    public void commandExtractor(final @NonNull CommandExtractor commandExtractor) {
+        this.commandExtractor = commandExtractor;
+    }
+
+    /**
      * Parses all known {@link cloud.commandframework.annotations.processing.CommandContainer command containers}.
      *
      * @return Collection of parsed commands
@@ -411,32 +536,13 @@ public final class AnnotationParser<C> {
      * @param <T>      Type of the instance
      * @return Collection of parsed commands
      */
-    @SuppressWarnings({"deprecation", "unchecked", "rawtypes"})
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public <T> @NonNull Collection<@NonNull Command<C>> parse(final @NonNull T instance) {
-        /* Start by registering all @Suggestion annotated methods */
         this.parseSuggestions(instance);
-        /* Then register all parsers */
         this.parseParsers(instance);
-        /* Then construct commands from @CommandMethod annotated classes */
-        final Method[] methods = instance.getClass().getDeclaredMethods();
-        final Collection<CommandMethodPair> commandMethodPairs = new ArrayList<>();
-        for (final Method method : methods) {
-            final CommandMethod commandMethod = method.getAnnotation(CommandMethod.class);
-            if (commandMethod == null) {
-                continue;
-            }
-            if (!method.isAccessible()) {
-                method.setAccessible(true);
-            }
-            if (Modifier.isStatic(method.getModifiers())) {
-                throw new IllegalArgumentException(String.format(
-                        "@CommandMethod annotated method '%s' is static! @CommandMethod annotated methods should not be static.",
-                        method.getName()
-                ));
-            }
-            commandMethodPairs.add(new CommandMethodPair(method, commandMethod));
-        }
-        final Collection<Command<C>> commands = this.construct(instance, commandMethodPairs);
+
+        final Collection<CommandDescriptor> commandDescriptors = this.commandExtractor.extractCommands(instance);
+        final Collection<Command<C>> commands = this.construct(instance, commandDescriptors);
         for (final Command<C> command : commands) {
             ((CommandManager) this.manager).command(command);
         }
@@ -538,19 +644,12 @@ public final class AnnotationParser<C> {
     @SuppressWarnings("unchecked")
     private @NonNull Collection<@NonNull Command<C>> construct(
             final @NonNull Object instance,
-            final @NonNull Collection<@NonNull CommandMethodPair> methodPairs
+            final @NonNull Collection<@NonNull CommandDescriptor> commandDescriptors
     ) {
         final AnnotationAccessor classAnnotations = AnnotationAccessor.of(instance.getClass());
-        final CommandMethod classCommandMethod = classAnnotations.annotation(CommandMethod.class);
-        final String syntaxPrefix = classCommandMethod == null ? "" : (this.processString(classCommandMethod.value()) + " ");
         final Collection<Command<C>> commands = new ArrayList<>();
-        for (final CommandMethodPair commandMethodPair : methodPairs) {
-            final CommandMethod commandMethod = commandMethodPair.getCommandMethod();
-            final Method method = commandMethodPair.getMethod();
-            final String syntax = syntaxPrefix + this.processString(commandMethod.value());
-            final List<SyntaxFragment> tokens = this.syntaxParser.apply(syntax);
-            /* Determine command name */
-            final String commandToken = syntax.split(" ")[0].split("\\|")[0];
+        for (final CommandDescriptor commandDescriptor : commandDescriptors) {
+            final Method method = commandDescriptor.method();
             @SuppressWarnings("rawtypes") final CommandManager manager = this.manager;
             final SimpleCommandMeta.Builder metaBuilder = SimpleCommandMeta.builder()
                     .with(this.metaFactory.apply(method));
@@ -560,26 +659,30 @@ public final class AnnotationParser<C> {
 
             @SuppressWarnings("rawtypes")
             Command.Builder builder = manager.commandBuilder(
-                    commandToken,
-                    tokens.get(0).getMinor(),
+                    commandDescriptor.commandToken(),
+                    commandDescriptor.syntax().get(0).getMinor(),
                     metaBuilder.build()
             );
-            final Collection<ArgumentParameterPair> arguments = this.argumentExtractor.apply(method);
-            final Collection<CommandFlag<?>> flags = this.flagExtractor.apply(method);
+            final Collection<ArgumentDescriptor> arguments = this.argumentExtractor.extractArguments(commandDescriptor.syntax(), method);
+            final Collection<FlagDescriptor> flagDescriptors = this.flagExtractor.extractFlags(method);
+            final Collection<CommandFlag<?>> flags = flagDescriptors.stream()
+                    .map(this.flagAssembler()::assembleFlag)
+                    .collect(Collectors.toList());
+
             final Map<String, CommandComponent<C>> commandComponents = new HashMap<>();
             /* Go through all annotated parameters and build up the argument tree */
-            for (final ArgumentParameterPair argumentPair : arguments) {
-                final String argumentName = this.processString(argumentPair.argumentName());
+            for (final ArgumentDescriptor argumentPair : arguments) {
+                final String argumentName = this.processString(argumentPair.name());
                 final CommandComponent<C> component = this.buildComponent(
                         method,
-                        this.findSyntaxFragment(tokens, argumentName),
+                        this.findSyntaxFragment(commandDescriptor.syntax(), argumentName),
                         argumentPair
                 );
                 commandComponents.put(component.argument().getName(), component);
             }
             boolean commandNameFound = false;
             /* Build the command tree */
-            for (final SyntaxFragment token : tokens) {
+            for (final SyntaxFragment token : commandDescriptor.syntax()) {
                 if (!commandNameFound) {
                     commandNameFound = true;
                     continue;
@@ -615,8 +718,8 @@ public final class AnnotationParser<C> {
                 builder = builder.permission(this.processString(commandPermission.value()));
             }
 
-            if (commandMethod.requiredSender() != Object.class) {
-                builder = builder.senderType(commandMethod.requiredSender());
+            if (commandDescriptor.requiredSender() != Object.class) {
+                builder = builder.senderType(commandDescriptor.requiredSender());
             } else if (senderType != null) {
                 builder = builder.senderType(senderType);
             }
@@ -625,6 +728,8 @@ public final class AnnotationParser<C> {
                         new MethodCommandExecutionHandler.CommandMethodContext<>(
                                 instance,
                                 commandComponents,
+                                arguments,
+                                flagDescriptors,
                                 method,
                                 this /* annotationParser */
                         );
@@ -705,16 +810,16 @@ public final class AnnotationParser<C> {
     private @NonNull CommandComponent<C> buildComponent(
             final @NonNull Method method,
             final @Nullable SyntaxFragment syntaxFragment,
-            final @NonNull ArgumentParameterPair argumentPair
+            final @NonNull ArgumentDescriptor argumentDescriptor
     ) {
-        final Parameter parameter = argumentPair.getParameter();
+        final Parameter parameter = argumentDescriptor.parameter();
         final Collection<Annotation> annotations = Arrays.asList(parameter.getAnnotations());
         final TypeToken<?> token = TypeToken.get(parameter.getParameterizedType());
         final ParserParameters parameters = this.manager.parserRegistry()
                 .parseAnnotations(token, annotations);
         /* Create the argument parser */
         final ArgumentParser<C, ?> parser;
-        if (argumentPair.getArgument().parserName().isEmpty()) {
+        if (argumentDescriptor.parserName() == null) {
             parser = this.manager.parserRegistry()
                     .createParser(token, parameters)
                     .orElseThrow(() -> new IllegalArgumentException(
@@ -726,7 +831,7 @@ public final class AnnotationParser<C> {
                             )));
         } else {
             parser = this.manager.parserRegistry()
-                    .createParser(this.processString(argumentPair.getArgument().parserName()), parameters)
+                    .createParser(this.processString(argumentDescriptor.parserName()), parameters)
                     .orElseThrow(() -> new IllegalArgumentException(
                             String.format("Parameter '%s' in method '%s' "
                                             + "has parser '%s' but no parser exists "
@@ -735,14 +840,13 @@ public final class AnnotationParser<C> {
                                     token.getType().getTypeName()
                             )));
         }
-        /* Check whether or not the corresponding method parameter actually exists */
-        final String argumentName = this.processString(argumentPair.argumentName());
+        /* Check whether the corresponding method parameter actually exists */
+        final String argumentName = this.processString(argumentDescriptor.name());
         if (syntaxFragment == null || syntaxFragment.getArgumentMode() == ArgumentMode.LITERAL) {
             throw new IllegalArgumentException(String.format(
                     "Invalid command argument '%s' in method '%s': "
                             + "Missing syntax mapping", argumentName, method.getName()));
         }
-        final Argument argument = argumentPair.getArgument();
         /* Create the argument builder */
         @SuppressWarnings("rawtypes") final CommandArgument.Builder argumentBuilder = CommandArgument.ofType(
                 parameter.getType(),
@@ -755,8 +859,8 @@ public final class AnnotationParser<C> {
                     completions.value().replace(" ", "").split(",")
             ).map(Suggestion::simple).collect(Collectors.toList());
             argumentBuilder.withSuggestionProvider((commandContext, input) -> suggestions);
-        } else if (!argument.suggestions().isEmpty()) { /* Check whether a suggestion provider should be set */
-            final String suggestionProviderName = this.processString(argument.suggestions());
+        } else if (argumentDescriptor.suggestions() != null) {
+            final String suggestionProviderName = this.processString(argumentDescriptor.suggestions());
             final Optional<SuggestionProvider<C>> suggestionsFunction =
                     this.manager.parserRegistry().getSuggestionProvider(suggestionProviderName);
             argumentBuilder.withSuggestionProvider(
@@ -781,13 +885,19 @@ public final class AnnotationParser<C> {
             }
         }
 
-        final ArgumentDescription description = ArgumentDescription.of(this.processString(argumentPair.getArgument().description()));
+        final ArgumentDescription description;
+        if (argumentDescriptor.description() == null) {
+            description = ArgumentDescription.empty();
+        } else {
+            description = argumentDescriptor.description();
+        }
+
         if (syntaxFragment.getArgumentMode() == ArgumentMode.REQUIRED) {
             return CommandComponent.required(builtArgument, description);
-        } else if (argument.defaultValue().isEmpty()) {
+        } else if (argumentDescriptor.defaultValue() == null) {
             return CommandComponent.optional(builtArgument, description);
         } else {
-            return CommandComponent.optional(builtArgument, description, this.processString(argument.defaultValue()));
+            return CommandComponent.optional(builtArgument, description, this.processString(argumentDescriptor.defaultValue()));
         }
     }
 

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/ArgumentDescriptor.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/ArgumentDescriptor.java
@@ -1,0 +1,282 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.annotations;
+
+import cloud.commandframework.ArgumentDescription;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
+import java.lang.reflect.Parameter;
+import java.util.Objects;
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+@API(status = API.Status.STABLE, since = "2.0.0")
+public final class ArgumentDescriptor {
+
+    private final Parameter parameter;
+    private final String name;
+    private final String parserName;
+    private final String suggestions;
+    private final String defaultValue;
+    private final ArgumentDescription description;
+
+    /**
+     * Creates a new builder.
+     *
+     * @return the created builder
+     */
+    public static @NonNull Builder builder() {
+        return new Builder();
+    }
+
+    private ArgumentDescriptor(
+            final @NonNull Parameter parameter,
+            final @NonNull String name,
+            final @Nullable String parserName,
+            final @Nullable String suggestions,
+            final @Nullable String defaultValue,
+            final @Nullable ArgumentDescription description
+    ) {
+        this.parameter = parameter;
+        this.name = name;
+        this.parserName = parserName;
+        this.suggestions = suggestions;
+        this.defaultValue = defaultValue;
+        this.description = description;
+    }
+
+    /**
+     * Returns the parameter.
+     *
+     * @return the parameter
+     */
+    public @NonNull Parameter parameter() {
+        return this.parameter;
+    }
+
+    /**
+     * Returns the argument name
+     *
+     * @return the argument name
+     */
+    public @NonNull String name() {
+        if (this.name.equals(AnnotationParser.INFERRED_ARGUMENT_NAME)) {
+            return this.parameter.getName();
+        }
+        return this.name;
+    }
+
+    /**
+     * Returns the name of the parser to use. If {@code null} the default parser for the parameter type will be used.
+     *
+     * @return the parser name, or {@code null}
+     */
+    public @Nullable String parserName() {
+        return this.parserName;
+    }
+
+    /**
+     * Returns the name of the suggestion provider to use. If the string is {@code null}, the default
+     * provider for the argument parser will be used. Otherwise,
+     * the {@link cloud.commandframework.arguments.parser.ParserRegistry} instance in the
+     * {@link cloud.commandframework.CommandManager} will be queried for a matching suggestion provider.
+     * <p>
+     * For this to work, the suggestion needs to be registered in the parser registry. To do this, use
+     * {@link cloud.commandframework.arguments.parser.ParserRegistry#registerSuggestionProvider(String, SuggestionProvider)}.
+     * The registry instance can be retrieved using {@link cloud.commandframework.CommandManager#parserRegistry()}.
+     *
+     * @return the name of the suggestion provider, or {@code null}
+     */
+    public @Nullable String suggestions() {
+        return this.suggestions;
+    }
+
+    /**
+     * Returns the default value.
+     *
+     * @return the default value, or {@code null}
+     */
+    public @Nullable String defaultValue() {
+        return this.defaultValue;
+    }
+
+    /**
+     * Returns the description of the argument.
+     *
+     * @return the argument description, or {@code null}
+     */
+    public @Nullable ArgumentDescription description() {
+        return this.description;
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        ArgumentDescriptor that = (ArgumentDescriptor) object;
+        return Objects.equals(this.parameter, that.parameter)
+                && Objects.equals(this.name, that.name)
+                && Objects.equals(this.parserName, that.parserName)
+                && Objects.equals(this.suggestions, that.suggestions)
+                && Objects.equals(this.defaultValue, that.defaultValue)
+                && Objects.equals(this.description, that.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.parameter, this.name, this.parserName, this.suggestions, this.defaultValue, this.description);
+    }
+
+
+    public static final class Builder {
+
+        private final Parameter parameter;
+        private final String name;
+        private final String parserName;
+        private final String suggestions;
+        private final String defaultValue;
+        private final ArgumentDescription description;
+
+        private Builder(
+                final @Nullable Parameter parameter,
+                final @Nullable String name,
+                final @Nullable String parserName,
+                final @Nullable String suggestions,
+                final @Nullable String defaultValue,
+                final @Nullable ArgumentDescription description
+        ) {
+            this.parameter = parameter;
+            this.name = name;
+            this.parserName = parserName;
+            this.suggestions = suggestions;
+            this.defaultValue = defaultValue;
+            this.description = description;
+        }
+
+        private Builder() {
+            this(null, null, null, null, null, null);
+        }
+
+        /**
+         * Returns an updated builder with the given {@code parameter}.
+         *
+         * @param parameter the new parameter
+         * @return the builder containing the updated parameter
+         */
+        public @NonNull Builder parameter(final @NonNull Parameter parameter) {
+            return new Builder(parameter, this.name, this.parserName, this.suggestions, this.defaultValue, this.description);
+        }
+
+        /**
+         * Returns an updated builder with the given {@code name}.
+         * <p>
+         * This can be set to {@link AnnotationParser#INFERRED_ARGUMENT_NAME} to infer the argument name
+         * from the parameter name.
+         *
+         * @param name the new name
+         * @return the builder containing the updated name
+         */
+        public @NonNull Builder name(final @NonNull String name) {
+            return new Builder(this.parameter, name, this.parserName, this.suggestions, this.defaultValue, this.description);
+        }
+
+        /**
+         * Returns an updated builder with the given {@code parserName}.
+         *
+         * @param parserName the new parserName
+         * @return the builder containing the updated parserName
+         */
+        public @NonNull Builder parserName(final @Nullable String parserName) {
+            final String nullableName;
+            if (parserName != null && parserName.isEmpty()) {
+                nullableName = null;
+            } else {
+                nullableName = parserName;
+            }
+            return new Builder(this.parameter, this.name, nullableName, this.suggestions, this.defaultValue, this.description);
+        }
+
+        /**
+         * Returns an updated builder with the given {@code suggestions}.
+         *
+         * @param suggestions the new suggestions
+         * @return the builder containing the updated suggestions
+         */
+        public @NonNull Builder suggestions(final @Nullable String suggestions) {
+            final String nullableName;
+            if (suggestions != null && suggestions.isEmpty()) {
+                nullableName = null;
+            } else {
+                nullableName = suggestions;
+            }
+            return new Builder(this.parameter, this.name, this.parserName, nullableName, this.defaultValue, this.description);
+        }
+
+        /**
+         * Returns an updated builder with the given {@code defaultValue}.
+         *
+         * @param defaultValue the new default value
+         * @return the builder containing the updated default value
+         */
+        public @NonNull Builder defaultValue(final @Nullable String defaultValue) {
+            final String nullableName;
+            if (defaultValue != null && defaultValue.isEmpty()) {
+                nullableName = null;
+            } else {
+                nullableName = defaultValue;
+            }
+            return new Builder(this.parameter, this.name, this.parserName, this.suggestions, nullableName, this.description);
+        }
+
+        /**
+         * Returns an updated builder with the given {@code description}.
+         *
+         * @param description the new description
+         * @return the builder containing the updated description
+         */
+        public @NonNull Builder description(final @Nullable ArgumentDescription description) {
+            return new Builder(this.parameter, this.name, this.parserName, this.suggestions, this.defaultValue, description);
+        }
+
+        /**
+         * Returns the build argument descriptor.
+         *
+         * @return the argument descriptor
+         */
+        public @NonNull ArgumentDescriptor build() {
+            return new ArgumentDescriptor(
+                    Objects.requireNonNull(this.parameter, "parameter"),
+                    Objects.requireNonNull(this.name, "name"),
+                    this.parserName,
+                    this.suggestions,
+                    this.defaultValue,
+                    this.description
+            );
+        }
+    }
+}

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/ArgumentExtractorImpl.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/ArgumentExtractorImpl.java
@@ -1,0 +1,71 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.annotations;
+
+import cloud.commandframework.ArgumentDescription;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Utility that extract {@link Argument arguments} from
+ * {@link java.lang.reflect.Method method} {@link java.lang.reflect.Parameter parameters}
+ */
+class ArgumentExtractorImpl implements ArgumentExtractor {
+
+    private final Function<@NonNull Argument, @Nullable ArgumentDescription> descriptionMapper;
+
+    ArgumentExtractorImpl() {
+        this.descriptionMapper = argument -> ArgumentDescription.of(argument.description());
+    }
+
+    @Override
+    public @NonNull Collection<@NonNull ArgumentDescriptor> extractArguments(
+            final @NonNull List<@NonNull SyntaxFragment> syntax,
+            final @NonNull Method method
+    ) {
+        final Collection<ArgumentDescriptor> arguments = new ArrayList<>();
+        for (final Parameter parameter : method.getParameters()) {
+            if (!parameter.isAnnotationPresent(Argument.class)) {
+                continue;
+            }
+            final Argument argument = parameter.getAnnotation(Argument.class);
+            final ArgumentDescriptor argumentDescriptor = ArgumentDescriptor.builder()
+                    .parameter(parameter)
+                    .name(argument.value())
+                    .parserName(argument.parserName())
+                    .defaultValue(argument.defaultValue())
+                    .description(this.descriptionMapper.apply(argument))
+                    .suggestions(argument.suggestions())
+                    .build();
+            arguments.add(argumentDescriptor);
+        }
+        return arguments;
+    }
+}

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/CommandDescriptor.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/CommandDescriptor.java
@@ -1,0 +1,95 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.annotations;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+@API(status = API.Status.STABLE, since = "2.0.0")
+public final class CommandDescriptor {
+
+    private final Method method;
+    private final List<@NonNull SyntaxFragment> syntax;
+    private final String commandToken;
+    private final Class<?> requiredSender;
+
+    /**
+     * Creates a new command descriptor.
+     *
+     * @param method         the command method
+     * @param syntax         the command syntax
+     * @param commandToken   the root command name
+     * @param requiredSender the required sender type
+     */
+    public CommandDescriptor(
+            final @NonNull Method method,
+            final @NonNull List<@NonNull SyntaxFragment> syntax,
+            final @NonNull String commandToken,
+            final @NonNull Class<?> requiredSender
+    ) {
+        this.method = method;
+        this.syntax = syntax;
+        this.commandToken = commandToken;
+        this.requiredSender = requiredSender;
+    }
+
+    /**
+     * Returns the command method.
+     *
+     * @return the command method
+     */
+    public @NonNull Method method() {
+        return this.method;
+    }
+
+    /**
+     * Returns an unmodifiable view of the syntax fragments.
+     *
+     * @return the syntax fragments
+     */
+    public @NonNull List<@NonNull SyntaxFragment> syntax() {
+        return Collections.unmodifiableList(this.syntax);
+    }
+
+    /**
+     * Returns the root command name.
+     *
+     * @return the name of the root command
+     */
+    public @NonNull String commandToken() {
+        return this.commandToken;
+    }
+
+    /**
+     * Returns the required sender type.
+     *
+     * @return the required sender type
+     */
+    public @NonNull Class<?> requiredSender() {
+        return this.requiredSender;
+    }
+}

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/CommandExtractor.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/CommandExtractor.java
@@ -23,35 +23,21 @@
 //
 package cloud.commandframework.annotations;
 
-import java.lang.reflect.Parameter;
+import java.util.Collection;
+import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-final class ArgumentParameterPair {
+/**
+ * Extracts {@link CommandDescriptor command descriptors} from command class instances.
+ */
+@API(status = API.Status.STABLE, since = "2.0.0")
+public interface CommandExtractor {
 
-    private final Parameter parameter;
-    private final Argument argument;
-
-    ArgumentParameterPair(
-            final @NonNull Parameter parameter,
-            final @NonNull Argument argument
-    ) {
-        this.parameter = parameter;
-        this.argument = argument;
-    }
-
-    @NonNull Parameter getParameter() {
-        return this.parameter;
-    }
-
-    @NonNull Argument getArgument() {
-        return this.argument;
-    }
-
-    @NonNull String argumentName() {
-        if (this.argument.value().equals(AnnotationParser.INFERRED_ARGUMENT_NAME)) {
-            return this.parameter.getName();
-        } else {
-            return this.argument.value();
-        }
-    }
+    /**
+     * Extracts the commands from the given {@code instance}.
+     *
+     * @param instance the class instance
+     * @return the extracted commands
+     */
+    @NonNull Collection<@NonNull CommandDescriptor> extractCommands(@NonNull Object instance);
 }

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/CommandExtractorImpl.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/CommandExtractorImpl.java
@@ -1,0 +1,80 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.annotations;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collection;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+final class CommandExtractorImpl implements CommandExtractor {
+
+    private final AnnotationParser<?> annotationParser;
+
+    CommandExtractorImpl(final @NonNull AnnotationParser<?> annotationParser) {
+        this.annotationParser = annotationParser;
+    }
+
+    @Override
+    public @NonNull Collection<@NonNull CommandDescriptor> extractCommands(final @NonNull Object instance) {
+        final AnnotationAccessor classAnnotations = AnnotationAccessor.of(instance.getClass());
+        final CommandMethod classCommandMethod = classAnnotations.annotation(CommandMethod.class);
+
+        final String syntaxPrefix;
+        if (classCommandMethod == null) {
+            syntaxPrefix = "";
+        } else {
+            syntaxPrefix = this.annotationParser.processString(classCommandMethod.value()) + " ";
+        }
+
+        final Method[] methods = instance.getClass().getDeclaredMethods();
+        final Collection<CommandDescriptor> commandDescriptors = new ArrayList<>();
+        for (final Method method : methods) {
+            final CommandMethod commandMethod = method.getAnnotation(CommandMethod.class);
+            if (commandMethod == null) {
+                continue;
+            }
+            if (!method.isAccessible()) {
+                method.setAccessible(true);
+            }
+            if (Modifier.isStatic(method.getModifiers())) {
+                throw new IllegalArgumentException(String.format(
+                        "@CommandMethod annotated method '%s' is static! @CommandMethod annotated methods should not be static.",
+                        method.getName()
+                ));
+            }
+            final String syntax = syntaxPrefix + this.annotationParser.processString(commandMethod.value());
+            commandDescriptors.add(
+                    new CommandDescriptor(
+                            method,
+                            this.annotationParser.syntaxParser().parseSyntax(method, syntax),
+                            syntax.split(" ")[0].split("\\|")[0],
+                            commandMethod.requiredSender()
+                    )
+            );
+        }
+        return commandDescriptors;
+    }
+}

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagAssembler.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagAssembler.java
@@ -23,29 +23,23 @@
 //
 package cloud.commandframework.annotations;
 
-import java.lang.reflect.Method;
-import java.util.Collection;
-import java.util.List;
+import cloud.commandframework.arguments.flags.CommandFlag;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
- * Extracts {@link ArgumentDescriptor argument descriptors} from {@link Method methods}.
+ * Assembles {@link CommandFlag flags} from {@link FlagDescriptor flag descriptors}.
  *
  * @since 2.0.0
  */
 @API(status = API.Status.STABLE, since = "2.0.0")
-public interface ArgumentExtractor {
+public interface FlagAssembler {
 
     /**
-     * Extracts the arguments from the given {@code method}.
+     * Assembles a flag from the given {@code descriptor}.
      *
-     * @param syntax the syntax of the command
-     * @param method the method
-     * @return the extracted arguments
+     * @param descriptor the descriptor
+     * @return the assembled flag
      */
-    @NonNull Collection<@NonNull ArgumentDescriptor> extractArguments(
-            @NonNull List<@NonNull SyntaxFragment> syntax,
-            @NonNull Method method
-    );
+    @NonNull CommandFlag<?> assembleFlag(@NonNull FlagDescriptor descriptor);
 }

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagAssemblerImpl.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagAssemblerImpl.java
@@ -1,0 +1,133 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.annotations;
+
+import cloud.commandframework.ArgumentDescription;
+import cloud.commandframework.CommandManager;
+import cloud.commandframework.arguments.CommandArgument;
+import cloud.commandframework.arguments.flags.CommandFlag;
+import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.parser.ParserRegistry;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
+import cloud.commandframework.permission.CommandPermission;
+import cloud.commandframework.permission.Permission;
+import io.leangen.geantyref.GenericTypeReflector;
+import io.leangen.geantyref.TypeToken;
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Collection;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+final class FlagAssemblerImpl implements FlagAssembler {
+
+    private final CommandManager<?> commandManager;
+
+    FlagAssemblerImpl(final @NonNull CommandManager<?> commandManager) {
+        this.commandManager = commandManager;
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public @NonNull CommandFlag<?> assembleFlag(@NonNull final FlagDescriptor descriptor) {
+        final ArgumentDescription description;
+        if (descriptor.description() == null) {
+            description = ArgumentDescription.empty();
+        } else {
+            description = descriptor.description();
+        }
+
+        final CommandPermission permission;
+        if (descriptor.permission() == null) {
+            permission = Permission.empty();
+        } else {
+            permission = descriptor.permission();
+        }
+
+        CommandFlag.Builder<Void> builder = this.commandManager
+                .flagBuilder(descriptor.name())
+                .withDescription(description)
+                .withAliases(descriptor.aliases())
+                .withPermission(permission);
+        if (descriptor.repeatable()) {
+            builder = builder.asRepeatable();
+        }
+
+        if (descriptor.parameter().getType().equals(boolean.class)) {
+            return builder.build();
+        }
+
+        final TypeToken<?> token;
+        if (descriptor.repeatable() && Collection.class.isAssignableFrom(descriptor.parameter().getType())) {
+            token = TypeToken.get(GenericTypeReflector.getTypeParameter(
+                    descriptor.parameter().getParameterizedType(),
+                    Collection.class.getTypeParameters()[0]
+            ));
+        } else {
+            token = TypeToken.get(descriptor.parameter().getType());
+        }
+
+        if (token.equals(TypeToken.get(boolean.class))) {
+            return builder.build();
+        }
+
+        final Collection<Annotation> annotations = Arrays.asList(descriptor.parameter().getAnnotations());
+        final ParserRegistry<?> registry = this.commandManager.parserRegistry();
+        final ArgumentParser<?, ?> parser;
+        if (descriptor.parserName() == null) {
+            parser = registry.createParser(token, registry.parseAnnotations(token, annotations))
+                    .orElse(null);
+        } else {
+            parser = registry.createParser(descriptor.parserName(), registry.parseAnnotations(token, annotations))
+                    .orElse(null);
+        }
+        if (parser == null) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Cannot find parser for type '%s' for flag '%s'",
+                            descriptor.parameter().getType().getCanonicalName(),
+                            descriptor.name()
+                    ));
+        }
+        final SuggestionProvider<?> suggestionProvider;
+        if (descriptor.suggestions() != null) {
+            suggestionProvider = registry.getSuggestionProvider(descriptor.suggestions()).orElse(null);
+        } else {
+            suggestionProvider = null;
+        }
+        final CommandArgument.Builder argumentBuilder0 = CommandArgument.ofType(
+                descriptor.parameter().getType(),
+                descriptor.name()
+        );
+        final CommandArgument.Builder argumentBuilder = argumentBuilder0
+                .manager(this.commandManager)
+                .withParser(parser);
+        final CommandArgument argument;
+        if (suggestionProvider != null) {
+            argument = argumentBuilder.withSuggestionProvider(suggestionProvider).build();
+        } else {
+            argument = argumentBuilder.build();
+        }
+        return builder.withArgument(argument).build();
+    }
+}

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagDescriptor.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagDescriptor.java
@@ -1,0 +1,417 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.annotations;
+
+import cloud.commandframework.ArgumentDescription;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
+import cloud.commandframework.permission.CommandPermission;
+import java.lang.reflect.Parameter;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+@API(status = API.Status.STABLE, since = "2.0.0")
+public final class FlagDescriptor {
+
+    private final Parameter parameter;
+    private final String name;
+    private final Set<@NonNull String> aliases;
+    private final String parserName;
+    private final String suggestions;
+    private final CommandPermission permission;
+    private final ArgumentDescription description;
+    private final boolean repeatable;
+
+    /**
+     * Creates a new builder.
+     *
+     * @return the created builder
+     */
+    public static @NonNull Builder builder() {
+        return new Builder();
+    }
+
+    private FlagDescriptor(
+            final @NonNull Parameter parameter,
+            final @NonNull String name,
+            final @NonNull Collection<@NonNull String> aliases,
+            final @Nullable String parserName,
+            final @Nullable String suggestions,
+            final @Nullable CommandPermission permission,
+            final @Nullable ArgumentDescription description,
+            final boolean repeatable
+    ) {
+        this.parameter = parameter;
+        this.name = name;
+        this.aliases = Collections.unmodifiableSet(new HashSet<>(aliases));
+        this.parserName = parserName;
+        this.suggestions = suggestions;
+        this.permission = permission;
+        this.description = description;
+        this.repeatable = repeatable;
+    }
+
+    /**
+     * Returns the parameter.
+     *
+     * @return the parameter
+     */
+    public @NonNull Parameter parameter() {
+        return this.parameter;
+    }
+
+    /**
+     * Returns the flag name.
+     *
+     * @return the flag name
+     */
+    public @NonNull String name() {
+        if (this.name.equals(AnnotationParser.INFERRED_ARGUMENT_NAME)) {
+            return this.parameter.getName();
+        }
+        return this.name;
+    }
+
+    /**
+     * Returns an unmodifiable view of the flag aliases.
+     *
+     * @return the flag aliases
+     */
+    public @NonNull Collection<@NonNull String> aliases() {
+        return this.aliases;
+    }
+
+    /**
+     * Returns the name of the parser to use. If {@code null} the default parser for the parameter type will be used.
+     *
+     * @return the parser name, or {@code null}
+     */
+    public @Nullable String parserName() {
+        return this.parserName;
+    }
+
+    /**
+     * Returns the name of the suggestion provider to use. If the string is {@code null}, the default
+     * provider for the argument parser will be used. Otherwise,
+     * the {@link cloud.commandframework.arguments.parser.ParserRegistry} instance in the
+     * {@link cloud.commandframework.CommandManager} will be queried for a matching suggestion provider.
+     * <p>
+     * For this to work, the suggestion needs to be registered in the parser registry. To do this, use
+     * {@link cloud.commandframework.arguments.parser.ParserRegistry#registerSuggestionProvider(String, SuggestionProvider)}.
+     * The registry instance can be retrieved using {@link cloud.commandframework.CommandManager#parserRegistry()}.
+     *
+     * @return the name of the suggestion provider, or {@code null}
+     */
+    public @Nullable String suggestions() {
+        return this.suggestions;
+    }
+
+    /**
+     * Returns the permission of the flag.
+     *
+     * @return the flag permission, or {@code null}
+     */
+    public @Nullable CommandPermission permission() {
+        return this.permission;
+    }
+
+    /**
+     * Returns the description of the flag.
+     *
+     * @return the flag description, or {@code null}
+     */
+    public @Nullable ArgumentDescription description() {
+        return this.description;
+    }
+
+    /**
+     * Returns whether the flag is repeatable.
+     *
+     * @return whether the flag is repeatable
+     */
+    public boolean repeatable() {
+        return this.repeatable;
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        FlagDescriptor that = (FlagDescriptor) object;
+        return Objects.equals(this.parameter, that.parameter)
+                && Objects.equals(this.name, that.name)
+                && Objects.equals(this.aliases, that.aliases)
+                && Objects.equals(this.parserName, that.parserName)
+                && Objects.equals(this.suggestions, that.suggestions)
+                && Objects.equals(this.permission, that.permission)
+                && Objects.equals(this.description, that.description)
+                && this.repeatable == that.repeatable;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                this.parameter,
+                this.name,
+                this.aliases,
+                this.parserName,
+                this.suggestions,
+                this.permission,
+                this.description,
+                this.repeatable
+        );
+    }
+
+
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    public static final class Builder {
+
+        private final Parameter parameter;
+        private final String name;
+        private final Collection<String> aliases;
+        private final String parserName;
+        private final String suggestions;
+        private final CommandPermission permission;
+        private final ArgumentDescription description;
+        private final boolean repeatable;
+
+        private Builder(
+                final @Nullable Parameter parameter,
+                final @Nullable String name,
+                final @NonNull Collection<String> aliases,
+                final @Nullable String parserName,
+                final @Nullable String suggestions,
+                final @Nullable CommandPermission permission,
+                final @Nullable ArgumentDescription description,
+                final boolean repeatable
+        ) {
+            this.parameter = parameter;
+            this.name = name;
+            this.aliases = aliases;
+            this.parserName = parserName;
+            this.suggestions = suggestions;
+            this.permission = permission;
+            this.description = description;
+            this.repeatable = repeatable;
+        }
+
+        private Builder() {
+            this(null, null, Collections.emptySet(), null, null, null, null, false);
+        }
+
+        /**
+         * Returns an updated builder with the given {@code parameter}.
+         *
+         * @param parameter the new parameter
+         * @return the builder containing the updated parameter
+         */
+        public @NonNull Builder parameter(final @NonNull Parameter parameter) {
+            return new Builder(
+                    parameter,
+                    this.name,
+                    this.aliases,
+                    this.parserName,
+                    this.suggestions,
+                    this.permission,
+                    this.description,
+                    this.repeatable
+            );
+        }
+
+        /**
+         * Returns an updated builder with the given {@code name}.
+         * <p>
+         * This can be set to {@link AnnotationParser#INFERRED_ARGUMENT_NAME} to infer the flag name
+         * from the parameter name.
+         *
+         * @param name the new name
+         * @return the builder containing the updated name
+         */
+        public @NonNull Builder name(final @NonNull String name) {
+            return new Builder(
+                    this.parameter,
+                    name,
+                    this.aliases,
+                    this.parserName,
+                    this.suggestions,
+                    this.permission,
+                    this.description,
+                    this.repeatable
+            );
+        }
+
+        /**
+         * Returns an updated builder with the given {@code aliases}.
+         *
+         * @param aliases the new aliases
+         * @return the builder containing the updated aliases
+         */
+        public @NonNull Builder aliases(final @NonNull Collection<@NonNull String> aliases) {
+            return new Builder(
+                    this.parameter,
+                    this.name,
+                    aliases,
+                    this.parserName,
+                    this.suggestions,
+                    this.permission,
+                    this.description,
+                    this.repeatable
+            );
+        }
+
+        /**
+         * Returns an updated builder with the given {@code parserName}.
+         *
+         * @param parserName the new parserName
+         * @return the builder containing the updated parserName
+         */
+        public @NonNull Builder parserName(final @Nullable String parserName) {
+            final String nullableName;
+            if (parserName != null && parserName.isEmpty()) {
+                nullableName = null;
+            } else {
+                nullableName = parserName;
+            }
+            return new Builder(
+                    this.parameter,
+                    this.name,
+                    this.aliases,
+                    nullableName,
+                    this.suggestions,
+                    this.permission,
+                    this.description,
+                    this.repeatable
+            );
+        }
+
+        /**
+         * Returns an updated builder with the given {@code suggestions}.
+         *
+         * @param suggestions the new suggestions
+         * @return the builder containing the updated suggestions
+         */
+        public @NonNull Builder suggestions(final @Nullable String suggestions) {
+            final String nullableName;
+            if (suggestions != null && suggestions.isEmpty()) {
+                nullableName = null;
+            } else {
+                nullableName = suggestions;
+            }
+            return new Builder(
+                    this.parameter,
+                    this.name,
+                    this.aliases,
+                    this.parserName,
+                    nullableName,
+                    this.permission,
+                    this.description,
+                    this.repeatable
+            );
+        }
+
+        /**
+         * Returns an updated builder with the given {@code permission}.
+         *
+         * @param permission the new permission
+         * @return the builder containing the updated permission
+         */
+        public @NonNull Builder permission(final @Nullable CommandPermission permission) {
+            return new Builder(
+                    this.parameter,
+                    this.name,
+                    this.aliases,
+                    this.parserName,
+                    this.suggestions,
+                    permission,
+                    this.description,
+                    this.repeatable
+            );
+        }
+
+        /**
+         * Returns an updated builder with the given {@code description}.
+         *
+         * @param description the new description
+         * @return the builder containing the updated description
+         */
+        public @NonNull Builder description(final @Nullable ArgumentDescription description) {
+            return new Builder(
+                    this.parameter,
+                    this.name,
+                    this.aliases,
+                    this.parserName,
+                    this.suggestions,
+                    this.permission,
+                    description,
+                    this.repeatable
+            );
+        }
+
+        /**
+         * Returns an updated builder with the given {@code repeatable} value.
+         *
+         * @param repeatable whether the flag is repeatable
+         * @return the builder containing the updated repeatable value
+         */
+        public @NonNull Builder repeatable(final boolean repeatable) {
+            return new Builder(
+                    this.parameter,
+                    this.name,
+                    this.aliases,
+                    this.parserName,
+                    this.suggestions,
+                    this.permission,
+                    this.description,
+                    repeatable
+            );
+        }
+
+        /**
+         * Returns the built flag descriptor.
+         *
+         * @return the flag descriptor
+         */
+        public @NonNull FlagDescriptor build() {
+            return new FlagDescriptor(
+                    Objects.requireNonNull(this.parameter, "parameter"),
+                    Objects.requireNonNull(this.name, "name"),
+                    Objects.requireNonNull(this.aliases, "aliases"),
+                    this.parserName,
+                    this.suggestions,
+                    this.permission,
+                    this.description,
+                    this.repeatable
+            );
+        }
+    }
+}

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagExtractorImpl.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagExtractorImpl.java
@@ -1,0 +1,67 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.annotations;
+
+import cloud.commandframework.ArgumentDescription;
+import cloud.commandframework.permission.Permission;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+final class FlagExtractorImpl implements FlagExtractor {
+
+    private final AnnotationParser<?> annotationParser;
+
+    FlagExtractorImpl(final @NonNull AnnotationParser<?> annotationParser) {
+        this.annotationParser = annotationParser;
+    }
+
+    @Override
+    public @NonNull Collection<@NonNull FlagDescriptor> extractFlags(final @NonNull Method method) {
+        final Collection<FlagDescriptor> flags = new LinkedList<>();
+        for (final Parameter parameter : method.getParameters()) {
+            if (!parameter.isAnnotationPresent(Flag.class)) {
+                continue;
+            }
+            final Flag flag = parameter.getAnnotation(Flag.class);
+            final String flagName = this.annotationParser.processString(flag.value());
+
+            final FlagDescriptor flagDescriptor = FlagDescriptor.builder()
+                    .parameter(parameter)
+                    .name(flagName)
+                    .description(ArgumentDescription.of(this.annotationParser.processString(flag.description())))
+                    .aliases(this.annotationParser.processStrings(Arrays.asList(flag.aliases())))
+                    .permission(Permission.of(this.annotationParser.processString(flag.permission())))
+                    .repeatable(flag.repeatable())
+                    .parserName(this.annotationParser.processString(flag.parserName()))
+                    .suggestions(this.annotationParser.processString(flag.suggestions()))
+                    .build();
+            flags.add(flagDescriptor);
+        }
+        return flags;
+    }
+}

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/SyntaxFragment.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/SyntaxFragment.java
@@ -24,18 +24,29 @@
 package cloud.commandframework.annotations;
 
 import java.util.List;
+import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
- * Public since 1.7.0.
+ * Represents the fragment of the syntax making up a command.
+ *
+ * @since 1.7.0
  */
+@API(status = API.Status.STABLE, since = "1.7.0")
 public final class SyntaxFragment {
 
     private final String major;
     private final List<String> minor;
     private final ArgumentMode argumentMode;
 
-    SyntaxFragment(
+    /**
+     * Creates a new syntax fragment
+     *
+     * @param major        the major portion of the fragment
+     * @param minor        the minor portions of the fragment
+     * @param argumentMode the argument mode of the fragment
+     */
+    public SyntaxFragment(
             final @NonNull String major,
             final @NonNull List<@NonNull String> minor,
             final @NonNull ArgumentMode argumentMode

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/SyntaxParser.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/SyntaxParser.java
@@ -23,55 +23,26 @@
 //
 package cloud.commandframework.annotations;
 
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.lang.reflect.Method;
 import java.util.List;
-import java.util.StringTokenizer;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.regex.Pattern;
+import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * Parses command syntax into syntax fragments.
- * <p>
- * Public since 1.7.0.
+ * Parser that produces {@link SyntaxFragment syntax fragments} from command methods.
+ *
+ * @since 2.0.0
  */
-public final class SyntaxParser implements Function<@NonNull String, @NonNull List<@NonNull SyntaxFragment>> {
+@API(status = API.Status.STABLE, since = "2.0.0")
+public interface SyntaxParser {
 
-    private static final Predicate<String> PATTERN_ARGUMENT_LITERAL = Pattern.compile("([A-Za-z0-9\\-_]+)(|([A-Za-z0-9\\-_]+))*")
-            .asPredicate();
-    private static final Predicate<String> PATTERN_ARGUMENT_REQUIRED = Pattern.compile("<([A-Za-z0-9\\-_]+)>")
-            .asPredicate();
-    private static final Predicate<String> PATTERN_ARGUMENT_OPTIONAL = Pattern.compile("\\[([A-Za-z0-9\\-_]+)]")
-            .asPredicate();
-
-    @Override
-    public @NonNull List<@NonNull SyntaxFragment> apply(final @NonNull String syntax) {
-        final StringTokenizer stringTokenizer = new StringTokenizer(syntax, " ");
-        final List<SyntaxFragment> syntaxFragments = new ArrayList<>();
-        while (stringTokenizer.hasMoreTokens()) {
-            final String token = stringTokenizer.nextToken();
-            String major;
-            List<String> minor = new ArrayList<>();
-            ArgumentMode mode;
-            if (PATTERN_ARGUMENT_REQUIRED.test(token)) {
-                major = token.substring(1, token.length() - 1);
-                mode = ArgumentMode.REQUIRED;
-            } else if (PATTERN_ARGUMENT_OPTIONAL.test(token)) {
-                major = token.substring(1, token.length() - 1);
-                mode = ArgumentMode.OPTIONAL;
-            } else if (PATTERN_ARGUMENT_LITERAL.test(token)) {
-                final String[] literals = token.split("\\|");
-                /* Actually use the other literals as well */
-                major = literals[0];
-                minor.addAll(Arrays.asList(literals).subList(1, literals.length));
-                mode = ArgumentMode.LITERAL;
-            } else {
-                throw new IllegalArgumentException(String.format("Unrecognizable syntax token '%s'", syntax));
-            }
-            syntaxFragments.add(new SyntaxFragment(major, minor, mode));
-        }
-        return syntaxFragments;
-    }
+    /**
+     * Parses the given {@code string} into {@link SyntaxFragment syntax fragements}.
+     *
+     * @param method the method that the syntax is being parsed for, {@code null} if not method is available
+     * @param string the string to parsed
+     * @return the parsed fragments
+     */
+    @NonNull List<@NonNull SyntaxFragment> parseSyntax(@Nullable Method method, @NonNull String string);
 }

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/SyntaxParserImpl.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/SyntaxParserImpl.java
@@ -1,0 +1,78 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.annotations;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringTokenizer;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Parses command syntax into syntax fragments.
+ * <p>
+ * Public since 1.7.0.
+ */
+public final class SyntaxParserImpl implements SyntaxParser {
+
+    private static final Predicate<String> PATTERN_ARGUMENT_LITERAL = Pattern.compile("([A-Za-z0-9\\-_]+)(|([A-Za-z0-9\\-_]+))*")
+            .asPredicate();
+    private static final Predicate<String> PATTERN_ARGUMENT_REQUIRED = Pattern.compile("<([A-Za-z0-9\\-_]+)>")
+            .asPredicate();
+    private static final Predicate<String> PATTERN_ARGUMENT_OPTIONAL = Pattern.compile("\\[([A-Za-z0-9\\-_]+)]")
+            .asPredicate();
+
+    @Override
+    public @NonNull List<@NonNull SyntaxFragment> parseSyntax(final @Nullable Method method, final @NonNull String syntax) {
+        final StringTokenizer stringTokenizer = new StringTokenizer(syntax, " ");
+        final List<SyntaxFragment> syntaxFragments = new ArrayList<>();
+        while (stringTokenizer.hasMoreTokens()) {
+            final String token = stringTokenizer.nextToken();
+            String major;
+            List<String> minor = new ArrayList<>();
+            ArgumentMode mode;
+            if (PATTERN_ARGUMENT_REQUIRED.test(token)) {
+                major = token.substring(1, token.length() - 1);
+                mode = ArgumentMode.REQUIRED;
+            } else if (PATTERN_ARGUMENT_OPTIONAL.test(token)) {
+                major = token.substring(1, token.length() - 1);
+                mode = ArgumentMode.OPTIONAL;
+            } else if (PATTERN_ARGUMENT_LITERAL.test(token)) {
+                final String[] literals = token.split("\\|");
+                /* Actually use the other literals as well */
+                major = literals[0];
+                minor.addAll(Arrays.asList(literals).subList(1, literals.length));
+                mode = ArgumentMode.LITERAL;
+            } else {
+                throw new IllegalArgumentException(String.format("Unrecognizable syntax token '%s'", syntax));
+            }
+            syntaxFragments.add(new SyntaxFragment(major, minor, mode));
+        }
+        return syntaxFragments;
+    }
+}

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/processing/CommandMethodVisitor.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/processing/CommandMethodVisitor.java
@@ -27,7 +27,7 @@ import cloud.commandframework.annotations.Argument;
 import cloud.commandframework.annotations.ArgumentMode;
 import cloud.commandframework.annotations.CommandMethod;
 import cloud.commandframework.annotations.SyntaxFragment;
-import cloud.commandframework.annotations.SyntaxParser;
+import cloud.commandframework.annotations.SyntaxParserImpl;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -47,11 +47,11 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 class CommandMethodVisitor implements ElementVisitor<Void, Void> {
 
     private final ProcessingEnvironment processingEnvironment;
-    private final SyntaxParser syntaxParser;
+    private final SyntaxParserImpl syntaxParser;
 
     CommandMethodVisitor(final @NonNull ProcessingEnvironment processingEnvironment) {
         this.processingEnvironment = processingEnvironment;
-        this.syntaxParser = new SyntaxParser();
+        this.syntaxParser = new SyntaxParserImpl();
     }
 
     @Override
@@ -123,7 +123,7 @@ class CommandMethodVisitor implements ElementVisitor<Void, Void> {
                 .collect(Collectors.toList());
         final List<String> parsedArgumentNames = new ArrayList<>(parameterArgumentNames.size());
 
-        final List<SyntaxFragment> syntaxFragments = this.syntaxParser.apply(commandMethod.value());
+        final List<SyntaxFragment> syntaxFragments = this.syntaxParser.parseSyntax(null, commandMethod.value());
 
         boolean foundOptional = false;
         for (final SyntaxFragment fragment : syntaxFragments) {

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/SyntaxParserImplTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/SyntaxParserImplTest.java
@@ -30,15 +30,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests the correct functioning of the {@link SyntaxParser}, which parses
+ * Tests the correct functioning of the {@link SyntaxParserImpl}, which parses
  * command syntax into a List of {@link SyntaxFragment}
  */
-public class SyntaxParserTest {
+public class SyntaxParserImplTest {
 
     @Test
     void testParseWithAliases() {
-        List<SyntaxFragment> fragments = new SyntaxParser().apply(
-                "literal|litalias1|litalias2 <requirement> [optional]");
+        List<SyntaxFragment> fragments = new SyntaxParserImpl().parseSyntax(
+                null,
+                "literal|litalias1|litalias2 <requirement> [optional]"
+        );
 
         Assertions.assertEquals(3, fragments.size());
 
@@ -60,8 +62,10 @@ public class SyntaxParserTest {
 
     @Test
     void testParse() {
-        List<SyntaxFragment> fragments = new SyntaxParser().apply(
-                "literal <requirement> [optional]");
+        List<SyntaxFragment> fragments = new SyntaxParserImpl().parseSyntax(
+                null,
+                "literal <requirement> [optional]"
+        );
 
         Assertions.assertEquals(3, fragments.size());
 
@@ -83,8 +87,10 @@ public class SyntaxParserTest {
 
     @Test
     void testParseSpecialCharacters() {
-        List<SyntaxFragment> fragments = new SyntaxParser().apply(
-                "l_itera-l|with_ali-as <r_equiremen-t> [o_ptiona-l]");
+        List<SyntaxFragment> fragments = new SyntaxParserImpl().parseSyntax(
+                null,
+                "l_itera-l|with_ali-as <r_equiremen-t> [o_ptiona-l]"
+        );
 
         Assertions.assertEquals(3, fragments.size());
 

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/ArgumentDrivenCommandsTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/ArgumentDrivenCommandsTest.java
@@ -1,0 +1,193 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.annotations.feature;
+
+import cloud.commandframework.CommandManager;
+import cloud.commandframework.annotations.AnnotationParser;
+import cloud.commandframework.annotations.ArgumentDescriptor;
+import cloud.commandframework.annotations.ArgumentExtractor;
+import cloud.commandframework.annotations.ArgumentMode;
+import cloud.commandframework.annotations.CommandDescriptor;
+import cloud.commandframework.annotations.CommandExtractor;
+import cloud.commandframework.annotations.SyntaxFragment;
+import cloud.commandframework.annotations.SyntaxParser;
+import cloud.commandframework.annotations.TestCommandManager;
+import cloud.commandframework.annotations.TestCommandSender;
+import cloud.commandframework.meta.SimpleCommandMeta;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ArgumentDrivenCommandsTest {
+
+    private CommandManager<TestCommandSender> commandManager;
+    private AnnotationParser<TestCommandSender> annotationParser;
+
+
+    @BeforeEach
+    void setup() {
+        this.commandManager = new TestCommandManager();
+        this.annotationParser = new AnnotationParser<>(
+                this.commandManager,
+                TestCommandSender.class,
+                p -> SimpleCommandMeta.empty()
+        );
+    }
+
+    @Test
+    void testCommandConstruction() throws Exception {
+        // Arrange
+        this.annotationParser.argumentExtractor(new TestArgumentExtractor());
+        this.annotationParser.syntaxParser(new TestSyntaxParser());
+        this.annotationParser.commandExtractor(new TestCommandExtractor(this.annotationParser));
+        this.annotationParser.parse(new ArgumentDrivenCommandClass());
+
+        // Act
+        this.commandManager.executeCommand(new TestCommandSender(), "test 3 literal").get();
+    }
+
+    private static class TestArgumentExtractor implements ArgumentExtractor {
+        @Override
+        public @NonNull Collection<@NonNull ArgumentDescriptor> extractArguments(
+                final @NonNull List<@NonNull SyntaxFragment> syntax,
+                final @NonNull Method method
+        ) {
+            final Collection<ArgumentDescriptor> arguments = new ArrayList<>();
+            for (final Parameter parameter : method.getParameters()) {
+                if (!parameter.isAnnotationPresent(Argument.class)) {
+                    continue;
+                }
+                final Argument argument = parameter.getAnnotation(Argument.class);
+                if (argument.literal()) {
+                    continue;
+                }
+                final ArgumentDescriptor argumentDescriptor = ArgumentDescriptor.builder()
+                        .parameter(parameter)
+                        .name(AnnotationParser.INFERRED_ARGUMENT_NAME)
+                        .build();
+                arguments.add(argumentDescriptor);
+            }
+            return arguments;
+        }
+    }
+
+    private static class TestSyntaxParser implements SyntaxParser {
+
+        @Override
+        public @NonNull List<@NonNull SyntaxFragment> parseSyntax(final @Nullable Method method, final @NonNull String string) {
+            Objects.requireNonNull(method);
+
+            final List<SyntaxFragment> syntaxFragments = new ArrayList<>();
+            for (final Parameter parameter : method.getParameters()) {
+                if (!parameter.isAnnotationPresent(Argument.class)) {
+                    continue;
+                }
+                final Argument argument = parameter.getAnnotation(Argument.class);
+
+                final ArgumentMode argumentMode;
+                if (argument.literal()) {
+                    argumentMode = ArgumentMode.LITERAL;
+                } else if (argument.required()) {
+                    argumentMode = ArgumentMode.REQUIRED;
+                } else {
+                    argumentMode = ArgumentMode.OPTIONAL;
+                }
+
+                syntaxFragments.add(new SyntaxFragment(parameter.getName(), Collections.emptyList(), argumentMode));
+            }
+
+            return syntaxFragments;
+        }
+    }
+
+    private static class TestCommandExtractor implements CommandExtractor {
+
+        private final AnnotationParser<TestCommandSender> annotationParser;
+
+        private TestCommandExtractor(final @NonNull AnnotationParser<TestCommandSender> annotationParser) {
+            this.annotationParser = annotationParser;
+        }
+
+        @Override
+        public @NonNull Collection<@NonNull CommandDescriptor> extractCommands(final @NonNull Object instance) {
+            final Collection<CommandDescriptor> commandDescriptors = new ArrayList<>();
+            for (final Method method : instance.getClass().getMethods()) {
+                boolean commandMethod = false;
+                String commandName = "";
+                for (final Parameter parameter : method.getParameters()) {
+                    if (parameter.isAnnotationPresent(Argument.class)) {
+                        commandMethod = true;
+                        commandName = parameter.getName();
+                        break;
+                    }
+                }
+                if (!commandMethod) {
+                    continue;
+                }
+                commandDescriptors.add(
+                        new CommandDescriptor(
+                                method,
+                                this.annotationParser.syntaxParser().parseSyntax(method, ""),
+                                commandName,
+                                Object.class
+                        )
+                );
+            }
+            return commandDescriptors;
+        }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.PARAMETER)
+    public @interface Argument {
+
+        boolean literal() default false;
+
+        boolean required() default true;
+    }
+
+    public static class ArgumentDrivenCommandClass {
+
+        public void someCommand(
+                @Argument(literal = true) String test,
+                @Argument int argument,
+                @Argument(literal = true) String literal,
+                @Argument(required = false) String anotherArgument,
+                TestCommandSender commandSender
+        ) {
+        }
+    }
+}

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/flags/CommandFlag.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/flags/CommandFlag.java
@@ -232,6 +232,19 @@ public final class CommandFlag<T> {
          * @return New builder instance
          */
         public @NonNull Builder<T> withAliases(final @NonNull String... aliases) {
+            return this.withAliases(Arrays.asList(aliases));
+        }
+
+        /**
+         * Create a new builder instance using the given flag aliases.
+         * These may at most be one character in length
+         *
+         * @param aliases Flag aliases
+         * @return New builder instance
+         * @since 2.0.0
+         */
+        @API(status = API.Status.STABLE, since = "2.0.0")
+        public @NonNull Builder<T> withAliases(final @NonNull Collection<@NonNull String> aliases) {
             final Set<String> filteredAliases = new HashSet<>();
             for (final String alias : aliases) {
                 if (alias.isEmpty()) {


### PR DESCRIPTION
This PR allows us to swap out the components that make up the annotation parsing process. This means that we're no longer bound to the cloud annotations, and that users can swap out how command methods are detected, arguments are bound, flags are assembled, etc.

Example of what this allows us to do: https://github.com/Incendo/cloud/blob/eeadc61c90771ae616f0ed4d387a94ebdff908f4/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/ArgumentDrivenCommandsTest.java