### PR TITLE
build!: target java 17 

### DIFF
--- a/build-logic/src/main/kotlin/cloud.base-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cloud.base-conventions.gradle.kts
@@ -11,8 +11,8 @@ plugins {
 indra {
     javaVersions {
         minimumToolchain(17)
-        target(8)
-        testWith(8, 11, 17)
+        target(17)
+        testWith(17)
     }
 
     checkstyle(libs.versions.checkstyle.get())

--- a/build-logic/src/main/kotlin/cloud.kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cloud.kotlin-conventions.gradle.kts
@@ -9,13 +9,13 @@ plugins {
 kotlin {
     explicitApi()
     jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
     coreLibrariesVersion = "1.5.31"
     target {
         compilations.configureEach {
             kotlinOptions {
-                jvmTarget = "1.8"
+                jvmTarget = "17"
                 languageVersion = "1.5"
             }
         }

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/CommandExtractorImpl.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/CommandExtractorImpl.java
@@ -56,7 +56,7 @@ final class CommandExtractorImpl implements CommandExtractor {
             if (commandMethod == null) {
                 continue;
             }
-            if (!method.isAccessible()) {
+            if (!method.canAccess(instance)) {
                 method.setAccessible(true);
             }
             if (Modifier.isStatic(method.getModifiers())) {

--- a/examples/example-bukkit/build.gradle.kts
+++ b/examples/example-bukkit/build.gradle.kts
@@ -38,14 +38,11 @@ tasks {
     }
 
     // Set up a run task for each supported version
-    mapOf(
-        8 to setOf("1.8.8"),
-        11 to setOf("1.9.4", "1.10.2", "1.11.2"),
-        17 to setOf("1.12.2", "1.13.2", "1.14.4", "1.15.2", "1.16.5", "1.17.1", "1.18.2", "1.19.4", "1.20.2")
-    ).forEach { (javaVersion, minecraftVersions) ->
-        for (version in minecraftVersions) {
-            createVersionedRun(version, javaVersion)
-        }
+    setOf(
+        "1.8.8", "1.9.4", "1.10.2", "1.11.2", "1.12.2", "1.13.2", "1.14.4",
+        "1.15.2", "1.16.5", "1.17.1", "1.18.2", "1.19.4", "1.20.2"
+    ).forEach { minecraftVersion ->
+        createVersionedRun(minecraftVersion, 17)
     }
 }
 

--- a/examples/example-velocity/build.gradle.kts
+++ b/examples/example-velocity/build.gradle.kts
@@ -4,10 +4,6 @@ plugins {
     alias(libs.plugins.run.velocity)
 }
 
-indra {
-    javaVersions().target(11) // Velocity 3 requires Java 11
-}
-
 tasks {
     shadowJar {
         dependencies {


### PR DESCRIPTION
Could also target 11 instead, but seeing as this will be our only change to change target for a long time I thought we may as well go to 17.

1.8 servers etc can run just fine on Java 17 with the flag, is there still a reason to target Java 8?

This PR doesn't update the code to use new features introduced since Java 8, except from a [fix for #isAccessible](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/reflect/AccessibleObject.html#isAccessible()) 