### PR TITLE
feature: add command sender to descriptions and flags

### DIFF
--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/ArgumentAssembler.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/ArgumentAssembler.java
@@ -45,6 +45,6 @@ public interface ArgumentAssembler<C> {
      */
     @NonNull CommandComponent<C> assembleArgument(
             @NonNull SyntaxFragment syntaxFragment,
-            @NonNull ArgumentDescriptor descriptor
+            @NonNull ArgumentDescriptor<C> descriptor
     );
 }

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/ArgumentAssemblerImpl.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/ArgumentAssemblerImpl.java
@@ -55,7 +55,7 @@ final class ArgumentAssemblerImpl<C> implements ArgumentAssembler<C> {
     @Override
     public @NonNull CommandComponent<C> assembleArgument(
             @NonNull final SyntaxFragment syntaxFragment,
-            @NonNull final ArgumentDescriptor descriptor
+            @NonNull final ArgumentDescriptor<C> descriptor
     ) {
         final Parameter parameter = descriptor.parameter();
         final Collection<Annotation> annotations = Arrays.asList(parameter.getAnnotations());
@@ -131,7 +131,7 @@ final class ArgumentAssemblerImpl<C> implements ArgumentAssembler<C> {
             }
         }
 
-        final ArgumentDescription description;
+        final ArgumentDescription<C> description;
         if (descriptor.description() == null) {
             description = ArgumentDescription.empty();
         } else {

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/ArgumentDescriptor.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/ArgumentDescriptor.java
@@ -32,22 +32,23 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 @API(status = API.Status.STABLE, since = "2.0.0")
-public final class ArgumentDescriptor {
+public final class ArgumentDescriptor<C> {
 
     private final Parameter parameter;
     private final String name;
     private final String parserName;
     private final String suggestions;
     private final String defaultValue;
-    private final ArgumentDescription description;
+    private final ArgumentDescription<C> description;
 
     /**
      * Creates a new builder.
      *
+     * @param <C> command sender type
      * @return the created builder
      */
-    public static @NonNull Builder builder() {
-        return new Builder();
+    public static <C> @NonNull Builder<C> builder() {
+        return new Builder<>();
     }
 
     private ArgumentDescriptor(
@@ -56,7 +57,7 @@ public final class ArgumentDescriptor {
             final @Nullable String parserName,
             final @Nullable String suggestions,
             final @Nullable String defaultValue,
-            final @Nullable ArgumentDescription description
+            final @Nullable ArgumentDescription<C> description
     ) {
         this.parameter = parameter;
         this.name = name;
@@ -126,7 +127,7 @@ public final class ArgumentDescriptor {
      *
      * @return the argument description, or {@code null}
      */
-    public @Nullable ArgumentDescription description() {
+    public @Nullable ArgumentDescription<C> description() {
         return this.description;
     }
 
@@ -138,7 +139,7 @@ public final class ArgumentDescriptor {
         if (object == null || getClass() != object.getClass()) {
             return false;
         }
-        ArgumentDescriptor that = (ArgumentDescriptor) object;
+        ArgumentDescriptor<?> that = (ArgumentDescriptor<?>) object;
         return Objects.equals(this.parameter, that.parameter)
                 && Objects.equals(this.name, that.name)
                 && Objects.equals(this.parserName, that.parserName)
@@ -153,14 +154,14 @@ public final class ArgumentDescriptor {
     }
 
 
-    public static final class Builder {
+    public static final class Builder<C> {
 
         private final Parameter parameter;
         private final String name;
         private final String parserName;
         private final String suggestions;
         private final String defaultValue;
-        private final ArgumentDescription description;
+        private final ArgumentDescription<C> description;
 
         private Builder(
                 final @Nullable Parameter parameter,
@@ -168,7 +169,7 @@ public final class ArgumentDescriptor {
                 final @Nullable String parserName,
                 final @Nullable String suggestions,
                 final @Nullable String defaultValue,
-                final @Nullable ArgumentDescription description
+                final @Nullable ArgumentDescription<C> description
         ) {
             this.parameter = parameter;
             this.name = name;
@@ -188,8 +189,8 @@ public final class ArgumentDescriptor {
          * @param parameter the new parameter
          * @return the builder containing the updated parameter
          */
-        public @NonNull Builder parameter(final @NonNull Parameter parameter) {
-            return new Builder(parameter, this.name, this.parserName, this.suggestions, this.defaultValue, this.description);
+        public @NonNull Builder<C> parameter(final @NonNull Parameter parameter) {
+            return new Builder<>(parameter, this.name, this.parserName, this.suggestions, this.defaultValue, this.description);
         }
 
         /**
@@ -201,8 +202,8 @@ public final class ArgumentDescriptor {
          * @param name the new name
          * @return the builder containing the updated name
          */
-        public @NonNull Builder name(final @NonNull String name) {
-            return new Builder(this.parameter, name, this.parserName, this.suggestions, this.defaultValue, this.description);
+        public @NonNull Builder<C> name(final @NonNull String name) {
+            return new Builder<>(this.parameter, name, this.parserName, this.suggestions, this.defaultValue, this.description);
         }
 
         /**
@@ -211,14 +212,14 @@ public final class ArgumentDescriptor {
          * @param parserName the new parserName
          * @return the builder containing the updated parserName
          */
-        public @NonNull Builder parserName(final @Nullable String parserName) {
+        public @NonNull Builder<C> parserName(final @Nullable String parserName) {
             final String nullableName;
             if (parserName != null && parserName.isEmpty()) {
                 nullableName = null;
             } else {
                 nullableName = parserName;
             }
-            return new Builder(this.parameter, this.name, nullableName, this.suggestions, this.defaultValue, this.description);
+            return new Builder<>(this.parameter, this.name, nullableName, this.suggestions, this.defaultValue, this.description);
         }
 
         /**
@@ -227,14 +228,14 @@ public final class ArgumentDescriptor {
          * @param suggestions the new suggestions
          * @return the builder containing the updated suggestions
          */
-        public @NonNull Builder suggestions(final @Nullable String suggestions) {
+        public @NonNull Builder<C> suggestions(final @Nullable String suggestions) {
             final String nullableName;
             if (suggestions != null && suggestions.isEmpty()) {
                 nullableName = null;
             } else {
                 nullableName = suggestions;
             }
-            return new Builder(this.parameter, this.name, this.parserName, nullableName, this.defaultValue, this.description);
+            return new Builder<>(this.parameter, this.name, this.parserName, nullableName, this.defaultValue, this.description);
         }
 
         /**
@@ -243,14 +244,14 @@ public final class ArgumentDescriptor {
          * @param defaultValue the new default value
          * @return the builder containing the updated default value
          */
-        public @NonNull Builder defaultValue(final @Nullable String defaultValue) {
+        public @NonNull Builder<C> defaultValue(final @Nullable String defaultValue) {
             final String nullableName;
             if (defaultValue != null && defaultValue.isEmpty()) {
                 nullableName = null;
             } else {
                 nullableName = defaultValue;
             }
-            return new Builder(this.parameter, this.name, this.parserName, this.suggestions, nullableName, this.description);
+            return new Builder<>(this.parameter, this.name, this.parserName, this.suggestions, nullableName, this.description);
         }
 
         /**
@@ -259,8 +260,8 @@ public final class ArgumentDescriptor {
          * @param description the new description
          * @return the builder containing the updated description
          */
-        public @NonNull Builder description(final @Nullable ArgumentDescription description) {
-            return new Builder(this.parameter, this.name, this.parserName, this.suggestions, this.defaultValue, description);
+        public @NonNull Builder<C> description(final @Nullable ArgumentDescription<C> description) {
+            return new Builder<>(this.parameter, this.name, this.parserName, this.suggestions, this.defaultValue, description);
         }
 
         /**
@@ -268,8 +269,8 @@ public final class ArgumentDescriptor {
          *
          * @return the argument descriptor
          */
-        public @NonNull ArgumentDescriptor build() {
-            return new ArgumentDescriptor(
+        public @NonNull ArgumentDescriptor<C> build() {
+            return new ArgumentDescriptor<>(
                     Objects.requireNonNull(this.parameter, "parameter"),
                     Objects.requireNonNull(this.name, "name"),
                     this.parserName,

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/ArgumentExtractor.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/ArgumentExtractor.java
@@ -32,10 +32,11 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 /**
  * Extracts {@link ArgumentDescriptor argument descriptors} from {@link Method methods}.
  *
+ * @param <C> command sender type
  * @since 2.0.0
  */
 @API(status = API.Status.STABLE, since = "2.0.0")
-public interface ArgumentExtractor {
+public interface ArgumentExtractor<C> {
 
     /**
      * Extracts the arguments from the given {@code method}.
@@ -44,7 +45,7 @@ public interface ArgumentExtractor {
      * @param method the method
      * @return the extracted arguments
      */
-    @NonNull Collection<@NonNull ArgumentDescriptor> extractArguments(
+    @NonNull Collection<@NonNull ArgumentDescriptor<C>> extractArguments(
             @NonNull List<@NonNull SyntaxFragment> syntax,
             @NonNull Method method
     );

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/ArgumentExtractorImpl.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/ArgumentExtractorImpl.java
@@ -33,30 +33,26 @@ import java.util.function.Function;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-/**
- * Utility that extract {@link Argument arguments} from
- * {@link java.lang.reflect.Method method} {@link java.lang.reflect.Parameter parameters}
- */
-class ArgumentExtractorImpl implements ArgumentExtractor {
+class ArgumentExtractorImpl<C> implements ArgumentExtractor<C> {
 
-    private final Function<@NonNull Argument, @Nullable ArgumentDescription> descriptionMapper;
+    private final Function<@NonNull Argument, @Nullable ArgumentDescription<C>> descriptionMapper;
 
     ArgumentExtractorImpl() {
         this.descriptionMapper = argument -> ArgumentDescription.of(argument.description());
     }
 
     @Override
-    public @NonNull Collection<@NonNull ArgumentDescriptor> extractArguments(
+    public @NonNull Collection<@NonNull ArgumentDescriptor<C>> extractArguments(
             final @NonNull List<@NonNull SyntaxFragment> syntax,
             final @NonNull Method method
     ) {
-        final Collection<ArgumentDescriptor> arguments = new ArrayList<>();
+        final Collection<ArgumentDescriptor<C>> arguments = new ArrayList<>();
         for (final Parameter parameter : method.getParameters()) {
             if (!parameter.isAnnotationPresent(Argument.class)) {
                 continue;
             }
             final Argument argument = parameter.getAnnotation(Argument.class);
-            final ArgumentDescriptor argumentDescriptor = ArgumentDescriptor.builder()
+            final ArgumentDescriptor<C> argumentDescriptor = ArgumentDescriptor.<C>builder()
                     .parameter(parameter)
                     .name(argument.value())
                     .parserName(argument.parserName())

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagAssembler.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagAssembler.java
@@ -30,10 +30,11 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 /**
  * Assembles {@link CommandFlag flags} from {@link FlagDescriptor flag descriptors}.
  *
+ * @param <C> command sender type
  * @since 2.0.0
  */
 @API(status = API.Status.STABLE, since = "2.0.0")
-public interface FlagAssembler {
+public interface FlagAssembler<C> {
 
     /**
      * Assembles a flag from the given {@code descriptor}.
@@ -41,5 +42,5 @@ public interface FlagAssembler {
      * @param descriptor the descriptor
      * @return the assembled flag
      */
-    @NonNull CommandFlag<?> assembleFlag(@NonNull FlagDescriptor descriptor);
+    @NonNull CommandFlag<C, ?> assembleFlag(@NonNull FlagDescriptor descriptor);
 }

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagAssemblerImpl.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagAssemblerImpl.java
@@ -39,7 +39,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-final class FlagAssemblerImpl implements FlagAssembler {
+final class FlagAssemblerImpl<C> implements FlagAssembler<C> {
 
     private final CommandManager<?> commandManager;
 
@@ -49,7 +49,7 @@ final class FlagAssemblerImpl implements FlagAssembler {
 
     @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public @NonNull CommandFlag<?> assembleFlag(@NonNull final FlagDescriptor descriptor) {
+    public @NonNull CommandFlag<C, ?> assembleFlag(@NonNull final FlagDescriptor descriptor) {
         final ArgumentDescription description;
         if (descriptor.description() == null) {
             description = ArgumentDescription.empty();
@@ -64,7 +64,7 @@ final class FlagAssemblerImpl implements FlagAssembler {
             permission = descriptor.permission();
         }
 
-        CommandFlag.Builder<Void> builder = this.commandManager
+        CommandFlag.Builder<C, Void> builder = this.commandManager
                 .flagBuilder(descriptor.name())
                 .withDescription(description)
                 .withAliases(descriptor.aliases())

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagDescriptor.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagDescriptor.java
@@ -45,7 +45,7 @@ public final class FlagDescriptor {
     private final String parserName;
     private final String suggestions;
     private final CommandPermission permission;
-    private final ArgumentDescription description;
+    private final ArgumentDescription<?> description;
     private final boolean repeatable;
 
     /**
@@ -64,7 +64,7 @@ public final class FlagDescriptor {
             final @Nullable String parserName,
             final @Nullable String suggestions,
             final @Nullable CommandPermission permission,
-            final @Nullable ArgumentDescription description,
+            final @Nullable ArgumentDescription<?> description,
             final boolean repeatable
     ) {
         this.parameter = parameter;
@@ -146,7 +146,7 @@ public final class FlagDescriptor {
      *
      * @return the flag description, or {@code null}
      */
-    public @Nullable ArgumentDescription description() {
+    public @Nullable ArgumentDescription<?> description() {
         return this.description;
     }
 
@@ -202,7 +202,7 @@ public final class FlagDescriptor {
         private final String parserName;
         private final String suggestions;
         private final CommandPermission permission;
-        private final ArgumentDescription description;
+        private final ArgumentDescription<?> description;
         private final boolean repeatable;
 
         private Builder(
@@ -212,7 +212,7 @@ public final class FlagDescriptor {
                 final @Nullable String parserName,
                 final @Nullable String suggestions,
                 final @Nullable CommandPermission permission,
-                final @Nullable ArgumentDescription description,
+                final @Nullable ArgumentDescription<?> description,
                 final boolean repeatable
         ) {
             this.parameter = parameter;
@@ -364,7 +364,7 @@ public final class FlagDescriptor {
          * @param description the new description
          * @return the builder containing the updated description
          */
-        public @NonNull Builder description(final @Nullable ArgumentDescription description) {
+        public @NonNull Builder description(final @Nullable ArgumentDescription<?> description) {
             return new Builder(
                     this.parameter,
                     this.name,

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/MethodCommandExecutionHandler.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/MethodCommandExecutionHandler.java
@@ -104,12 +104,12 @@ public class MethodCommandExecutionHandler<C> implements CommandExecutionHandler
      */
     protected final List<Object> createParameterValues(
             final CommandContext<C> commandContext,
-            final FlagContext flagContext,
+            final FlagContext<C> flagContext,
             final Parameter[] parameters
     ) {
         final List<Object> arguments = new ArrayList<>(parameters.length);
         for (final Parameter parameter : parameters) {
-            final ArgumentDescriptor argumentDescriptor = this.context.argumentDescriptors.stream()
+            final ArgumentDescriptor<C> argumentDescriptor = this.context.argumentDescriptors.stream()
                     .filter(descriptor -> descriptor.parameter().equals(parameter))
                     .findFirst()
                     .orElse(null);
@@ -221,13 +221,13 @@ public class MethodCommandExecutionHandler<C> implements CommandExecutionHandler
         private final Method method;
         private final ParameterInjectorRegistry<C> injectorRegistry;
         private final AnnotationParser<C> annotationParser;
-        private final Collection<@NonNull ArgumentDescriptor> argumentDescriptors;
+        private final Collection<@NonNull ArgumentDescriptor<C>> argumentDescriptors;
         private final Collection<@NonNull FlagDescriptor> flagDescriptors;
 
         CommandMethodContext(
                 final @NonNull Object instance,
                 final @NonNull Map<@NonNull String, @NonNull CommandComponent<C>> commandComponents,
-                final @NonNull Collection<@NonNull ArgumentDescriptor> argumentDescriptors,
+                final @NonNull Collection<@NonNull ArgumentDescriptor<C>> argumentDescriptors,
                 final @NonNull Collection<@NonNull FlagDescriptor> flagDescriptors,
                 final @NonNull Method method,
                 final @NonNull AnnotationParser<C> annotationParser
@@ -299,7 +299,7 @@ public class MethodCommandExecutionHandler<C> implements CommandExecutionHandler
          * @since 2.0.0
          */
         @API(status = API.Status.STABLE, since = "2.0.0")
-        public @NonNull Collection<@NonNull ArgumentDescriptor> argumentDescriptors() {
+        public @NonNull Collection<@NonNull ArgumentDescriptor<C>> argumentDescriptors() {
             return Collections.unmodifiableCollection(this.argumentDescriptors);
         }
 

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/ArgumentDrivenCommandsTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/ArgumentDrivenCommandsTest.java
@@ -79,13 +79,13 @@ class ArgumentDrivenCommandsTest {
         this.commandManager.executeCommand(new TestCommandSender(), "test 3 literal").get();
     }
 
-    private static class TestArgumentExtractor implements ArgumentExtractor {
+    private static class TestArgumentExtractor implements ArgumentExtractor<TestCommandSender> {
         @Override
-        public @NonNull Collection<@NonNull ArgumentDescriptor> extractArguments(
+        public @NonNull Collection<@NonNull ArgumentDescriptor<TestCommandSender>> extractArguments(
                 final @NonNull List<@NonNull SyntaxFragment> syntax,
                 final @NonNull Method method
         ) {
-            final Collection<ArgumentDescriptor> arguments = new ArrayList<>();
+            final Collection<ArgumentDescriptor<TestCommandSender>> arguments = new ArrayList<>();
             for (final Parameter parameter : method.getParameters()) {
                 if (!parameter.isAnnotationPresent(Argument.class)) {
                     continue;
@@ -94,7 +94,7 @@ class ArgumentDrivenCommandsTest {
                 if (argument.literal()) {
                     continue;
                 }
-                final ArgumentDescriptor argumentDescriptor = ArgumentDescriptor.builder()
+                final ArgumentDescriptor<TestCommandSender> argumentDescriptor = ArgumentDescriptor.<TestCommandSender>builder()
                         .parameter(parameter)
                         .name(AnnotationParser.INFERRED_ARGUMENT_NAME)
                         .build();

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/StringProcessingTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/StringProcessingTest.java
@@ -112,7 +112,7 @@ class StringProcessingTest {
         final FlagArgument<TestCommandSender> flagArgument = (FlagArgument<TestCommandSender>) components.get(2).argument();
         assertThat(flagArgument).isNotNull();
 
-        final List<CommandFlag<?>> flags = new ArrayList<>(flagArgument.getFlags());
+        final List<CommandFlag<?, ?>> flags = new ArrayList<>(flagArgument.getFlags());
         assertThat(flags).hasSize(1);
         assertThat(flags.get(0).getName()).isEqualTo(testFlagName);
     }

--- a/cloud-core/src/main/java/cloud/commandframework/ArgumentDescription.java
+++ b/cloud-core/src/main/java/cloud/commandframework/ArgumentDescription.java
@@ -32,49 +32,52 @@ import static java.util.Objects.requireNonNull;
 /**
  * A description for a {@link CommandArgument}
  *
+ * @param <C> command sender
  * @since 1.4.0
  */
 @API(status = API.Status.STABLE, since = "1.4.0")
-public interface ArgumentDescription {
+public interface ArgumentDescription<C> {
 
     /**
      * Get an empty command description.
      *
+     * @param <C> command sender type
      * @return Command description
      */
-    @SuppressWarnings("deprecation")
-    static @NonNull ArgumentDescription empty() {
-        return Description.EMPTY;
+    static <C> @NonNull ArgumentDescription<C> empty() {
+        return new Description<>("");
     }
 
     /**
      * Create a command description instance.
      *
+     * @param <C> command sender type
      * @param string Command description
      * @return Created command description
      */
-    @SuppressWarnings("deprecation")
-    static @NonNull ArgumentDescription of(final @NonNull String string) {
+    static <C> @NonNull ArgumentDescription<C> of(final @NonNull String string) {
         if (requireNonNull(string, "string").isEmpty()) {
-            return Description.EMPTY;
+            return empty();
         } else {
-            return new Description(string);
+            return new Description<>(string);
         }
     }
 
     /**
      * Get the plain-text description.
      *
+     * @param commandSender the command sender that is viewing the description
      * @return Command description
      */
-    @NonNull String getDescription();
+    @NonNull String description(@NonNull C commandSender);
 
     /**
-     * Get whether or not this description contains contents.
+     * Get whether this description contains contents.
      *
+     * @param commandSender the command sender that is viewing the description
      * @return if this description is empty or not
      */
-    default boolean isEmpty() {
-        return this.getDescription().isEmpty();
+    default boolean isEmpty(@NonNull C commandSender) {
+        return this.description(commandSender).isEmpty();
     }
 }

--- a/cloud-core/src/main/java/cloud/commandframework/Command.java
+++ b/cloud-core/src/main/java/cloud/commandframework/Command.java
@@ -56,6 +56,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * @param <C> Command sender type
  */
+@SuppressWarnings("overloads")
 @API(status = API.Status.STABLE)
 public class Command<C> {
 
@@ -167,36 +168,13 @@ public class Command<C> {
      * @param aliases     Command aliases
      * @param <C>         Command sender type
      * @return Command builder
-     * @deprecated for removal since 1.4.0. Use {@link #newBuilder(String, CommandMeta, ArgumentDescription, String...)} instead.
-     */
-    @Deprecated
-    @API(status = API.Status.DEPRECATED, since = "1.4.0")
-    public static <C> @NonNull Builder<C> newBuilder(
-            final @NonNull String commandName,
-            final @NonNull CommandMeta commandMeta,
-            final @NonNull Description description,
-            final @NonNull String... aliases
-    ) {
-        return newBuilder(commandName, commandMeta, (ArgumentDescription) description, aliases);
-    }
-
-    /**
-     * Create a new command builder. Is recommended to use the builder methods
-     * in {@link CommandManager} rather than invoking this method directly.
-     *
-     * @param commandName Base command argument
-     * @param commandMeta Command meta instance
-     * @param description Command description
-     * @param aliases     Command aliases
-     * @param <C>         Command sender type
-     * @return Command builder
      * @since 1.4.0
      */
     @API(status = API.Status.STABLE, since = "1.4.0")
     public static <C> @NonNull Builder<C> newBuilder(
             final @NonNull String commandName,
             final @NonNull CommandMeta commandMeta,
-            final @NonNull ArgumentDescription description,
+            final @NonNull ArgumentDescription<C> description,
             final @NonNull String... aliases
     ) {
         final List<CommandComponent<C>> commands = new ArrayList<>();
@@ -328,26 +306,6 @@ public class Command<C> {
         return this.commandMeta;
     }
 
-    /**
-     * Get the description for an argument
-     *
-     * @param argument Argument
-     * @return Argument description
-     * @throws IllegalArgumentException If the command argument does not exist
-     * @deprecated More than one matching command argument may exist per command.
-     *         Use {@link #components()} and search in that, instead.
-     */
-    @Deprecated
-    @API(status = API.Status.DEPRECATED)
-    public @NonNull String getArgumentDescription(final @NonNull CommandArgument<C, ?> argument) {
-        for (final CommandComponent<C> component : this.components) {
-            if (component.argument().equals(argument)) {
-                return component.argumentDescription().getDescription();
-            }
-        }
-        throw new IllegalArgumentException("Command argument not found: " + argument);
-    }
-
     @Override
     public final String toString() {
         final StringBuilder stringBuilder = new StringBuilder();
@@ -383,7 +341,7 @@ public class Command<C> {
         private final Class<? extends C> senderType;
         private final CommandPermission commandPermission;
         private final CommandManager<C> commandManager;
-        private final Collection<CommandFlag<?>> flags;
+        private final Collection<CommandFlag<C, ?>> flags;
 
         private Builder(
                 final @Nullable CommandManager<C> commandManager,
@@ -392,7 +350,7 @@ public class Command<C> {
                 final @NonNull List<@NonNull CommandComponent<C>> commandComponents,
                 final @NonNull CommandExecutionHandler<@NonNull C> commandExecutionHandler,
                 final @NonNull CommandPermission commandPermission,
-                final @NonNull Collection<CommandFlag<?>> flags
+                final @NonNull Collection<CommandFlag<C, ?>> flags
         ) {
             this.commandManager = commandManager;
             this.senderType = senderType;
@@ -530,31 +488,12 @@ public class Command<C> {
          * @param description Literal description
          * @param aliases     Argument aliases
          * @return New builder instance with the modified command chain
-         * @deprecated for removal since 1.4.0. Use {@link #literal(String, ArgumentDescription, String...)} instead.
-         */
-        @Deprecated
-        @API(status = API.Status.DEPRECATED, since = "1.4.0")
-        public @NonNull Builder<C> literal(
-                final @NonNull String main,
-                final @NonNull Description description,
-                final @NonNull String... aliases
-        ) {
-            return this.required(StaticArgument.of(main, aliases), description);
-        }
-
-        /**
-         * Inserts a required {@link StaticArgument} into the command chain
-         *
-         * @param main        Main argument name
-         * @param description Literal description
-         * @param aliases     Argument aliases
-         * @return New builder instance with the modified command chain
          * @since 1.4.0
          */
         @API(status = API.Status.STABLE, since = "1.4.0")
         public @NonNull Builder<C> literal(
                 final @NonNull String main,
-                final @NonNull ArgumentDescription description,
+                final @NonNull ArgumentDescription<C> description,
                 final @NonNull String... aliases
         ) {
             return this.required(StaticArgument.of(main, aliases), description);
@@ -575,7 +514,7 @@ public class Command<C> {
         @API(status = API.Status.STABLE, since = "2.0.0")
         public <T> @NonNull Builder<C> required(
                 final @NonNull CommandArgument<C, T> argument,
-                final @NonNull ArgumentDescription description
+                final @NonNull ArgumentDescription<C> description
         ) {
             return this.argument(CommandComponent.required(argument, description));
         }
@@ -595,7 +534,7 @@ public class Command<C> {
         @API(status = API.Status.STABLE, since = "2.0.0")
         public <T> @NonNull Builder<C> required(
                 final CommandArgument.@NonNull Builder<C, T> argument,
-                final @NonNull ArgumentDescription description
+                final @NonNull ArgumentDescription<C> description
         ) {
             return this.argument(CommandComponent.required(argument.build(), description));
         }
@@ -615,7 +554,7 @@ public class Command<C> {
         @API(status = API.Status.STABLE, since = "2.0.0")
         public <T> @NonNull Builder<C> optional(
                 final @NonNull CommandArgument<C, T> argument,
-                final @NonNull ArgumentDescription description
+                final @NonNull ArgumentDescription<C> description
         ) {
             return this.argument(CommandComponent.optional(argument, description));
         }
@@ -635,7 +574,7 @@ public class Command<C> {
         @API(status = API.Status.STABLE, since = "2.0.0")
         public <T> @NonNull Builder<C> optional(
                 final CommandArgument.@NonNull Builder<C, T> argument,
-                final @NonNull ArgumentDescription description
+                final @NonNull ArgumentDescription<C> description
         ) {
             return this.argument(CommandComponent.optional(argument.build(), description));
         }
@@ -656,7 +595,7 @@ public class Command<C> {
         @API(status = API.Status.STABLE, since = "2.0.0")
         public <T> @NonNull Builder<C> optional(
                 final @NonNull CommandArgument<C, T> argument,
-                final @NonNull ArgumentDescription description,
+                final @NonNull ArgumentDescription<C> description,
                 final @NonNull DefaultValue<C, T> defaultValue
         ) {
             return this.argument(CommandComponent.optional(argument, description, defaultValue));
@@ -678,7 +617,7 @@ public class Command<C> {
         @API(status = API.Status.STABLE, since = "2.0.0")
         public <T> @NonNull Builder<C> optional(
                 final CommandArgument.@NonNull Builder<C, T> argument,
-                final @NonNull ArgumentDescription description,
+                final @NonNull ArgumentDescription<C> description,
                 final @NonNull DefaultValue<C, T> defaultValue
         ) {
             return this.argument(CommandComponent.optional(argument.build(), description, defaultValue));
@@ -901,7 +840,7 @@ public class Command<C> {
                 final @NonNull String name,
                 final @NonNull Pair<@NonNull String, @NonNull String> names,
                 final @NonNull Pair<@NonNull Class<U>, @NonNull Class<V>> parserPair,
-                final @NonNull ArgumentDescription description
+                final @NonNull ArgumentDescription<C> description
         ) {
             if (this.commandManager == null) {
                 throw new IllegalStateException("This cannot be called from a command that has no command manager attached");
@@ -932,7 +871,7 @@ public class Command<C> {
                 final @NonNull String name,
                 final @NonNull Pair<@NonNull String, @NonNull String> names,
                 final @NonNull Pair<@NonNull Class<U>, @NonNull Class<V>> parserPair,
-                final @NonNull ArgumentDescription description
+                final @NonNull ArgumentDescription<C> description
         ) {
             if (this.commandManager == null) {
                 throw new IllegalStateException("This cannot be called from a command that has no command manager attached");
@@ -968,7 +907,7 @@ public class Command<C> {
                 final @NonNull Pair<String, String> names,
                 final @NonNull Pair<Class<U>, Class<V>> parserPair,
                 final @NonNull BiFunction<C, Pair<U, V>, O> mapper,
-                final @NonNull ArgumentDescription description
+                final @NonNull ArgumentDescription<C> description
         ) {
             if (this.commandManager == null) {
                 throw new IllegalStateException("This cannot be called from a command that has no command manager attached");
@@ -1007,7 +946,7 @@ public class Command<C> {
                 final @NonNull Pair<String, String> names,
                 final @NonNull Pair<Class<U>, Class<V>> parserPair,
                 final @NonNull BiFunction<C, Pair<U, V>, O> mapper,
-                final @NonNull ArgumentDescription description
+                final @NonNull ArgumentDescription<C> description
         ) {
             if (this.commandManager == null) {
                 throw new IllegalStateException("This cannot be called from a command that has no command manager attached");
@@ -1042,7 +981,7 @@ public class Command<C> {
                 final @NonNull String name,
                 final @NonNull Triplet<String, String, String> names,
                 final @NonNull Triplet<Class<U>, Class<V>, Class<W>> parserTriplet,
-                final @NonNull ArgumentDescription description
+                final @NonNull ArgumentDescription<C> description
         ) {
             if (this.commandManager == null) {
                 throw new IllegalStateException("This cannot be called from a command that has no command manager attached");
@@ -1074,7 +1013,7 @@ public class Command<C> {
                 final @NonNull String name,
                 final @NonNull Triplet<String, String, String> names,
                 final @NonNull Triplet<Class<U>, Class<V>, Class<W>> parserTriplet,
-                final @NonNull ArgumentDescription description
+                final @NonNull ArgumentDescription<C> description
         ) {
             if (this.commandManager == null) {
                 throw new IllegalStateException("This cannot be called from a command that has no command manager attached");
@@ -1111,7 +1050,7 @@ public class Command<C> {
                 final @NonNull Triplet<String, String, String> names,
                 final @NonNull Triplet<Class<U>, Class<V>, Class<W>> parserTriplet,
                 final @NonNull BiFunction<C, Triplet<U, V, W>, O> mapper,
-                final @NonNull ArgumentDescription description
+                final @NonNull ArgumentDescription<C> description
         ) {
             if (this.commandManager == null) {
                 throw new IllegalStateException("This cannot be called from a command that has no command manager attached");
@@ -1151,7 +1090,7 @@ public class Command<C> {
                 final @NonNull Triplet<String, String, String> names,
                 final @NonNull Triplet<Class<U>, Class<V>, Class<W>> parserTriplet,
                 final @NonNull BiFunction<C, Triplet<U, V, W>, O> mapper,
-                final @NonNull ArgumentDescription description
+                final @NonNull ArgumentDescription<C> description
         ) {
             if (this.commandManager == null) {
                 throw new IllegalStateException("This cannot be called from a command that has no command manager attached");
@@ -1308,8 +1247,8 @@ public class Command<C> {
          * @param <T>  Flag value type
          * @return New builder instance that uses the provided flag
          */
-        public @NonNull <T> Builder<C> flag(final @NonNull CommandFlag<T> flag) {
-            final List<CommandFlag<?>> flags = new ArrayList<>(this.flags);
+        public @NonNull <T> Builder<C> flag(final @NonNull CommandFlag<C, T> flag) {
+            final List<CommandFlag<C, ?>> flags = new ArrayList<>(this.flags);
             flags.add(flag);
             return new Builder<>(
                     this.commandManager,
@@ -1329,7 +1268,7 @@ public class Command<C> {
          * @param <T>     Flag value type
          * @return New builder instance that uses the provided flag
          */
-        public @NonNull <T> Builder<C> flag(final CommandFlag.@NonNull Builder<T> builder) {
+        public @NonNull <T> Builder<C> flag(final CommandFlag.@NonNull Builder<C, T> builder) {
             return this.flag(builder.build());
         }
 

--- a/cloud-core/src/main/java/cloud/commandframework/CommandComponent.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandComponent.java
@@ -40,7 +40,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class CommandComponent<C> {
 
     private final CommandArgument<C, ?> argument;
-    private final ArgumentDescription description;
+    private final ArgumentDescription<C> description;
     private final boolean required;
     private final DefaultValue<C, ?> defaultValue;
 
@@ -55,7 +55,7 @@ public final class CommandComponent<C> {
      */
     private CommandComponent(
             final @NonNull CommandArgument<C, ?> argument,
-            final @NonNull ArgumentDescription description,
+            final @NonNull ArgumentDescription<C> description,
             final boolean required,
             final @Nullable DefaultValue<C, ?> defaultValue
     ) {
@@ -78,26 +78,10 @@ public final class CommandComponent<C> {
      * Gets the command component description
      *
      * @return command component description
-     * @deprecated for removal since 1.4.0. Use {@link #argumentDescription()} instead.
-     */
-    @Deprecated
-    @API(status = API.Status.DEPRECATED, since = "1.4.0")
-    public @NonNull Description description() {
-        if (this.description instanceof Description) {
-            return (Description) this.description;
-        } else {
-            return new Description(this.description.getDescription());
-        }
-    }
-
-    /**
-     * Gets the command component description
-     *
-     * @return command component description
      * @since 1.4.0
      */
     @API(status = API.Status.STABLE, since = "1.4.0")
-    public @NonNull ArgumentDescription argumentDescription() {
+    public @NonNull ArgumentDescription<C> argumentDescription() {
         return this.description;
     }
 
@@ -186,7 +170,7 @@ public final class CommandComponent<C> {
     public @NonNull CommandComponent<C> copy() {
         return new CommandComponent<>(
                 this.argument().copy(),
-                this.description(),
+                this.argumentDescription(),
                 this.required(),
                 this.defaultValue()
         );
@@ -204,7 +188,7 @@ public final class CommandComponent<C> {
     @API(status = API.Status.STABLE, since = "2.0.0")
     public static <C> @NonNull CommandComponent<C> required(
             final @NonNull CommandArgument<C, ?> commandArgument,
-            final @NonNull ArgumentDescription commandDescription
+            final @NonNull ArgumentDescription<C> commandDescription
     ) {
         return new CommandComponent<C>(commandArgument, commandDescription, true, null);
     }
@@ -222,7 +206,7 @@ public final class CommandComponent<C> {
     @API(status = API.Status.STABLE, since = "2.0.0")
     public static <C> @NonNull CommandComponent<C> optional(
             final @NonNull CommandArgument<C, ?> commandArgument,
-            final @NonNull ArgumentDescription commandDescription,
+            final @NonNull ArgumentDescription<C> commandDescription,
             final @Nullable DefaultValue<C, ?> defaultValue
     ) {
         return new CommandComponent<C>(commandArgument, commandDescription, false, defaultValue);
@@ -240,7 +224,7 @@ public final class CommandComponent<C> {
     @API(status = API.Status.STABLE, since = "2.0.0")
     public static <C> @NonNull CommandComponent<C> optional(
             final @NonNull CommandArgument<C, ?> commandArgument,
-            final @NonNull ArgumentDescription commandDescription
+            final @NonNull ArgumentDescription<C> commandDescription
     ) {
         return new CommandComponent<C>(commandArgument, commandDescription, false, null);
     }

--- a/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
@@ -609,42 +609,13 @@ public abstract class CommandManager<C> {
      * @param description Description for the root literal
      * @param meta        Command meta
      * @return Builder instance
-     * @deprecated for removal since 1.4.0. Use
-     *         {@link #commandBuilder(String, Collection, ArgumentDescription, CommandMeta)} instead.
-     */
-    @Deprecated
-    @API(status = API.Status.DEPRECATED, since = "1.4.0")
-    public Command.@NonNull Builder<C> commandBuilder(
-            final @NonNull String name,
-            final @NonNull Collection<String> aliases,
-            final @NonNull Description description,
-            final @NonNull CommandMeta meta
-    ) {
-        return this.commandBuilder(name, aliases, (ArgumentDescription) description, meta);
-    }
-
-    /**
-     * Create a new command builder. This will also register the creating manager in the command
-     * builder using {@link Command.Builder#manager(CommandManager)}, so that the command
-     * builder is associated with the creating manager. This allows for parser inference based on
-     * the type, with the help of the {@link ParserRegistry parser registry}
-     * <p>
-     * This method will not register the command in the manager. To do that, {@link #command(Command.Builder)}
-     * or {@link #command(Command)} has to be invoked with either the {@link Command.Builder} instance, or the constructed
-     * {@link Command command} instance
-     *
-     * @param name        Command name
-     * @param aliases     Command aliases
-     * @param description Description for the root literal
-     * @param meta        Command meta
-     * @return Builder instance
      * @since 1.4.0
      */
     @API(status = API.Status.STABLE, since = "1.4.0")
     public Command.@NonNull Builder<C> commandBuilder(
             final @NonNull String name,
             final @NonNull Collection<String> aliases,
-            final @NonNull ArgumentDescription description,
+            final @NonNull ArgumentDescription<C> description,
             final @NonNull CommandMeta meta
     ) {
         return Command.<C>newBuilder(
@@ -700,42 +671,13 @@ public abstract class CommandManager<C> {
      * @param description Description for the root literal
      * @param aliases     Command aliases
      * @return Builder instance
-     * @deprecated for removal since 1.4.0. Use {@link #commandBuilder(String, CommandMeta, ArgumentDescription, String...)}
-     *         instead.
-     */
-    @Deprecated
-    @API(status = API.Status.DEPRECATED, since = "1.4.0")
-    public Command.@NonNull Builder<C> commandBuilder(
-            final @NonNull String name,
-            final @NonNull CommandMeta meta,
-            final @NonNull Description description,
-            final @NonNull String... aliases
-    ) {
-        return this.commandBuilder(name, meta, (ArgumentDescription) description, aliases);
-    }
-
-    /**
-     * Create a new command builder. This will also register the creating manager in the command
-     * builder using {@link Command.Builder#manager(CommandManager)}, so that the command
-     * builder is associated with the creating manager. This allows for parser inference based on
-     * the type, with the help of the {@link ParserRegistry parser registry}
-     * <p>
-     * This method will not register the command in the manager. To do that, {@link #command(Command.Builder)}
-     * or {@link #command(Command)} has to be invoked with either the {@link Command.Builder} instance, or the constructed
-     * {@link Command command} instance
-     *
-     * @param name        Command name
-     * @param meta        Command meta
-     * @param description Description for the root literal
-     * @param aliases     Command aliases
-     * @return Builder instance
      * @since 1.4.0
      */
     @API(status = API.Status.STABLE, since = "1.4.0")
     public Command.@NonNull Builder<C> commandBuilder(
             final @NonNull String name,
             final @NonNull CommandMeta meta,
-            final @NonNull ArgumentDescription description,
+            final @NonNull ArgumentDescription<C> description,
             final @NonNull String... aliases
     ) {
         return Command.<C>newBuilder(
@@ -794,42 +736,12 @@ public abstract class CommandManager<C> {
      * @return Builder instance
      * @throws UnsupportedOperationException If the command manager does not support default command meta creation
      * @see #createDefaultCommandMeta() Default command meta creation
-     * @deprecated for removal since 1.4.0. Use {@link #commandBuilder(String, ArgumentDescription, String...)} instead.
-     */
-    @Deprecated
-    @API(status = API.Status.DEPRECATED, since = "1.4.0")
-    public Command.@NonNull Builder<C> commandBuilder(
-            final @NonNull String name,
-            final @NonNull Description description,
-            final @NonNull String... aliases
-    ) {
-        return this.commandBuilder(name, (ArgumentDescription) description, aliases);
-    }
-
-    /**
-     * Create a new command builder using default command meta created by {@link #createDefaultCommandMeta()}.
-     * <p>
-     * This will also register the creating manager in the command
-     * builder using {@link Command.Builder#manager(CommandManager)}, so that the command
-     * builder is associated with the creating manager. This allows for parser inference based on
-     * the type, with the help of the {@link ParserRegistry parser registry}
-     * <p>
-     * This method will not register the command in the manager. To do that, {@link #command(Command.Builder)}
-     * or {@link #command(Command)} has to be invoked with either the {@link Command.Builder} instance, or the constructed
-     * {@link Command command} instance
-     *
-     * @param name        Command name
-     * @param description Description for the root literal
-     * @param aliases     Command aliases
-     * @return Builder instance
-     * @throws UnsupportedOperationException If the command manager does not support default command meta creation
-     * @see #createDefaultCommandMeta() Default command meta creation
      * @since 1.4.0
      */
     @API(status = API.Status.STABLE, since = "1.4.0")
     public Command.@NonNull Builder<C> commandBuilder(
             final @NonNull String name,
-            final @NonNull ArgumentDescription description,
+            final @NonNull ArgumentDescription<C> description,
             final @NonNull String... aliases
     ) {
         return Command.<C>newBuilder(
@@ -896,7 +808,7 @@ public abstract class CommandManager<C> {
      * @param name Flag name
      * @return Flag builder
      */
-    public CommandFlag.@NonNull Builder<Void> flagBuilder(final @NonNull String name) {
+    public CommandFlag.@NonNull Builder<C, Void> flagBuilder(final @NonNull String name) {
         return CommandFlag.builder(name);
     }
 

--- a/cloud-core/src/main/java/cloud/commandframework/Description.java
+++ b/cloud-core/src/main/java/cloud/commandframework/Description.java
@@ -23,23 +23,12 @@
 //
 package cloud.commandframework;
 
-import cloud.commandframework.arguments.CommandArgument;
+import java.util.Objects;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-/**
- * {@link CommandArgument} description
- *
- * @deprecated to become package-private since 1.4.0. Use {@link ArgumentDescription} instead.
- */
-@Deprecated
-@API(status = API.Status.DEPRECATED, since = "1.4.0")
-public final class Description implements ArgumentDescription {
-
-    /**
-     * Empty command description
-     */
-    static final Description EMPTY = new Description("");
+@API(status = API.Status.INTERNAL, since = "1.4.0")
+final class Description<C> implements ArgumentDescription<C> {
 
     private final String description;
 
@@ -47,46 +36,30 @@ public final class Description implements ArgumentDescription {
         this.description = description;
     }
 
-    /**
-     * Get an empty command description
-     *
-     * @return Command description
-     * @deprecated for removal since 1.4.0. See {@link ArgumentDescription#empty()}
-     */
-    @Deprecated
-    public static @NonNull Description empty() {
-        return EMPTY;
-    }
-
-    /**
-     * Create a command description instance
-     *
-     * @param string Command description
-     * @return Created command description
-     * @deprecated for removal since 1.4.0. See {@link ArgumentDescription#of(String)}
-     */
-    @Deprecated
-    public static @NonNull Description of(final @NonNull String string) {
-        return new Description(string);
-    }
-
-    /**
-     * Get the command description
-     *
-     * @return Command description
-     */
     @Override
-    public @NonNull String getDescription() {
+    public @NonNull String description(final @NonNull C commandSender) {
         return this.description;
     }
 
-    /**
-     * Get the command description
-     *
-     * @return Command description
-     */
     @Override
     public @NonNull String toString() {
         return this.description;
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        final Description<?> that = (Description<?>) object;
+        return Objects.equals(this.description, that.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.description);
     }
 }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/CommandArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/CommandArgument.java
@@ -94,7 +94,7 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
     /**
      * A description that will be used when registering this argument if no override is provided.
      */
-    private final ArgumentDescription defaultDescription;
+    private final ArgumentDescription<C> defaultDescription;
 
     /**
      * Whether or not the argument has been used before
@@ -120,7 +120,7 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
             final @NonNull ArgumentParser<C, T> parser,
             final @NonNull TypeToken<T> valueType,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription,
+            final @NonNull ArgumentDescription<C> defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>, @NonNull Queue<@NonNull String>,
                     @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
     ) {
@@ -200,7 +200,7 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
             final @NonNull ArgumentParser<C, T> parser,
             final @NonNull TypeToken<T> valueType,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         this(name, parser, valueType, suggestionProvider, defaultDescription, Collections.emptyList());
     }
@@ -238,7 +238,7 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
             final @NonNull ArgumentParser<C, T> parser,
             final @NonNull Class<T> valueType,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         this(name, parser, TypeToken.get(valueType), suggestionProvider, defaultDescription);
     }
@@ -402,7 +402,7 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
      *
      * @return the default description
      */
-    public final @NonNull ArgumentDescription getDefaultDescription() {
+    public final @NonNull ArgumentDescription<C> getDefaultDescription() {
         return this.defaultDescription;
     }
 
@@ -495,7 +495,7 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
         private CommandManager<C> manager;
         private ArgumentParser<C, T> parser;
         private SuggestionProvider<C> suggestionProvider;
-        private @NonNull ArgumentDescription defaultDescription = ArgumentDescription.empty();
+        private @NonNull ArgumentDescription<C> defaultDescription = ArgumentDescription.empty();
 
         private final Collection<BiFunction<@NonNull CommandContext<C>,
                 @NonNull String, @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors = new LinkedList<>();
@@ -562,7 +562,7 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
          */
         @API(status = API.Status.STABLE, since = "1.4.0")
         public @NonNull @This Builder<@NonNull C, @NonNull T> withDefaultDescription(
-                final @NonNull ArgumentDescription defaultDescription
+                final @NonNull ArgumentDescription<C> defaultDescription
         ) {
             this.defaultDescription = Objects.requireNonNull(defaultDescription, "Default description may not be null");
             return this;
@@ -606,7 +606,7 @@ public class CommandArgument<C, T> implements Comparable<CommandArgument<?, ?>>,
             return this.suggestionProvider;
         }
 
-        protected final @NonNull ArgumentDescription getDefaultDescription() {
+        protected final @NonNull ArgumentDescription<C> getDefaultDescription() {
             return this.defaultDescription;
         }
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/StandardCommandSyntaxFormatter.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/StandardCommandSyntaxFormatter.java
@@ -56,16 +56,16 @@ public class StandardCommandSyntaxFormatter<C> implements CommandSyntaxFormatter
             final @NonNull List<@NonNull CommandComponent<C>> commandComponents,
             final @Nullable CommandNode<C> node
     ) {
-        final FormattingInstance formattingInstance = this.createInstance();
+        final FormattingInstance<C> formattingInstance = this.createInstance();
         final Iterator<CommandComponent<C>> iterator = commandComponents.iterator();
         while (iterator.hasNext()) {
             final CommandComponent<C> commandComponent = iterator.next();
             if (commandComponent.argument() instanceof StaticArgument) {
                 formattingInstance.appendLiteral((StaticArgument<C>) commandComponent.argument());
             } else if (commandComponent.argument() instanceof CompoundArgument) {
-                formattingInstance.appendCompound(commandComponent, (CompoundArgument<?, ?, ?>) commandComponent.argument());
+                formattingInstance.appendCompound(commandComponent, (CompoundArgument<?, C, ?>) commandComponent.argument());
             } else if (commandComponent.argument() instanceof FlagArgument) {
-                formattingInstance.appendFlag((FlagArgument<?>) commandComponent.argument());
+                formattingInstance.appendFlag((FlagArgument<C>) commandComponent.argument());
             } else {
                 if (commandComponent.required()) {
                     formattingInstance.appendRequired(commandComponent.argument());
@@ -102,13 +102,13 @@ public class StandardCommandSyntaxFormatter<C> implements CommandSyntaxFormatter
             final CommandComponent<C> component = tail.children().get(0).component();
             if (component.argument() instanceof CompoundArgument) {
                 formattingInstance.appendBlankSpace();
-                formattingInstance.appendCompound(component, (CompoundArgument<?, ?, ?>) component.argument());
+                formattingInstance.appendCompound(component, (CompoundArgument<?, C, ?>) component.argument());
             } else if (component.argument() instanceof FlagArgument) {
                 formattingInstance.appendBlankSpace();
-                formattingInstance.appendFlag((FlagArgument<?>) component.argument());
+                formattingInstance.appendFlag((FlagArgument<C>) component.argument());
             } else if (component.argument() instanceof StaticArgument) {
                 formattingInstance.appendBlankSpace();
-                formattingInstance.appendLiteral((StaticArgument<?>) component.argument());
+                formattingInstance.appendLiteral((StaticArgument<C>) component.argument());
             } else {
                 formattingInstance.appendBlankSpace();
                 if (component.required()) {
@@ -127,16 +127,18 @@ public class StandardCommandSyntaxFormatter<C> implements CommandSyntaxFormatter
      *
      * @return Formatting instance
      */
-    protected @NonNull FormattingInstance createInstance() {
-        return new FormattingInstance();
+    protected @NonNull FormattingInstance<C> createInstance() {
+        return new FormattingInstance<>();
     }
 
 
     /**
      * Instance that is used when building command syntax
+     *
+     * @param <C> command sender type
      */
     @API(status = API.Status.STABLE)
-    public static class FormattingInstance {
+    public static class FormattingInstance<C> {
 
         private final StringBuilder builder;
 
@@ -193,15 +195,15 @@ public class StandardCommandSyntaxFormatter<C> implements CommandSyntaxFormatter
          *
          * @param flagArgument Flag argument
          */
-        public void appendFlag(final @NonNull FlagArgument<?> flagArgument) {
+        public void appendFlag(final @NonNull FlagArgument<C> flagArgument) {
             this.builder.append(this.getOptionalPrefix());
 
-            final Iterator<CommandFlag<?>> flagIterator = flagArgument
+            final Iterator<CommandFlag<C, ?>> flagIterator = flagArgument
                     .getFlags()
                     .iterator();
 
             while (flagIterator.hasNext()) {
-                final CommandFlag<?> flag = flagIterator.next();
+                final CommandFlag<C, ?> flag = flagIterator.next();
                 this.appendName(String.format("--%s", flag.getName()));
 
                 if (flag.getCommandArgument() != null) {

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/flags/FlagContext.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/flags/FlagContext.java
@@ -36,17 +36,19 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Flag value mappings
+ *
+ * @param <C> command sender type
  */
 @API(status = API.Status.STABLE)
-@SuppressWarnings({"rawtypes", "unchecked"})
-public final class FlagContext {
+@SuppressWarnings({"unchecked"})
+public final class FlagContext<C> {
 
     /**
      * Dummy object stored as a flag value when the flag has no associated parser
      */
     public static final Object FLAG_PRESENCE_VALUE = new Object();
 
-    private final Map<String, List> flagValues;
+    private final Map<String, List<Object>> flagValues;
 
     private FlagContext() {
         this.flagValues = new HashMap<>();
@@ -55,10 +57,11 @@ public final class FlagContext {
     /**
      * Create a new flag context instance
      *
+     * @param <C> command sender type
      * @return Constructed instance
      */
-    public static @NonNull FlagContext create() {
-        return new FlagContext();
+    public static <C> @NonNull FlagContext<C> create() {
+        return new FlagContext<>();
     }
 
     /**
@@ -66,11 +69,11 @@ public final class FlagContext {
      *
      * @param flag Flag instance
      */
-    public void addPresenceFlag(final @NonNull CommandFlag<?> flag) {
-        ((List<Object>) this.flagValues.computeIfAbsent(
+    public void addPresenceFlag(final @NonNull CommandFlag<C, ?> flag) {
+        this.flagValues.computeIfAbsent(
                 flag.getName(),
                 $ -> new ArrayList<>()
-        )).add(FLAG_PRESENCE_VALUE);
+        ).add(FLAG_PRESENCE_VALUE);
     }
 
     /**
@@ -81,13 +84,13 @@ public final class FlagContext {
      * @param <T>   Value type
      */
     public <T> void addValueFlag(
-            final @NonNull CommandFlag<T> flag,
+            final @NonNull CommandFlag<C, T> flag,
             final @NonNull T value
     ) {
-        ((List<T>) this.flagValues.computeIfAbsent(
+        this.flagValues.computeIfAbsent(
                 flag.getName(),
                 $ -> new ArrayList<>()
-        )).add(value);
+        ).add(value);
     }
 
     /**
@@ -99,7 +102,7 @@ public final class FlagContext {
      * @since 1.7.0
      */
     @API(status = API.Status.STABLE, since = "1.7.0")
-    public <T> int count(final @NonNull CommandFlag<T> flag) {
+    public <T> int count(final @NonNull CommandFlag<C, T> flag) {
         return this.getAll(flag).size();
     }
 
@@ -124,7 +127,7 @@ public final class FlagContext {
      *         else {@code false}
      */
     public boolean isPresent(final @NonNull String flag) {
-        final List value = this.flagValues.get(flag);
+        final List<?> value = this.flagValues.get(flag);
         return value != null && !value.isEmpty();
     }
 
@@ -138,7 +141,7 @@ public final class FlagContext {
      * @since 1.4.0
      */
     @API(status = API.Status.STABLE, since = "1.4.0")
-    public boolean isPresent(final @NonNull CommandFlag<Void> flag) {
+    public boolean isPresent(final @NonNull CommandFlag<C, Void> flag) {
         return this.isPresent(flag.getName());
     }
 
@@ -159,7 +162,7 @@ public final class FlagContext {
     public <T> @NonNull Optional<T> getValue(
             final @NonNull String name
     ) {
-        final List value = this.flagValues.get(name);
+        final List<?> value = this.flagValues.get(name);
         if (value == null || value.isEmpty()) {
             return Optional.empty();
         }
@@ -181,7 +184,7 @@ public final class FlagContext {
      */
     @API(status = API.Status.STABLE, since = "1.4.0")
     public <T> @NonNull Optional<T> getValue(
-            final @NonNull CommandFlag<T> flag
+            final @NonNull CommandFlag<C, T> flag
     ) {
         return this.getValue(flag.getName());
     }
@@ -222,7 +225,7 @@ public final class FlagContext {
      */
     @API(status = API.Status.STABLE, since = "1.4.0")
     public <T> @Nullable T getValue(
-            final @NonNull CommandFlag<T> name,
+            final @NonNull CommandFlag<C, T> name,
             final @Nullable T defaultValue
     ) {
         return this.getValue(name).orElse(defaultValue);
@@ -255,7 +258,7 @@ public final class FlagContext {
      */
     @API(status = API.Status.STABLE, since = "1.4.0")
     public boolean hasFlag(
-            final @NonNull CommandFlag<?> flag
+            final @NonNull CommandFlag<C, ?> flag
     ) {
         return this.getValue(flag).isPresent();
     }
@@ -284,7 +287,7 @@ public final class FlagContext {
      * @since 1.4.0
      */
     @API(status = API.Status.STABLE, since = "1.4.0")
-    public boolean contains(final @NonNull CommandFlag<?> flag) {
+    public boolean contains(final @NonNull CommandFlag<C, ?> flag) {
         return this.hasFlag(flag);
     }
 
@@ -324,7 +327,7 @@ public final class FlagContext {
      */
     @API(status = API.Status.STABLE, since = "1.4.0")
     public <T> @Nullable T get(
-            final @NonNull CommandFlag<T> flag
+            final @NonNull CommandFlag<C, T> flag
     ) {
         return this.getValue(flag).orElse(null);
     }
@@ -339,9 +342,9 @@ public final class FlagContext {
      */
     @API(status = API.Status.STABLE, since = "1.7.0")
     public <T> @NonNull Collection<T> getAll(
-            final @NonNull CommandFlag<T> flag
+            final @NonNull CommandFlag<C, T> flag
     ) {
-        final List values = this.flagValues.get(flag.getName());
+        final List<?> values = this.flagValues.get(flag.getName());
         if (values != null) {
             return Collections.unmodifiableList((List<T>) values);
         }
@@ -360,7 +363,7 @@ public final class FlagContext {
     public <T> @NonNull Collection<T> getAll(
             final @NonNull String flag
     ) {
-        final List values = this.flagValues.get(flag);
+        final List<?> values = this.flagValues.get(flag);
         if (values != null) {
             return Collections.unmodifiableList((List<T>) values);
         }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/BooleanArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/BooleanArgument.java
@@ -54,7 +54,7 @@ public final class BooleanArgument<C> extends CommandArgument<C, Boolean> {
             final @NonNull String name,
             final boolean liberal,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription description
+            final @NonNull ArgumentDescription<C> description
     ) {
         super(name, new BooleanParser<>(liberal), Boolean.class, suggestionProvider, description);
         this.liberal = liberal;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ByteArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ByteArgument.java
@@ -51,7 +51,7 @@ public final class ByteArgument<C> extends CommandArgument<C, Byte> {
             final byte min,
             final byte max,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(name, new ByteParser<>(min, max), Byte.class, suggestionProvider, defaultDescription);
         this.min = min;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/CharArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/CharArgument.java
@@ -46,7 +46,7 @@ public final class CharArgument<C> extends CommandArgument<C, Character> {
     private CharArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(name, new CharacterParser<>(), Character.class, suggestionProvider, defaultDescription);
     }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DoubleArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DoubleArgument.java
@@ -50,7 +50,7 @@ public final class DoubleArgument<C> extends CommandArgument<C, Double> {
             final double min,
             final double max,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(name, new DoubleParser<>(min, max), Double.class, suggestionProvider, defaultDescription);
         this.min = min;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DurationArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DurationArgument.java
@@ -64,7 +64,7 @@ public final class DurationArgument<C> extends CommandArgument<C, Duration> {
     private DurationArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/EnumArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/EnumArgument.java
@@ -56,7 +56,7 @@ public class EnumArgument<C, E extends Enum<E>> extends CommandArgument<C, E> {
             final @NonNull Class<E> enumClass,
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(name, new EnumParser<>(enumClass), enumClass, suggestionProvider, defaultDescription);
     }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/FloatArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/FloatArgument.java
@@ -50,7 +50,7 @@ public final class FloatArgument<C> extends CommandArgument<C, Float> {
             final float min,
             final float max,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(name, new FloatParser<>(min, max), Float.class, suggestionProvider, defaultDescription);
         this.min = min;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/IntegerArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/IntegerArgument.java
@@ -58,7 +58,7 @@ public final class IntegerArgument<C> extends CommandArgument<C, Integer> {
             final int min,
             final int max,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/LongArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/LongArgument.java
@@ -51,7 +51,7 @@ public final class LongArgument<C> extends CommandArgument<C, Long> {
             final long min,
             final long max,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(name, new LongParser<>(min, max), Long.class, suggestionProvider, defaultDescription);
         this.min = min;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ShortArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ShortArgument.java
@@ -51,7 +51,7 @@ public final class ShortArgument<C> extends CommandArgument<C, Short> {
             final short min,
             final short max,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(name, new ShortParser<>(min, max), Short.class, suggestionProvider, defaultDescription);
         this.min = min;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringArgument.java
@@ -58,7 +58,7 @@ public final class StringArgument<C> extends CommandArgument<C, String> {
             final @NonNull String name,
             final @NonNull StringMode stringMode,
             final @NonNull SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(name, new StringParser<>(stringMode, suggestionProvider),
                 String.class, suggestionProvider, defaultDescription

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringArrayArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringArrayArgument.java
@@ -51,7 +51,7 @@ public final class StringArrayArgument<C> extends CommandArgument<C, String[]> {
     private StringArrayArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription,
+            final @NonNull ArgumentDescription<C> defaultDescription,
             final boolean flagYielding
     ) {
         super(

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/UUIDArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/UUIDArgument.java
@@ -47,7 +47,7 @@ public final class UUIDArgument<C> extends CommandArgument<C, UUID> {
     private UUIDArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(name, new UUIDParser<>(), UUID.class, suggestionProvider, defaultDescription);
     }

--- a/cloud-core/src/main/java/cloud/commandframework/context/CommandContext.java
+++ b/cloud-core/src/main/java/cloud/commandframework/context/CommandContext.java
@@ -61,7 +61,7 @@ public class CommandContext<C> {
 
     private final CaptionVariableReplacementHandler captionVariableReplacementHandler;
     private final List<ArgumentContext<C, ?>> argumentContexts = new LinkedList<>();
-    private final FlagContext flagContext = FlagContext.create();
+    private final FlagContext<C> flagContext = FlagContext.create();
     private final Map<CloudKey<?>, Object> internalStorage = new HashMap<>();
     private final C commandSender;
     private final boolean suggestions;
@@ -711,7 +711,7 @@ public class CommandContext<C> {
      *
      * @return Flag context
      */
-    public @NonNull FlagContext flags() {
+    public @NonNull FlagContext<C> flags() {
         return this.flagContext;
     }
 

--- a/cloud-core/src/test/java/cloud/commandframework/CommandHelpHandlerTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandHelpHandlerTest.java
@@ -23,7 +23,6 @@
 //
 package cloud.commandframework;
 
-import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.StaticArgument;
 import cloud.commandframework.arguments.standard.IntegerArgument;
 import cloud.commandframework.arguments.standard.StringArgument;
@@ -247,7 +246,7 @@ class CommandHelpHandlerTest {
         while (iterator.hasNext()) {
             final CommandComponent<TestCommandSender> component = iterator.next();
 
-            String description = component.argumentDescription().getDescription();
+            String description = component.argumentDescription().description(new TestCommandSender());
             if (!description.isEmpty()) {
                 description = ": " + description;
             }

--- a/cloud-core/src/test/java/cloud/commandframework/CommandManagerTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandManagerTest.java
@@ -163,9 +163,9 @@ class CommandManagerTest {
         assertThat(TypeToken.get(int.class)).isEqualTo(components.get(3).argument().getValueType());
 
         // Check description is set for all components, is empty when not specified
-        assertThat(components.get(0).argumentDescription().getDescription()).isEmpty();
-        assertThat(components.get(1).argumentDescription().getDescription()).isEmpty();
-        assertThat(components.get(2).argumentDescription().getDescription()).isEqualTo("detaildescription");
-        assertThat(components.get(3).argumentDescription().getDescription()).isEqualTo("argumentdescription");
+        assertThat(components.get(0).argumentDescription().description(new TestCommandSender())).isEmpty();
+        assertThat(components.get(1).argumentDescription().description(new TestCommandSender())).isEmpty();
+        assertThat(components.get(2).argumentDescription().description(new TestCommandSender())).isEqualTo("detaildescription");
+        assertThat(components.get(3).argumentDescription().description(new TestCommandSender())).isEqualTo("argumentdescription");
     }
 }

--- a/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
@@ -232,7 +232,7 @@ class CommandTreeTest {
         final CommandExecutionHandler<TestCommandSender> executionHandler = mock(CommandExecutionHandler.class);
         when(executionHandler.executeFuture(any())).thenReturn(CompletableFuture.completedFuture(null));
 
-        final CommandFlag<Integer> num = this.commandManager.flagBuilder("num")
+        final CommandFlag<TestCommandSender, Integer> num = this.commandManager.flagBuilder("num")
                 .withArgument(IntegerArgument.of("num"))
                 .build();
 

--- a/cloud-core/src/test/java/cloud/commandframework/issue/Issue321.java
+++ b/cloud-core/src/test/java/cloud/commandframework/issue/Issue321.java
@@ -75,7 +75,7 @@ class Issue321 {
 
         // Assert
         final CommandContext<TestCommandSender> context = result.getCommandContext();
-        final FlagContext flags = context.flags();
+        final FlagContext<TestCommandSender> flags = context.flags();
 
         assertThat(flags.<String[]>getValue("flag1")).hasValue(new String[]{"one", "two", "three"});
         assertThat(flags.<String[]>getValue("flag2")).hasValue(new String[]{"1", "2", "3"});

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/ChannelArgument.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/ChannelArgument.java
@@ -55,7 +55,7 @@ public final class ChannelArgument<C> extends CommandArgument<C, MessageChannel>
     private ChannelArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription,
+            final @NonNull ArgumentDescription<C> defaultDescription,
             final @NonNull Set<ParserMode> modes
     ) {
         super(

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/RoleArgument.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/RoleArgument.java
@@ -54,7 +54,7 @@ public final class RoleArgument<C> extends CommandArgument<C, Role> {
     private RoleArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription,
+            final @NonNull ArgumentDescription<C> defaultDescription,
             final @NonNull Set<ParserMode> modes
     ) {
         super(name, new RoleParser<>(modes), Role.class, suggestionProvider, defaultDescription);

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/UserArgument.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/parsers/UserArgument.java
@@ -59,7 +59,7 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
     private UserArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription,
+            final @NonNull ArgumentDescription<C> defaultDescription,
             final @NonNull Set<ParserMode> modes,
             final @NonNull Isolation isolationLevel
     ) {

--- a/cloud-irc/cloud-pircbotx/src/main/java/cloud/commandframework/pircbotx/arguments/UserArgument.java
+++ b/cloud-irc/cloud-pircbotx/src/main/java/cloud/commandframework/pircbotx/arguments/UserArgument.java
@@ -53,7 +53,7 @@ public final class UserArgument<C> extends CommandArgument<C, User> {
     private UserArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-kotlin/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/MutableCommandBuilder.kt
+++ b/cloud-kotlin/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/MutableCommandBuilder.kt
@@ -26,7 +26,6 @@ package cloud.commandframework.kotlin
 import cloud.commandframework.ArgumentDescription
 import cloud.commandframework.Command
 import cloud.commandframework.CommandManager
-import cloud.commandframework.Description
 import cloud.commandframework.arguments.CommandArgument
 import cloud.commandframework.execution.CommandExecutionHandler
 import cloud.commandframework.kotlin.extension.command
@@ -63,60 +62,14 @@ public class MutableCommandBuilder<C : Any>(
      * @param description description for the root command node
      * @param aliases aliases for the root command node
      * @param commandManager the command manager which will own this command
-     * @since 1.3.0
-     */
-    @Suppress("DEPRECATION")
-    @Deprecated(
-        message = "ArgumentDescription should be used over Description",
-        level = DeprecationLevel.HIDDEN
-    )
-    public constructor(
-        name: String,
-        description: Description = Description.empty(),
-        aliases: Array<String> = emptyArray(),
-        commandManager: CommandManager<C>
-    ) : this(commandManager.commandBuilder(name, description, *aliases), commandManager)
-
-    /**
-     * Create a new [MutableCommandBuilder]
-     *
-     * @param name name for the root command node
-     * @param description description for the root command node
-     * @param aliases aliases for the root command node
-     * @param commandManager the command manager which will own this command
      * @since 1.4.0
      */
     public constructor(
         name: String,
-        description: ArgumentDescription = ArgumentDescription.empty(),
+        description: ArgumentDescription<C> = ArgumentDescription.empty(),
         aliases: Array<String> = emptyArray(),
         commandManager: CommandManager<C>
     ) : this(commandManager.commandBuilder(name, description, *aliases), commandManager)
-
-    /**
-     * Create a new [MutableCommandBuilder] and invoke the provided receiver lambda on it
-     *
-     * @param name name for the root command node
-     * @param description description for the root command node
-     * @param aliases aliases for the root command node
-     * @param commandManager the command manager which will own this command
-     * @param lambda receiver lambda which will be invoked on the new builder
-     * @since 1.3.0
-     */
-    @Suppress("DEPRECATION")
-    @Deprecated(
-        message = "ArgumentDescription should be used over Description",
-        level = DeprecationLevel.HIDDEN
-    )
-    public constructor(
-        name: String,
-        description: Description = Description.empty(),
-        aliases: Array<String> = emptyArray(),
-        commandManager: CommandManager<C>,
-        lambda: MutableCommandBuilder<C>.() -> Unit
-    ) : this(name, description, aliases, commandManager) {
-        lambda(this)
-    }
 
     /**
      * Create a new [MutableCommandBuilder] and invoke the provided receiver lambda on it
@@ -130,7 +83,7 @@ public class MutableCommandBuilder<C : Any>(
      */
     public constructor(
         name: String,
-        description: ArgumentDescription = ArgumentDescription.empty(),
+        description: ArgumentDescription<C> = ArgumentDescription.empty(),
         aliases: Array<String> = emptyArray(),
         commandManager: CommandManager<C>,
         lambda: MutableCommandBuilder<C>.() -> Unit
@@ -204,36 +157,11 @@ public class MutableCommandBuilder<C : Any>(
      * @param description description for the literal
      * @param lambda receiver lambda which will be invoked on the new builder
      * @return a copy of this mutable builder
-     * @since 1.3.0
-     */
-    @Suppress("DEPRECATION")
-    @Deprecated(
-        message = "ArgumentDescription should be used over Description",
-        level = DeprecationLevel.HIDDEN
-    )
-    public fun copy(
-        literal: String,
-        description: Description,
-        lambda: MutableCommandBuilder<C>.() -> Unit
-    ): MutableCommandBuilder<C> =
-        copy().apply {
-            literal(literal, description)
-            lambda(this)
-        }
-
-    /**
-     * Make a new copy of this [MutableCommandBuilder], append a literal, and invoke the provided
-     * receiver lambda on it
-     *
-     * @param literal name for the literal
-     * @param description description for the literal
-     * @param lambda receiver lambda which will be invoked on the new builder
-     * @return a copy of this mutable builder
      * @since 1.4.0
      */
     public fun copy(
         literal: String,
-        description: ArgumentDescription,
+        description: ArgumentDescription<C>,
         lambda: MutableCommandBuilder<C>.() -> Unit
     ): MutableCommandBuilder<C> =
         copy().apply {
@@ -304,33 +232,11 @@ public class MutableCommandBuilder<C : Any>(
      * @param lambda receiver lambda which will be invoked on the new builder
      * @return the new mutable builder
      * @see [CommandManager.command]
-     * @since 1.3.0
-     */
-    @Suppress("DEPRECATION")
-    @Deprecated(
-        message = "ArgumentDescription should be used over Description",
-        level = DeprecationLevel.HIDDEN
-    )
-    public fun registerCopy(
-        literal: String,
-        description: Description,
-        lambda: MutableCommandBuilder<C>.() -> Unit
-    ): MutableCommandBuilder<C> = copy(literal, description, lambda).register()
-
-    /**
-     * Create a new copy of this mutable builder, append a literal, act on it with a receiver
-     * lambda, and then register it with the owning command manager
-     *
-     * @param literal name for the literal
-     * @param description description for the literal
-     * @param lambda receiver lambda which will be invoked on the new builder
-     * @return the new mutable builder
-     * @see [CommandManager.command]
      * @since 1.4.0
      */
     public fun registerCopy(
         literal: String,
-        description: ArgumentDescription,
+        description: ArgumentDescription<C>,
         lambda: MutableCommandBuilder<C>.() -> Unit
     ): MutableCommandBuilder<C> = copy(literal, description, lambda).register()
 
@@ -484,7 +390,7 @@ public class MutableCommandBuilder<C : Any>(
      */
     public fun required(
         argument: CommandArgument<C, *>,
-        description: ArgumentDescription = ArgumentDescription.empty()
+        description: ArgumentDescription<C> = ArgumentDescription.empty()
     ): MutableCommandBuilder<C> = mutate { it.required(argument, description) }
 
     /**
@@ -497,7 +403,7 @@ public class MutableCommandBuilder<C : Any>(
      */
     public fun optional(
         argument: CommandArgument<C, *>,
-        description: ArgumentDescription = ArgumentDescription.empty()
+        description: ArgumentDescription<C> = ArgumentDescription.empty()
     ): MutableCommandBuilder<C> = mutate { it.optional(argument, description) }
 
     /**
@@ -510,7 +416,7 @@ public class MutableCommandBuilder<C : Any>(
      */
     public fun required(
         argument: CommandArgument.Builder<C, *>,
-        description: ArgumentDescription = ArgumentDescription.empty()
+        description: ArgumentDescription<C> = ArgumentDescription.empty()
     ): MutableCommandBuilder<C> = mutate { it.required(argument, description) }
 
     /**
@@ -523,7 +429,7 @@ public class MutableCommandBuilder<C : Any>(
      */
     public fun optional(
         argument: CommandArgument.Builder<C, *>,
-        description: ArgumentDescription = ArgumentDescription.empty()
+        description: ArgumentDescription<C> = ArgumentDescription.empty()
     ): MutableCommandBuilder<C> = mutate { it.optional(argument, description) }
 
     /**
@@ -535,7 +441,7 @@ public class MutableCommandBuilder<C : Any>(
      * @since 2.0.0
      */
     public fun required(
-        description: ArgumentDescription = ArgumentDescription.empty(),
+        description: ArgumentDescription<C> = ArgumentDescription.empty(),
         argumentSupplier: () -> CommandArgument<C, *>
     ): MutableCommandBuilder<C> = mutate { it.required(argumentSupplier(), description) }
 
@@ -548,7 +454,7 @@ public class MutableCommandBuilder<C : Any>(
      * @since 2.0.0
      */
     public fun optional(
-        description: ArgumentDescription = ArgumentDescription.empty(),
+        description: ArgumentDescription<C> = ArgumentDescription.empty(),
         argumentSupplier: () -> CommandArgument<C, *>
     ): MutableCommandBuilder<C> = mutate { it.optional(argumentSupplier(), description) }
 
@@ -563,7 +469,7 @@ public class MutableCommandBuilder<C : Any>(
      */
     public fun literal(
         name: String,
-        description: ArgumentDescription = ArgumentDescription.empty(),
+        description: ArgumentDescription<C> = ArgumentDescription.empty(),
         vararg aliases: String
     ): MutableCommandBuilder<C> = mutate { it.literal(name, description, *aliases) }
 
@@ -591,7 +497,7 @@ public class MutableCommandBuilder<C : Any>(
     public fun flag(
         name: String,
         aliases: Array<String> = emptyArray(),
-        description: ArgumentDescription = ArgumentDescription.empty(),
+        description: ArgumentDescription<C> = ArgumentDescription.empty(),
         argumentSupplier: () -> CommandArgument<C, *>
     ): MutableCommandBuilder<C> = mutate {
         it.flag(
@@ -617,7 +523,7 @@ public class MutableCommandBuilder<C : Any>(
     public fun flag(
         name: String,
         aliases: Array<String> = emptyArray(),
-        description: ArgumentDescription = ArgumentDescription.empty(),
+        description: ArgumentDescription<C> = ArgumentDescription.empty(),
         argument: CommandArgument<C, *>
     ): MutableCommandBuilder<C> = mutate {
         it.flag(
@@ -643,7 +549,7 @@ public class MutableCommandBuilder<C : Any>(
     public fun flag(
         name: String,
         aliases: Array<String> = emptyArray(),
-        description: ArgumentDescription = ArgumentDescription.empty(),
+        description: ArgumentDescription<C> = ArgumentDescription.empty(),
         argumentBuilder: CommandArgument.Builder<C, *>
     ): MutableCommandBuilder<C> = mutate {
         it.flag(
@@ -668,7 +574,7 @@ public class MutableCommandBuilder<C : Any>(
     public fun flag(
         name: String,
         aliases: Array<String> = emptyArray(),
-        description: ArgumentDescription = ArgumentDescription.empty()
+        description: ArgumentDescription<C> = ArgumentDescription.empty()
     ): MutableCommandBuilder<C> = mutate {
         it.flag(
             this.commandManager

--- a/cloud-kotlin/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/extension/CommandBuildingExtensions.kt
+++ b/cloud-kotlin/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/extension/CommandBuildingExtensions.kt
@@ -26,7 +26,6 @@ package cloud.commandframework.kotlin.extension
 import cloud.commandframework.ArgumentDescription
 import cloud.commandframework.Command
 import cloud.commandframework.CommandManager
-import cloud.commandframework.Description
 import cloud.commandframework.kotlin.MutableCommandBuilder
 import kotlin.reflect.KClass
 
@@ -37,57 +36,14 @@ import kotlin.reflect.KClass
  * @param description description for the root command node
  * @param aliases aliases for the root command node
  * @param lambda receiver lambda which will be invoked on the new builder
- * @since 1.3.0
- */
-@Suppress("DEPRECATION")
-@Deprecated(
-    message = "ArgumentDescription should be used over Description",
-    level = DeprecationLevel.HIDDEN
-)
-public fun <C : Any> CommandManager<C>.commandBuilder(
-    name: String,
-    description: Description = Description.empty(),
-    aliases: Array<String> = emptyArray(),
-    lambda: MutableCommandBuilder<C>.() -> Unit
-): MutableCommandBuilder<C> = MutableCommandBuilder(name, description, aliases, this, lambda)
-
-/**
- * Create a new [MutableCommandBuilder] and invoke the provided receiver lambda on it
- *
- * @param name name for the root command node
- * @param description description for the root command node
- * @param aliases aliases for the root command node
- * @param lambda receiver lambda which will be invoked on the new builder
  * @since 1.4.0
  */
 public fun <C : Any> CommandManager<C>.commandBuilder(
     name: String,
-    description: ArgumentDescription = ArgumentDescription.empty(),
+    description: ArgumentDescription<C> = ArgumentDescription.empty(),
     aliases: Array<String> = emptyArray(),
     lambda: MutableCommandBuilder<C>.() -> Unit
 ): MutableCommandBuilder<C> = MutableCommandBuilder(name, description, aliases, this, lambda)
-
-/**
- * Create a new [MutableCommandBuilder] which will invoke the provided receiver lambda, and then
- * register itself with the owning [CommandManager]
- *
- * @param name name for the root command node
- * @param description description for the root command node
- * @param aliases aliases for the root command node
- * @param lambda receiver lambda which will be invoked on the new builder
- * @since 1.3.0
- */
-@Suppress("DEPRECATION")
-@Deprecated(
-    message = "ArgumentDescription should be used over Description",
-    level = DeprecationLevel.HIDDEN
-)
-public fun <C : Any> CommandManager<C>.buildAndRegister(
-    name: String,
-    description: Description = Description.empty(),
-    aliases: Array<String> = emptyArray(),
-    lambda: MutableCommandBuilder<C>.() -> Unit
-): MutableCommandBuilder<C> = commandBuilder(name, description, aliases, lambda).register()
 
 /**
  * Create a new [MutableCommandBuilder] which will invoke the provided receiver lambda, and then
@@ -101,7 +57,7 @@ public fun <C : Any> CommandManager<C>.buildAndRegister(
  */
 public fun <C : Any> CommandManager<C>.buildAndRegister(
     name: String,
-    description: ArgumentDescription = ArgumentDescription.empty(),
+    description: ArgumentDescription<C> = ArgumentDescription.empty(),
     aliases: Array<String> = emptyArray(),
     lambda: MutableCommandBuilder<C>.() -> Unit
 ): MutableCommandBuilder<C> = commandBuilder(name, description, aliases, lambda).register()
@@ -152,26 +108,12 @@ public fun <C : Any> Command.Builder<C>.mutate(
 ): MutableCommandBuilder<C> = MutableCommandBuilder(this, commandManager).also(lambda)
 
 /**
- * Get a [Description], defaulting to [Description.empty]
- *
- * @param description description string
- * @return the description
- * @since 1.3.0
- */
-@Suppress("DEPRECATION")
-@Deprecated(
-    message = "Use interface variant that allows for rich text",
-    replaceWith = ReplaceWith("argumentDescription(description)")
-)
-public fun description(description: String = ""): Description =
-    if (description.isEmpty()) Description.empty() else Description.of(description)
-
-/**
  * Get a [ArgumentDescription], defaulting to [ArgumentDescription.empty]
  *
+ * @param <C> command sender type
  * @param description description string
  * @return the description
  * @since 1.4.0
  */
-public fun argumentDescription(description: String = ""): ArgumentDescription =
+public fun <C> argumentDescription(description: String = ""): ArgumentDescription<C> =
     if (description.isEmpty()) ArgumentDescription.empty() else ArgumentDescription.of(description)

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/argument/NamespacedKeyArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/argument/NamespacedKeyArgument.java
@@ -55,7 +55,7 @@ public final class NamespacedKeyArgument<C> extends CommandArgument<C, Namespace
     private NamespacedKeyArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription,
+            final @NonNull ArgumentDescription<C> defaultDescription,
             final boolean requireExplicitNamespace,
             final String defaultNamespace
     ) {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/BlockPredicateArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/BlockPredicateArgument.java
@@ -66,7 +66,7 @@ public final class BlockPredicateArgument<C> extends CommandArgument<C, BlockPre
     private BlockPredicateArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(name, new Parser<>(), BlockPredicate.class, suggestionProvider, defaultDescription);
     }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/EnchantmentArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/EnchantmentArgument.java
@@ -52,7 +52,7 @@ public class EnchantmentArgument<C> extends CommandArgument<C, Enchantment> {
     protected EnchantmentArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/ItemStackArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/ItemStackArgument.java
@@ -70,7 +70,7 @@ public final class ItemStackArgument<C> extends CommandArgument<C, ProtoItemStac
     private ItemStackArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(name, new Parser<>(), ProtoItemStack.class, suggestionProvider, defaultDescription);
     }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/ItemStackPredicateArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/ItemStackPredicateArgument.java
@@ -67,7 +67,7 @@ public final class ItemStackPredicateArgument<C> extends CommandArgument<C, Item
     private ItemStackPredicateArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(name, new Parser<>(), ItemStackPredicate.class, suggestionProvider, defaultDescription);
     }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/MaterialArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/MaterialArgument.java
@@ -51,7 +51,7 @@ public class MaterialArgument<C> extends CommandArgument<C, Material> {
     protected MaterialArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(name, new MaterialParser<>(), Material.class, suggestionProvider, defaultDescription);
     }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/OfflinePlayerArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/OfflinePlayerArgument.java
@@ -59,7 +59,7 @@ public final class OfflinePlayerArgument<C> extends CommandArgument<C, OfflinePl
     private OfflinePlayerArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/PlayerArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/PlayerArgument.java
@@ -55,7 +55,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
     private PlayerArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(name, new PlayerParser<>(), Player.class, suggestionProvider, defaultDescription);
     }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/WorldArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/WorldArgument.java
@@ -52,7 +52,7 @@ public class WorldArgument<C> extends CommandArgument<C, World> {
     protected WorldArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(name, new WorldParser<>(), World.class, suggestionProvider, defaultDescription);
     }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/Location2DArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/Location2DArgument.java
@@ -58,7 +58,7 @@ public final class Location2DArgument<C> extends CommandArgument<C, Location2D> 
 
     private Location2DArgument(
             final @NonNull String name,
-            final @NonNull ArgumentDescription defaultDescription,
+            final @NonNull ArgumentDescription<C> defaultDescription,
             final @Nullable SuggestionProvider<C> suggestionProvider,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>,
                     @NonNull Queue<@NonNull String>, @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/LocationArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/LocationArgument.java
@@ -64,7 +64,7 @@ public final class LocationArgument<C> extends CommandArgument<C, Location> {
     private LocationArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription,
+            final @NonNull ArgumentDescription<C> defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>,
                     @NonNull Queue<@NonNull String>, @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
     ) {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultipleEntitySelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultipleEntitySelectorArgument.java
@@ -47,7 +47,7 @@ public final class MultipleEntitySelectorArgument<C> extends CommandArgument<C, 
             final boolean allowEmpty,
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(name, new MultipleEntitySelectorParser<>(allowEmpty),
                 MultipleEntitySelector.class, suggestionProvider, defaultDescription

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultiplePlayerSelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/MultiplePlayerSelectorArgument.java
@@ -54,7 +54,7 @@ public final class MultiplePlayerSelectorArgument<C> extends CommandArgument<C, 
             final boolean allowEmpty,
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(name, new MultiplePlayerSelectorParser<>(allowEmpty), MultiplePlayerSelector.class,
                 suggestionProvider, defaultDescription

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SingleEntitySelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SingleEntitySelectorArgument.java
@@ -45,7 +45,7 @@ public final class SingleEntitySelectorArgument<C> extends CommandArgument<C, Si
     private SingleEntitySelectorArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SinglePlayerSelectorArgument.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SinglePlayerSelectorArgument.java
@@ -52,7 +52,7 @@ public final class SinglePlayerSelectorArgument<C> extends CommandArgument<C, Si
     private SinglePlayerSelectorArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/PlayerArgument.java
+++ b/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/PlayerArgument.java
@@ -57,7 +57,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, ProxiedPlayer> {
     private PlayerArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription,
+            final @NonNull ArgumentDescription<C> defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>, @NonNull Queue<@NonNull String>,
                     @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
     ) {

--- a/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/ServerArgument.java
+++ b/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/ServerArgument.java
@@ -57,7 +57,7 @@ public final class ServerArgument<C> extends CommandArgument<C, ServerInfo> {
     private ServerArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription,
+            final @NonNull ArgumentDescription<C> defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>, @NonNull Queue<@NonNull String>,
                     @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
     ) {

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/AngleArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/AngleArgument.java
@@ -41,7 +41,7 @@ public final class AngleArgument<C> extends CommandArgument<C, net.minecraft.com
     AngleArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/AxisArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/AxisArgument.java
@@ -48,7 +48,7 @@ public final class AxisArgument<C> extends CommandArgument<C, EnumSet<Direction.
     AxisArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/CompoundTagArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/CompoundTagArgument.java
@@ -42,7 +42,7 @@ public final class CompoundTagArgument<C> extends CommandArgument<C, CompoundTag
     CompoundTagArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/EntityAnchorArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/EntityAnchorArgument.java
@@ -42,7 +42,7 @@ public final class EntityAnchorArgument<C> extends
     EntityAnchorArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/FloatRangeArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/FloatRangeArgument.java
@@ -44,7 +44,7 @@ public final class FloatRangeArgument<C> extends CommandArgument<C, MinMaxBounds
     FloatRangeArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/IntRangeArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/IntRangeArgument.java
@@ -44,7 +44,7 @@ public final class IntRangeArgument<C> extends CommandArgument<C, MinMaxBounds.I
     IntRangeArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ItemInputArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ItemInputArgument.java
@@ -42,7 +42,7 @@ public final class ItemInputArgument<C> extends CommandArgument<C, ItemInput> {
     ItemInputArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/MobEffectArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/MobEffectArgument.java
@@ -46,7 +46,7 @@ public final class MobEffectArgument<C> extends CommandArgument<C, MobEffect> {
     MobEffectArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/NamedColorArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/NamedColorArgument.java
@@ -42,7 +42,7 @@ public final class NamedColorArgument<C> extends CommandArgument<C, ChatFormatti
     NamedColorArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/NbtPathArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/NbtPathArgument.java
@@ -42,7 +42,7 @@ public final class NbtPathArgument<C> extends CommandArgument<C, net.minecraft.c
     NbtPathArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/NbtTagArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/NbtTagArgument.java
@@ -42,7 +42,7 @@ public final class NbtTagArgument<C> extends CommandArgument<C, Tag> {
     NbtTagArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ObjectiveCriteriaArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ObjectiveCriteriaArgument.java
@@ -42,7 +42,7 @@ public final class ObjectiveCriteriaArgument<C> extends CommandArgument<C, Objec
     ObjectiveCriteriaArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ParticleArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ParticleArgument.java
@@ -41,7 +41,7 @@ public final class ParticleArgument<C> extends CommandArgument<C, ParticleOption
     ParticleArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/RegistryEntryArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/RegistryEntryArgument.java
@@ -68,7 +68,7 @@ public class RegistryEntryArgument<C, V> extends CommandArgument<C, V> {
             final @NonNull ResourceKey<? extends Registry<V>> registry,
             final @NonNull TypeToken<V> valueType,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ResourceLocationArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ResourceLocationArgument.java
@@ -42,7 +42,7 @@ public final class ResourceLocationArgument<C> extends CommandArgument<C, Resour
     ResourceLocationArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ScoreboardOperationArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/ScoreboardOperationArgument.java
@@ -45,7 +45,7 @@ public final class ScoreboardOperationArgument<C> extends CommandArgument<C, Ope
     ScoreboardOperationArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/TeamArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/TeamArgument.java
@@ -53,7 +53,7 @@ public final class TeamArgument<C> extends CommandArgument<C, PlayerTeam> {
     TeamArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/TimeArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/TimeArgument.java
@@ -41,7 +41,7 @@ public final class TimeArgument<C> extends CommandArgument<C, MinecraftTime> {
     TimeArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/BlockPosArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/BlockPosArgument.java
@@ -42,7 +42,7 @@ public final class BlockPosArgument<C> extends CommandArgument<C, BlockCoordinat
     BlockPosArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/ColumnPosArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/ColumnPosArgument.java
@@ -42,7 +42,7 @@ public final class ColumnPosArgument<C> extends CommandArgument<C, ColumnCoordin
     ColumnPosArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/MessageArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/MessageArgument.java
@@ -42,7 +42,7 @@ public final class MessageArgument<C> extends CommandArgument<C, Message> {
     MessageArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/MultipleEntitySelectorArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/MultipleEntitySelectorArgument.java
@@ -43,7 +43,7 @@ public final class MultipleEntitySelectorArgument<C> extends CommandArgument<C, 
     MultipleEntitySelectorArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/MultiplePlayerSelectorArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/MultiplePlayerSelectorArgument.java
@@ -43,7 +43,7 @@ public final class MultiplePlayerSelectorArgument<C> extends CommandArgument<C, 
     MultiplePlayerSelectorArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/SingleEntitySelectorArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/SingleEntitySelectorArgument.java
@@ -43,7 +43,7 @@ public final class SingleEntitySelectorArgument<C> extends CommandArgument<C, Si
     SingleEntitySelectorArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/SinglePlayerSelectorArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/SinglePlayerSelectorArgument.java
@@ -43,7 +43,7 @@ public final class SinglePlayerSelectorArgument<C> extends CommandArgument<C, Si
     SinglePlayerSelectorArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(
                 name,

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/Vec2dArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/Vec2dArgument.java
@@ -44,7 +44,7 @@ public final class Vec2dArgument<C> extends CommandArgument<C, Coordinates.Coord
     Vec2dArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription,
+            final @NonNull ArgumentDescription<C> defaultDescription,
             final boolean centerIntegers
     ) {
         super(

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/Vec3dArgument.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/server/Vec3dArgument.java
@@ -44,7 +44,7 @@ public final class Vec3dArgument<C> extends CommandArgument<C, Coordinates> {
     Vec3dArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription,
+            final @NonNull ArgumentDescription<C> defaultDescription,
             final boolean centerIntegers
     ) {
         super(

--- a/cloud-minecraft/cloud-fabric/src/testmod/java/cloud/commandframework/fabric/testmod/FabricClientExample.java
+++ b/cloud-minecraft/cloud-fabric/src/testmod/java/cloud/commandframework/fabric/testmod/FabricClientExample.java
@@ -24,7 +24,6 @@
 package cloud.commandframework.fabric.testmod;
 
 import cloud.commandframework.Command;
-import cloud.commandframework.arguments.flags.CommandFlag;
 import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.execution.CommandExecutionCoordinator;
 import cloud.commandframework.fabric.FabricClientCommandManager;
@@ -129,7 +128,7 @@ public final class FabricClientExample implements ClientModInitializer {
 
         commandManager.command(base.literal("flag_test")
                 .optional(StringArgument.of("parameter"))
-                .flag(CommandFlag.builder("flag").withAliases("f"))
+                .flag(commandManager.flagBuilder("flag").withAliases("f"))
                 .handler(ctx -> ctx.getSender().sendFeedback(Component.literal("Had flag: " + ctx.flags().isPresent("flag")))));
     }
 

--- a/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/MinecraftHelp.java
+++ b/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/MinecraftHelp.java
@@ -535,8 +535,8 @@ public final class MinecraftHelp<C> {
                     );
                     textComponent.append(text(")", this.colors.alternateHighlight));
                 }
-                final ArgumentDescription description = component.argumentDescription();
-                if (!description.isEmpty()) {
+                final ArgumentDescription<C> description = component.argumentDescription();
+                if (!description.isEmpty(sender)) {
                     textComponent.append(text(" - ", this.colors.accent));
                     textComponent.append(this.formatDescription(sender, description).colorIfAbsent(this.colors.text));
                 }
@@ -547,11 +547,11 @@ public final class MinecraftHelp<C> {
         audience.sendMessage(this.footer(sender));
     }
 
-    private Component formatDescription(final C sender, final ArgumentDescription description) {
+    private Component formatDescription(final C sender, final ArgumentDescription<C> description) {
         if (description instanceof RichDescription) {
-            return ((RichDescription) description).getContents();
+            return ((RichDescription<C>) description).getContents();
         } else {
-            return this.descriptionDecorator.apply(sender, description.getDescription());
+            return this.descriptionDecorator.apply(sender, description.description(sender));
         }
     }
 

--- a/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/RichDescription.java
+++ b/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/RichDescription.java
@@ -35,11 +35,10 @@ import static java.util.Objects.requireNonNull;
 /**
  * An argument description implementation that uses Adventure components.
  *
+ * @param <C> command sender type
  * @since 1.4.0
  */
-public final class RichDescription implements ArgumentDescription {
-
-    private static final RichDescription EMPTY = new RichDescription(Component.empty());
+public final class RichDescription<C> implements ArgumentDescription<C> {
 
     private final Component contents;
 
@@ -50,25 +49,27 @@ public final class RichDescription implements ArgumentDescription {
     /**
      * Get an empty description.
      *
+     * @param <C> command sender type
      * @return the empty description
      */
-    public static @NonNull RichDescription empty() {
-        return EMPTY;
+    public static <C> @NonNull RichDescription<C> empty() {
+        return of(Component.empty());
     }
 
     /**
      * Create a new rich description from the provided component.
      *
+     * @param <C> command sender type
      * @param contents the rich contents
      * @return a new rich description
      */
-    public static @NonNull RichDescription of(final @NonNull ComponentLike contents) {
+    public static <C> @NonNull RichDescription<C> of(final @NonNull ComponentLike contents) {
         final Component componentContents = requireNonNull(contents, "contents").asComponent();
         if (Component.empty().equals(componentContents)) {
-            return EMPTY;
+            return empty();
         }
 
-        return new RichDescription(componentContents);
+        return new RichDescription<>(componentContents);
     }
 
     /* Translatable helper methods */
@@ -76,30 +77,32 @@ public final class RichDescription implements ArgumentDescription {
     /**
      * Create a rich description pointing to a translation key.
      *
+     * @param <C> command sender type
      * @param key the translation key
      * @return a new rich description
      */
-    public static @NonNull RichDescription translatable(final @NonNull String key) {
+    public static <C> @NonNull RichDescription<C> translatable(final @NonNull String key) {
         requireNonNull(key, "key");
 
-        return new RichDescription(Component.translatable(key));
+        return new RichDescription<>(Component.translatable(key));
     }
 
     /**
      * Create a rich description pointing to a translation key.
      *
+     * @param <C> command sender type
      * @param key  the translation key
      * @param args the arguments to use with the translation key
      * @return a new rich description
      */
-    public static @NonNull RichDescription translatable(
+    public static <C> @NonNull RichDescription<C> translatable(
             final @NonNull String key,
             final @NonNull ComponentLike @NonNull... args
     ) {
         requireNonNull(key, "key");
         requireNonNull(args, "args");
 
-        return new RichDescription(Component.translatable(key, args));
+        return new RichDescription<>(Component.translatable(key, args));
     }
 
     /**
@@ -110,7 +113,7 @@ public final class RichDescription implements ArgumentDescription {
      */
     @Override
     @Deprecated
-    public @NonNull String getDescription() {
+    public @NonNull String description(final @NonNull C commandSender) {
         return net.kyori.adventure.text.serializer.plain.PlainComponentSerializer.plain()
                 .serialize(GlobalTranslator.render(this.contents, Locale.getDefault()));
     }
@@ -125,7 +128,7 @@ public final class RichDescription implements ArgumentDescription {
     }
 
     @Override
-    public boolean isEmpty() {
+    public boolean isEmpty(final @NonNull C commandSender) {
         return Component.empty().equals(this.contents);
     }
 }

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/argument/KeyedWorldArgument.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/argument/KeyedWorldArgument.java
@@ -56,7 +56,7 @@ public final class KeyedWorldArgument<C> extends CommandArgument<C, World> {
     KeyedWorldArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription
+            final @NonNull ArgumentDescription<C> defaultDescription
     ) {
         super(name, new Parser<>(), World.class, suggestionProvider, defaultDescription);
     }

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/PlayerArgument.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/PlayerArgument.java
@@ -57,7 +57,7 @@ public final class PlayerArgument<C> extends CommandArgument<C, Player> {
     private PlayerArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription,
+            final @NonNull ArgumentDescription<C> defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>, @NonNull Queue<@NonNull String>,
                     @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
     ) {

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/ServerArgument.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/ServerArgument.java
@@ -57,7 +57,7 @@ public final class ServerArgument<C> extends CommandArgument<C, RegisteredServer
     private ServerArgument(
             final @NonNull String name,
             final @Nullable SuggestionProvider<C> suggestionProvider,
-            final @NonNull ArgumentDescription defaultDescription,
+            final @NonNull ArgumentDescription<C> defaultDescription,
             final @NonNull Collection<@NonNull BiFunction<@NonNull CommandContext<C>, @NonNull Queue<@NonNull String>,
                     @NonNull ArgumentParseResult<Boolean>>> argumentPreprocessors
     ) {


### PR DESCRIPTION
This is a re-implementation of #237. This allows us to show different descriptions per sender.

Command flags erased the sender types previously. We might as well fix that in 2.0.

This drops deprecated description methods.