### PR TITLE
feat: introduce aggregate parsers

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
@@ -42,11 +42,8 @@ import cloud.commandframework.exceptions.NoPermissionException;
 import cloud.commandframework.exceptions.NoSuchCommandException;
 import cloud.commandframework.internal.CommandNode;
 import cloud.commandframework.internal.SuggestionContext;
-import cloud.commandframework.keys.CloudKey;
-import cloud.commandframework.keys.SimpleCloudKey;
 import cloud.commandframework.permission.CommandPermission;
 import cloud.commandframework.permission.OrPermission;
-import io.leangen.geantyref.TypeToken;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -95,15 +92,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 @API(status = API.Status.INTERNAL, consumers = "cloud.commandframework.*")
 public final class CommandTree<C> {
-
-    /**
-     * Stores the index of the argument that is currently being parsed when parsing
-     * using {@link cloud.commandframework.arguments.compound.CompoundParser}
-     */
-    public static final CloudKey<Integer> PARSING_ARGUMENT_KEY = SimpleCloudKey.of(
-            "__parsing_argument__",
-            TypeToken.get(Integer.class)
-    );
 
     private final Object commandLock = new Object();
 
@@ -758,10 +746,11 @@ public final class CommandTree<C> {
             return CompletableFuture.completedFuture(context);
         }
 
+        CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
         if (component.parser() instanceof AggregateCommandParser) {
             // If we're working with a compound argument then we attempt to pop the required arguments from the input queue.
             final AggregateCommandParser<C, ?> aggregateParser = (AggregateCommandParser<C, ?>) component.parser();
-            this.popRequiredArguments(context.commandContext(), commandInput, aggregateParser);
+            future = this.popRequiredArguments(context.commandContext(), commandInput, aggregateParser);
         } else if (component.parser() instanceof CommandFlagParser) {
             // Use the flag argument parser to deduce what flag is being suggested right now
             // If empty, then no flag value is being typed, and the different flag options should
@@ -786,96 +775,98 @@ public final class CommandTree<C> {
             }
         }
 
-        if (commandInput.isEmpty()) {
-            return CompletableFuture.completedFuture(context);
-        } else if (commandInput.remainingTokens() == 1) {
-            return this.addArgumentSuggestions(context, child, commandInput.peekString());
-        } else if (child.isLeaf() && child.component().parser() instanceof AggregateCommandParser) {
-            return this.addArgumentSuggestions(context, child, commandInput.tokenize().getLast());
-        }
-
-        // Store original input command queue before the parsers below modify it
-        final CommandInput commandInputOriginal = commandInput.copy();
-
-        // START: Preprocessing
-        final ArgumentParseResult<Boolean> preParseResult = component.preprocess(
-                context.commandContext(),
-                commandInput
-        );
-        final boolean preParseSuccess = !preParseResult.getFailure().isPresent()
-                && preParseResult.getParsedValue().orElse(false);
-        // END: Preprocessing
-
-        final CompletableFuture<SuggestionContext<C>> parsingFuture;
-        if (!preParseSuccess) {
-            parsingFuture = CompletableFuture.completedFuture(null);
-        } else {
-            // START: Parsing
-            context.commandContext().currentComponent(child.component());
-            final CommandInput preParseInput = commandInput.copy();
-
-            parsingFuture = child.component()
-                    .parser()
-                    .parseFuture(context.commandContext(), commandInput)
-                    .thenApply(ArgumentParseResult::success)
-                    .exceptionally(throwable -> {
-                        if (throwable instanceof CompletionException) {
-                            return ArgumentParseResult.failure(throwable.getCause());
-                        } else {
-                            return ArgumentParseResult.failure(throwable);
-                        }
-                    }).thenCompose(result -> {
-                        final Optional<?> parsedValue = result.getParsedValue();
-                        final boolean parseSuccess = parsedValue.isPresent();
-
-                        if (result.getFailure().isPresent()) {
-                            commandInput.cursor(preParseInput.cursor());
-                        }
-
-                        // It's the last node, we don't care for success or not as we don't need to delegate to a child
-                        if (child.isLeaf()) {
-                            if (!commandInput.isEmpty()) {
-                                return CompletableFuture.completedFuture(context);
-                            }
-
-                            // Greedy parser took all the input, we can restore and just ask for suggestions
-                            commandInput.cursor(commandInputOriginal.cursor());
-                            this.addArgumentSuggestions(context, child, commandInput.remainingInput());
-                        }
-
-                        if (parseSuccess && !commandInput.isEmpty()) {
-                            // the current argument at the position is parsable and there are more arguments following
-                            context.commandContext().store(child.component().name(), parsedValue.get());
-                            return this.getSuggestions(context, commandInput, child);
-                        } else if (!parseSuccess && commandInputOriginal.remainingTokens() > 1) {
-                            // at this point there should normally be no need to reset the command queue as we expect
-                            // users to only take out an argument if the parse succeeded. Just to be sure we reset anyway
-                            commandInput.cursor(commandInputOriginal.cursor());
-
-                            // there are more arguments following but the current argument isn't matching - there
-                            // is no need to collect any further suggestions
-                            return CompletableFuture.completedFuture(context);
-                        }
-                        return CompletableFuture.completedFuture(null);
-                    });
-        }
-
-        return parsingFuture.thenCompose(previousResult -> {
-           if (previousResult != null) {
-               return CompletableFuture.completedFuture(previousResult);
-           }
-
-            // Restore original command input queue
-            commandInput.cursor(commandInputOriginal.cursor());
-
-            if (!preParseSuccess && commandInput.remainingTokens() > 1) {
-                // The preprocessor denied the argument, and there are more arguments following the current one
-                // Therefore we shouldn't list the suggestions of the current argument, as clearly the suggestions of
-                // one of the following arguments is requested
+        return future.thenCompose(ignored -> {
+            if (commandInput.isEmpty()) {
                 return CompletableFuture.completedFuture(context);
+            } else if (commandInput.remainingTokens() == 1) {
+                return this.addArgumentSuggestions(context, child, commandInput.peekString());
+            } else if (child.isLeaf() && child.component().parser() instanceof AggregateCommandParser) {
+                return this.addArgumentSuggestions(context, child, commandInput.tokenize().getLast());
             }
 
-            return this.addArgumentSuggestions(context, child, commandInput.peekString());
+            // Store original input command queue before the parsers below modify it
+            final CommandInput commandInputOriginal = commandInput.copy();
+
+            // START: Preprocessing
+            final ArgumentParseResult<Boolean> preParseResult = component.preprocess(
+                    context.commandContext(),
+                    commandInput
+            );
+            final boolean preParseSuccess = !preParseResult.getFailure().isPresent()
+                    && preParseResult.getParsedValue().orElse(false);
+            // END: Preprocessing
+
+            final CompletableFuture<SuggestionContext<C>> parsingFuture;
+            if (!preParseSuccess) {
+                parsingFuture = CompletableFuture.completedFuture(null);
+            } else {
+                // START: Parsing
+                context.commandContext().currentComponent(child.component());
+                final CommandInput preParseInput = commandInput.copy();
+
+                parsingFuture = child.component()
+                        .parser()
+                        .parseFuture(context.commandContext(), commandInput)
+                        .thenApply(ArgumentParseResult::success)
+                        .exceptionally(throwable -> {
+                            if (throwable instanceof CompletionException) {
+                                return ArgumentParseResult.failure(throwable.getCause());
+                            } else {
+                                return ArgumentParseResult.failure(throwable);
+                            }
+                        }).thenCompose(result -> {
+                            final Optional<?> parsedValue = result.getParsedValue();
+                            final boolean parseSuccess = parsedValue.isPresent();
+
+                            if (result.getFailure().isPresent()) {
+                                commandInput.cursor(preParseInput.cursor());
+                            }
+
+                            // It's the last node, we don't care for success or not as we don't need to delegate to a child
+                            if (child.isLeaf()) {
+                                if (!commandInput.isEmpty()) {
+                                    return CompletableFuture.completedFuture(context);
+                                }
+
+                                // Greedy parser took all the input, we can restore and just ask for suggestions
+                                commandInput.cursor(commandInputOriginal.cursor());
+                                this.addArgumentSuggestions(context, child, commandInput.remainingInput());
+                            }
+
+                            if (parseSuccess && !commandInput.isEmpty()) {
+                                // the current argument at the position is parsable and there are more arguments following
+                                context.commandContext().store(child.component().name(), parsedValue.get());
+                                return this.getSuggestions(context, commandInput, child);
+                            } else if (!parseSuccess && commandInputOriginal.remainingTokens() > 1) {
+                                // at this point there should normally be no need to reset the command queue as we expect
+                                // users to only take out an argument if the parse succeeded. Just to be sure we reset anyway
+                                commandInput.cursor(commandInputOriginal.cursor());
+
+                                // there are more arguments following but the current argument isn't matching - there
+                                // is no need to collect any further suggestions
+                                return CompletableFuture.completedFuture(context);
+                            }
+                            return CompletableFuture.completedFuture(null);
+                        });
+            }
+
+            return parsingFuture.thenCompose(previousResult -> {
+                if (previousResult != null) {
+                    return CompletableFuture.completedFuture(previousResult);
+                }
+
+                // Restore original command input queue
+                commandInput.cursor(commandInputOriginal.cursor());
+
+                if (!preParseSuccess && commandInput.remainingTokens() > 1) {
+                    // The preprocessor denied the argument, and there are more arguments following the current one
+                    // Therefore we shouldn't list the suggestions of the current argument, as clearly the suggestions of
+                    // one of the following arguments is requested
+                    return CompletableFuture.completedFuture(context);
+                }
+
+                return this.addArgumentSuggestions(context, child, commandInput.peekString());
+            });
         });
     }
 
@@ -886,22 +877,38 @@ public final class CommandTree<C> {
      * @param commandContext  the command context
      * @param commandInput    the input
      * @param aggregateParser the aggregate parser
+     * @return future that completes when the arguments have been popped
      */
-    private void popRequiredArguments(
+    private CompletableFuture<Void> popRequiredArguments(
             final @NonNull CommandContext<C> commandContext,
             final @NonNull CommandInput commandInput,
             final @NonNull AggregateCommandParser<C, ?> aggregateParser
     ) {
-        /* See how many arguments it requires */
         final int requiredArguments = aggregateParser.getRequestedArgumentCount();
-        /* Figure out whether we even need to care about this */
-        if (commandInput.remainingTokens() <= requiredArguments) {
-            /* Attempt to pop as many arguments from the stack as possible */
-            for (int i = 0; i < requiredArguments - 1 && commandInput.remainingTokens() > 1; i++) {
-                commandInput.readString();
-                commandContext.store(PARSING_ARGUMENT_KEY, i + 2);
-            }
+        if (commandInput.remainingTokens() > requiredArguments) {
+            return CompletableFuture.completedFuture(null);
         }
+
+        CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
+        final List<CommandComponent<C>> components = aggregateParser.components();
+        // We try to pop the input that would get parsed the inner components, but not the last one. We know that we have input
+        // that will be parsed by one of the inner components. If no parser before the last one parses the input, then we
+        // know for sure that the last one should capture all remaining input.
+        //
+        // We make sure to leave one string in the command input, as it should be passed to the suggestion method.
+        for (int argumentCount = 0; argumentCount < components.size() - 1 && commandInput.remainingTokens() > 1; argumentCount++) {
+            final CommandComponent<C> component = components.get(argumentCount);
+            future = future.thenCompose(previousResult -> {
+                        if (commandInput.remainingTokens() <= 1) {
+                            return CompletableFuture.completedFuture(previousResult);
+                        }
+                        return component.parser().parseFuture(commandContext, commandInput).thenApply(result -> {
+                            commandContext.store(component.name(), result);
+                            return null;
+                        });
+                    });
+        }
+        return future;
     }
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandContext.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandContext.java
@@ -27,6 +27,14 @@ import cloud.commandframework.keys.CloudKey;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
+/**
+ * Context that stores the individual result of invoking the child parsers of a {@link AggregateCommandParser}.
+ * <p>
+ * This is used in {@link AggregateResultMapper} to map to the output type using the intermediate results.
+ *
+ * @param <C> the command sender type
+ * @since 2.0.0
+ */
 @API(status = API.Status.STABLE, since = "2.0.0")
 public interface AggregateCommandContext<C> {
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandContext.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandContext.java
@@ -1,0 +1,90 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.arguments.aggregate;
+
+import cloud.commandframework.keys.CloudKey;
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+@API(status = API.Status.STABLE, since = "2.0.0")
+public interface AggregateCommandContext<C> {
+
+    /**
+     * Returns a new argument context instance that accepts values for the inner parsers of the given {@code parser}.
+     *
+     * @param <C>    the comment sender type
+     * @param parser the parser that the context is used by
+     * @return the command context
+     */
+    static <C> @NonNull AggregateCommandContext<C> argumentContext(
+            final @NonNull AggregateCommandParser<C, ?> parser
+    ) {
+        return new AggregateCommandContextImpl<>(parser);
+    }
+
+    /**
+     * Stores the given {@code value} identified by the given {@code key} in the context.
+     *
+     * @param key   the key
+     * @param value the value
+     */
+    void store(@NonNull CloudKey<?> key, @NonNull Object value);
+
+    /**
+     * Returns the value identified by the given {@code key} that was identified by the aggregate parser.
+     *
+     * @param <T> the type of the value
+     * @param key the key
+     * @return the value
+     * @throws NullPointerException if the value is not stored in the context
+     */
+    <T> @NonNull T get(@NonNull CloudKey<T> key);
+
+    /**
+     * Returns the value identified by the given {@code key} that was identified by the aggregate parser.
+     *
+     * @param <T> the type of the value
+     * @param key the key
+     * @return the value
+     * @throws NullPointerException if the value is not stored in the context
+     */
+    @SuppressWarnings("TypeParameterUnusedInFormals")
+    <T> @NonNull T get(@NonNull String key);
+
+    /**
+     * Returns whether the aggregate parser has stored a value identified by the given {@code key}.
+     *
+     * @param key the key
+     * @return {@code true} if the value exists, or {@code false} if not
+     */
+    boolean contains(@NonNull CloudKey<?> key);
+
+    /**
+     * Returns whether the aggregate parser has stored a value identified by the given {@code key}.
+     *
+     * @param key the key
+     * @return {@code true} if the value exists, or {@code false} if not
+     */
+    boolean contains(@NonNull String key);
+}

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandContextImpl.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandContextImpl.java
@@ -1,0 +1,84 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.arguments.aggregate;
+
+import cloud.commandframework.CommandComponent;
+import cloud.commandframework.keys.CloudKey;
+import cloud.commandframework.keys.SimpleCloudKey;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+@SuppressWarnings("unchecked")
+final class AggregateCommandContextImpl<C> implements AggregateCommandContext<C> {
+
+    private final Map<CloudKey<?>, Object> storage = new HashMap<>();
+    private final Collection<@NonNull String> validKeys;
+
+    AggregateCommandContextImpl(
+            final @NonNull AggregateCommandParser<C, ?> parser
+    ) {
+        this.validKeys = parser.components()
+                .stream()
+                .map(CommandComponent::name)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void store(final @NonNull CloudKey<?> key, final @NonNull Object value) {
+        this.storage.put(key, value);
+    }
+
+    @Override
+    public <T> @NonNull T get(@NonNull final CloudKey<T> key) {
+        if (!this.validKeys.contains(key.getName())) {
+            throw new NullPointerException("No value with the given key has been stored in the context");
+        }
+        final Object value = Objects.requireNonNull(this.storage.get(key));
+        return (T) value;
+    }
+
+    @Override
+    @SuppressWarnings("TypeParameterUnusedInFormals")
+    public <T> @NonNull T get(@NonNull final String key) {
+        if (!this.validKeys.contains(key)) {
+            throw new NullPointerException("No value with the given key has been stored in the context");
+        }
+        final Object value = Objects.requireNonNull(this.storage.get(SimpleCloudKey.of(key)));
+        return (T) value;
+    }
+
+    @Override
+    public boolean contains(@NonNull final CloudKey<?> key) {
+        return this.storage.containsKey(key);
+    }
+
+    @Override
+    public boolean contains(@NonNull final String key) {
+        return this.storage.containsKey(SimpleCloudKey.of(key));
+    }
+}

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParser.java
@@ -25,6 +25,7 @@ package cloud.commandframework.arguments.aggregate;
 
 import cloud.commandframework.CommandComponent;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.parser.ParserDescriptor;
 import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.context.CommandInput;
@@ -44,7 +45,18 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  * @since 2.0.0
  */
 @API(status = API.Status.STABLE, since = "2.0.0")
-public interface AggregateCommandParser<C, O> extends ArgumentParser.FutureArgumentParser<C, O> {
+public interface AggregateCommandParser<C, O> extends ArgumentParser.FutureArgumentParser<C, O>, ParserDescriptor<C, O> {
+
+    /**
+     * Returns a new aggregate command parser builder. The builder is immutable, and each method returns
+     * a new builder instance.
+     *
+     * @param <C> the command sender type
+     * @return the builder
+     */
+    static <C> @NonNull AggregateCommandParserBuilder<C> builder() {
+        return new AggregateCommandParserBuilder<>();
+    }
 
     /**
      * Returns the inner components of the parser.
@@ -99,5 +111,10 @@ public interface AggregateCommandParser<C, O> extends ArgumentParser.FutureArgum
     @Override
     default int getRequestedArgumentCount() {
         return this.components().stream().map(CommandComponent::parser).mapToInt(ArgumentParser::getRequestedArgumentCount).sum();
+    }
+
+    @Override
+    default @NonNull ArgumentParser<C, O> parser() {
+        return this;
     }
 }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParser.java
@@ -102,8 +102,8 @@ public interface AggregateCommandParser<C, O> extends ArgumentParser.FutureArgum
         return this.components()
                 .stream()
                 .filter(arg -> !context.contains(arg.name()))
-                .map(CommandComponent::parser)
-                .map(parser -> parser.suggestionsFuture(context, input))
+                .map(CommandComponent::suggestionProvider)
+                .map(suggestionProvider -> suggestionProvider.suggestionsFuture(context, input))
                 .findFirst()
                 .orElse(CompletableFuture.completedFuture(Collections.emptyList()));
     }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParser.java
@@ -1,0 +1,86 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.arguments.aggregate;
+
+import cloud.commandframework.CommandComponent;
+import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.context.CommandInput;
+import cloud.commandframework.keys.SimpleCloudKey;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * An argument parser that delegates to multiple inner {@link #components()} and transforms the aggregate results into
+ * an output using the {@link #mapper()}.
+ *
+ * @param <C> the command sender type
+ * @param <O> the output type
+ * @since 2.0.0
+ */
+@API(status = API.Status.STABLE, since = "2.0.0")
+public interface AggregateCommandParser<C, O> extends ArgumentParser.FutureArgumentParser<C, O> {
+
+    /**
+     * Returns the inner components of the parser.
+     *
+     * @return an unmodifiable view of the inner components in the order they were defined in
+     */
+    @NonNull List<@NonNull CommandComponent<C>> components();
+
+    /**
+     * Returns the result mapper. It will be invoked after parsing to map the intermediate results into the output type.
+     *
+     * @return the result mapper
+     */
+    @NonNull AggregateResultMapper<C, O> mapper();
+
+    @Override
+    default @NonNull CompletableFuture<@NonNull O> parseFuture(
+            final @NonNull CommandContext<@NonNull C> commandContext,
+            final @NonNull CommandInput commandInput
+    ) {
+        final AggregateCommandContext<C> aggregateCommandContext = AggregateCommandContext.argumentContext(this);
+        CompletableFuture<?> future = CompletableFuture.completedFuture(null);
+        for (final CommandComponent<C> component : this.components()) {
+            future =
+                    future.thenCompose(result -> component.parser()
+                            .parseFuture(commandContext, commandInput)
+                            .whenComplete((value, exception) -> {
+                                if (value == null || exception != null) {
+                                    return;
+                                }
+                                aggregateCommandContext.store(SimpleCloudKey.of(component.name(), component.valueType()), value);
+                            }));
+        }
+        return future.thenCompose(result -> this.mapper().map(commandContext, aggregateCommandContext));
+    }
+
+    @Override
+    default int getRequestedArgumentCount() {
+        return this.components().stream().map(CommandComponent::parser).mapToInt(ArgumentParser::getRequestedArgumentCount).sum();
+    }
+}

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParser.java
@@ -25,9 +25,11 @@ package cloud.commandframework.arguments.aggregate;
 
 import cloud.commandframework.CommandComponent;
 import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.context.CommandInput;
 import cloud.commandframework.keys.SimpleCloudKey;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apiguardian.api.API;
@@ -77,6 +79,21 @@ public interface AggregateCommandParser<C, O> extends ArgumentParser.FutureArgum
                             }));
         }
         return future.thenCompose(result -> this.mapper().map(commandContext, aggregateCommandContext));
+    }
+
+    @Override
+    @NonNull
+    default CompletableFuture<@NonNull List<@NonNull Suggestion>> suggestionsFuture(
+            final @NonNull CommandContext<C> context,
+            final @NonNull String input
+    ) {
+        return this.components()
+                .stream()
+                .filter(arg -> !context.contains(arg.name()))
+                .map(CommandComponent::parser)
+                .map(parser -> parser.suggestionsFuture(context, input))
+                .findFirst()
+                .orElse(CompletableFuture.completedFuture(Collections.emptyList()));
     }
 
     @Override

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParser.java
@@ -39,6 +39,17 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 /**
  * An argument parser that delegates to multiple inner {@link #components()} and transforms the aggregate results into
  * an output using the {@link #mapper()}.
+ * <p>
+ * You may either implement this interface to create a new parser type, or create an aggregate parser by using a
+ * {@link #builder()}.
+ * <p>
+ * The parsers {@link #components()} will be invoked in the order of the returned collection.
+ * When parsing, each parser will be invoked and the result will be stored in a {@link AggregateCommandContext}.
+ * After parsing, the {@link #mapper()} will be invoked, turning the intermediate results into the output type which is then
+ * returned by this parser.
+ * <p>
+ * When evaluating the suggestions for this parser, some {@link #components() component} parsers will be invoked, which allows
+ * the suggestion providers to rely on the results from the preceding components.
  *
  * @param <C> the command sender type
  * @param <O> the output type

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParserBuilder.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParserBuilder.java
@@ -1,0 +1,254 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.arguments.aggregate;
+
+import cloud.commandframework.CommandComponent;
+import cloud.commandframework.arguments.parser.ParserDescriptor;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
+import cloud.commandframework.keys.CloudKey;
+import io.leangen.geantyref.TypeToken;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+@API(status = API.Status.STABLE, since = "2.0.0")
+public class AggregateCommandParserBuilder<C> {
+
+    private final List<CommandComponent<C>> components;
+
+    AggregateCommandParserBuilder(final @NonNull List<CommandComponent<C>> components) {
+        this.components = Collections.unmodifiableList(components);
+    }
+
+    AggregateCommandParserBuilder() {
+        this.components = Collections.emptyList();
+    }
+
+    /**
+     * Returns a new builder with the given {@code mapper}.
+     *
+     * @param <O>       the type produced by the mapper
+     * @param valueType the type produced by the mapper
+     * @param mapper    the mapper
+     * @return the new builder
+     */
+    public final <O> @NonNull MappedAggregateCommandParserBuilder<C, O> withMapper(
+            final @NonNull TypeToken<O> valueType,
+            final @NonNull AggregateResultMapper<C, O> mapper
+    ) {
+        return new MappedAggregateCommandParserBuilder<>(this.components(), valueType, mapper);
+    }
+
+    /**
+     * Returns a new builder with the given {@code mapper}.
+     *
+     * @param <O>       the type produced by the mapper
+     * @param valueType the type produced by the mapper
+     * @param mapper    the mapper
+     * @return the new builder
+     */
+    public final <O> @NonNull MappedAggregateCommandParserBuilder<C, O> withMapper(
+            final @NonNull Class<O> valueType,
+            final @NonNull AggregateResultMapper<C, O> mapper
+    ) {
+        return new MappedAggregateCommandParserBuilder<>(this.components(), TypeToken.get(valueType), mapper);
+    }
+
+    /**
+     * Returns a new builder with the given {@code component} inserted into the component list.
+     *
+     * @param component the component
+     * @return the new builder
+     */
+    public @NonNull AggregateCommandParserBuilder<C> withComponent(
+            final @NonNull CommandComponent<C> component
+    ) {
+        final List<CommandComponent<C>> components = new ArrayList<>(this.components());
+        components.add(component);
+        return new AggregateCommandParserBuilder<>(components);
+    }
+
+    /**
+     * Returns a new builder with a new component using the given {@code parserDescriptor} into the component list.
+     *
+     * @param <T>              the type of the parser
+     * @param name             the name of the component
+     * @param parserDescriptor the parser
+     * @return the new builder
+     */
+    public <T> @NonNull AggregateCommandParserBuilder<C> withComponent(
+            final @NonNull String name,
+            final @NonNull ParserDescriptor<C, T> parserDescriptor
+    ) {
+        return this.withComponent(CommandComponent.<C, T>builder().name(name).parser(parserDescriptor).build());
+    }
+
+    /**
+     * Returns a new builder with a new component using the given {@code parserDescriptor} into the component list.
+     *
+     * @param <T>                the type of the parser
+     * @param name               the name of the component
+     * @param parserDescriptor   the parser
+     * @param suggestionProvider custom suggestion provider
+     * @return the new builder
+     */
+    public <T> @NonNull AggregateCommandParserBuilder<C> withComponent(
+            final @NonNull String name,
+            final @NonNull ParserDescriptor<C, T> parserDescriptor,
+            final @NonNull SuggestionProvider<C> suggestionProvider
+            ) {
+        return this.withComponent(
+                CommandComponent.<C, T>builder()
+                        .name(name)
+                        .parser(parserDescriptor)
+                        .suggestionProvider(suggestionProvider)
+                        .build()
+        );
+    }
+
+    /**
+     * Returns a new builder with a new component using the given {@code parserDescriptor} into the component list.
+     *
+     * @param <T>              the type of the parser
+     * @param name             the name of the component
+     * @param parserDescriptor the parser
+     * @return the new builder
+     */
+    public <T> @NonNull AggregateCommandParserBuilder<C> withComponent(
+            final @NonNull CloudKey<T> name,
+            final @NonNull ParserDescriptor<C, T> parserDescriptor
+    ) {
+        return this.withComponent(CommandComponent.<C, T>builder().key(name).parser(parserDescriptor).build());
+    }
+
+    /**
+     * Returns a new builder with a new component using the given {@code parserDescriptor} into the component list.
+     *
+     * @param <T>                the type of the parser
+     * @param name               the name of the component
+     * @param parserDescriptor   the parser
+     * @param suggestionProvider custom suggestion provider
+     * @return the new builder
+     */
+    public <T> @NonNull AggregateCommandParserBuilder<C> withComponent(
+            final @NonNull CloudKey<T> name,
+            final @NonNull ParserDescriptor<C, T> parserDescriptor,
+            final @NonNull SuggestionProvider<C> suggestionProvider
+    ) {
+        return this.withComponent(
+                CommandComponent.<C, T>builder()
+                        .key(name)
+                        .parser(parserDescriptor)
+                        .suggestionProvider(suggestionProvider)
+                        .build()
+        );
+    }
+
+    final @NonNull List<@NonNull CommandComponent<C>> components() {
+        return this.components;
+    }
+
+
+    public static final class MappedAggregateCommandParserBuilder<C, O> extends AggregateCommandParserBuilder<C> {
+
+        private final AggregateResultMapper<C, O> mapper;
+        private final TypeToken<O> valueType;
+
+        MappedAggregateCommandParserBuilder(
+                final @NonNull List<CommandComponent<C>> components,
+                final @NonNull TypeToken<O> valueType,
+                final @NonNull AggregateResultMapper<C, O> mapper
+        ) {
+            super(components);
+            this.valueType = valueType;
+            this.mapper = mapper;
+        }
+
+        @Override
+        public @NonNull MappedAggregateCommandParserBuilder<C, O> withComponent(
+                final @NonNull CommandComponent<C> component
+        ) {
+            final List<CommandComponent<C>> components = new ArrayList<>(this.components());
+            components.add(component);
+            return new MappedAggregateCommandParserBuilder<>(components, this.valueType, this.mapper);
+        }
+
+        @Override
+        public @NonNull <T> MappedAggregateCommandParserBuilder<C, O> withComponent(
+                final @NonNull String name,
+                final @NonNull ParserDescriptor<C, T> parserDescriptor
+        ) {
+            return this.withComponent(CommandComponent.<C, T>builder().name(name).parser(parserDescriptor).build());
+        }
+
+        @Override
+        public <T> @NonNull MappedAggregateCommandParserBuilder<C, O> withComponent(
+                final @NonNull String name,
+                final @NonNull ParserDescriptor<C, T> parserDescriptor,
+                final @NonNull SuggestionProvider<C> suggestionProvider
+        ) {
+            return this.withComponent(
+                    CommandComponent.<C, T>builder()
+                            .name(name)
+                            .parser(parserDescriptor)
+                            .suggestionProvider(suggestionProvider)
+                            .build()
+            );
+        }
+
+        @Override
+        public @NonNull <T> MappedAggregateCommandParserBuilder<C, O> withComponent(
+                final @NonNull CloudKey<T> name,
+                final @NonNull ParserDescriptor<C, T> parserDescriptor
+        ) {
+            return this.withComponent(CommandComponent.<C, T>builder().key(name).parser(parserDescriptor).build());
+        }
+
+        @Override
+        public @NonNull <T> MappedAggregateCommandParserBuilder<C, O> withComponent(
+                final @NonNull CloudKey<T> name,
+                final @NonNull ParserDescriptor<C, T> parserDescriptor,
+                final @NonNull SuggestionProvider<C> suggestionProvider
+        ) {
+            return this.withComponent(
+                    CommandComponent.<C, T>builder()
+                            .key(name)
+                            .parser(parserDescriptor)
+                            .suggestionProvider(suggestionProvider)
+                            .build()
+            );
+        }
+
+        /**
+         * Builds the parser described by this builder.
+         *
+         * @return the parser
+         */
+        public @NonNull AggregateCommandParser<C, O> build() {
+            return new AggregateCommandParserImpl<>(this.components(), this.valueType, this.mapper);
+        }
+    }
+}

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParserBuilder.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParserBuilder.java
@@ -64,6 +64,9 @@ public class AggregateCommandParserBuilder<C> {
 
     /**
      * Returns a new builder with the given {@code mapper}.
+     * <p>
+     * Use {@link #withDirectMapper(Class, AggregateResultMapper.DirectAggregateResultMapper)} if you do not want to wrap
+     * the result in a completable future.
      *
      * @param <O>       the type produced by the mapper
      * @param valueType the type produced by the mapper
@@ -73,6 +76,23 @@ public class AggregateCommandParserBuilder<C> {
     public final <O> @NonNull MappedAggregateCommandParserBuilder<C, O> withMapper(
             final @NonNull Class<O> valueType,
             final @NonNull AggregateResultMapper<C, O> mapper
+    ) {
+        return new MappedAggregateCommandParserBuilder<>(this.components(), TypeToken.get(valueType), mapper);
+    }
+
+    /**
+     * Returns a new builder with the given {@code mapper}.
+     * <p>
+     * This version does not need to wrap the result in a {@link java.util.concurrent.CompletableFuture}.
+     *
+     * @param <O>       the type produced by the mapper
+     * @param valueType the type produced by the mapper
+     * @param mapper    the mapper
+     * @return the new builder
+     */
+    public final <O> @NonNull MappedAggregateCommandParserBuilder<C, O> withDirectMapper(
+            final @NonNull Class<O> valueType,
+            final AggregateResultMapper.@NonNull DirectAggregateResultMapper<C, O> mapper
     ) {
         return new MappedAggregateCommandParserBuilder<>(this.components(), TypeToken.get(valueType), mapper);
     }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParserImpl.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParserImpl.java
@@ -1,0 +1,62 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.arguments.aggregate;
+
+import cloud.commandframework.CommandComponent;
+import io.leangen.geantyref.TypeToken;
+import java.util.Collections;
+import java.util.List;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+final class AggregateCommandParserImpl<C, O> implements AggregateCommandParser<C, O> {
+
+    private final List<CommandComponent<C>> components;
+    private final TypeToken<O> valueType;
+    private final AggregateResultMapper<C, O> mapper;
+
+    AggregateCommandParserImpl(
+            final @NonNull List<CommandComponent<C>> components,
+            final @NonNull TypeToken<O> valueType,
+            final @NonNull AggregateResultMapper<C, O> mapper
+    ) {
+        this.components = components;
+        this.valueType = valueType;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public @NonNull List<@NonNull CommandComponent<C>> components() {
+        return Collections.unmodifiableList(this.components);
+    }
+
+    @Override
+    public @NonNull AggregateResultMapper<C, O> mapper() {
+        return this.mapper;
+    }
+
+    @Override
+    public @NonNull TypeToken<O> valueType() {
+        return this.valueType;
+    }
+}

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateResultMapper.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateResultMapper.java
@@ -1,0 +1,49 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.arguments.aggregate;
+
+import cloud.commandframework.context.CommandContext;
+import java.util.concurrent.CompletableFuture;
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Mapper that maps the result of invoking the inner parsers of a {@link AggregateCommandParser}.
+ *
+ * @param <C> the command sender type
+ * @param <O> the output type
+ * @since 2.0.0
+ */
+@API(status = API.Status.STABLE, since = "2.0.0")
+public interface AggregateResultMapper<C, O> {
+
+    /**
+     * Maps the given {@code context} into the output of type {@link O}.
+     *
+     * @param commandContext the command context
+     * @param context        the context to map
+     * @return future that completes with the result
+     */
+    @NonNull CompletableFuture<O> map(@NonNull CommandContext<C> commandContext, @NonNull AggregateCommandContext<C> context);
+}

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateResultMapper.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateResultMapper.java
@@ -46,4 +46,32 @@ public interface AggregateResultMapper<C, O> {
      * @return future that completes with the result
      */
     @NonNull CompletableFuture<O> map(@NonNull CommandContext<C> commandContext, @NonNull AggregateCommandContext<C> context);
+
+
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    interface DirectAggregateResultMapper<C, O> extends AggregateResultMapper<C, O> {
+
+        /**
+         * Maps the given {@code context} into the output of type {@link O}.
+         *
+         * @param commandContext the command context
+         * @param context        the context to map
+         * @return the result
+         */
+        @NonNull O mapImmediately(@NonNull CommandContext<C> commandContext, @NonNull AggregateCommandContext<C> context);
+
+        @Override
+        default @NonNull CompletableFuture<O> map(
+                @NonNull CommandContext<C> commandContext,
+                @NonNull AggregateCommandContext<C> context
+        ) {
+            final CompletableFuture<O> result = new CompletableFuture<>();
+            try {
+                result.complete(this.mapImmediately(commandContext, context));
+            } catch (final Exception e) {
+                result.completeExceptionally(e);
+            }
+            return result;
+        }
+    }
 }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/package-info.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Aggregate parsers are parses that delegate to multiple inner parsers.
+ */
+package cloud.commandframework.arguments.aggregate;

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/compound/CompoundArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/compound/CompoundArgument.java
@@ -68,7 +68,8 @@ public class CompoundArgument<T extends Tuple, C, O> implements ParserDescriptor
                         types.toArray(),
                         parserTuple.toArray(),
                         mapper,
-                        tupleFactory
+                        tupleFactory,
+                        valueType
                 ),
                 valueType
         );

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/compound/CompoundArgument.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/compound/CompoundArgument.java
@@ -62,7 +62,16 @@ public class CompoundArgument<T extends Tuple, C, O> implements ParserDescriptor
             final @NonNull Function<@NonNull Object[], @NonNull T> tupleFactory,
             final @NonNull TypeToken<O> valueType
     ) {
-        this.parser = ParserDescriptor.of(new CompoundParser<>(names, types, parserTuple, mapper, tupleFactory), valueType);
+        this.parser = ParserDescriptor.of(
+                new CompoundParser<>(
+                        names.toArray(),
+                        types.toArray(),
+                        parserTuple.toArray(),
+                        mapper,
+                        tupleFactory
+                ),
+                valueType
+        );
     }
 
     @Override

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/compound/CompoundParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/compound/CompoundParser.java
@@ -28,6 +28,7 @@ import cloud.commandframework.arguments.aggregate.AggregateCommandParser;
 import cloud.commandframework.arguments.aggregate.AggregateResultMapper;
 import cloud.commandframework.arguments.parser.ArgumentParser;
 import cloud.commandframework.types.tuples.Tuple;
+import io.leangen.geantyref.TypeToken;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -43,6 +44,7 @@ public final class CompoundParser<T extends Tuple, C, O> implements AggregateCom
     private final List<CommandComponent<C>> components;
     private final BiFunction<C, T, O> mapper;
     private final Function<Object[], T> tupleFactory;
+    private final TypeToken<O> valueType;
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     CompoundParser(
@@ -50,11 +52,12 @@ public final class CompoundParser<T extends Tuple, C, O> implements AggregateCom
             final @NonNull Object[] types,
             final @NonNull Object[] parsers,
             final @NonNull BiFunction<@NonNull C, @NonNull T, @NonNull O> mapper,
-            final @NonNull Function<@NonNull Object[], @NonNull T> tupleFactory
+            final @NonNull Function<@NonNull Object[], @NonNull T> tupleFactory,
+            final @NonNull TypeToken<O> valueType
     ) {
         this.mapper = mapper;
         this.tupleFactory = tupleFactory;
-
+        this.valueType = valueType;
         this.components = new ArrayList<>(parsers.length);
         for (int i = 0; i < parsers.length; i++) {
             final CommandComponent component = CommandComponent.builder()
@@ -78,5 +81,10 @@ public final class CompoundParser<T extends Tuple, C, O> implements AggregateCom
             final T tuple = this.tupleFactory.apply(values);
             return CompletableFuture.completedFuture(this.mapper.apply(commandContext.getSender(), tuple));
         };
+    }
+
+    @Override
+    public @NonNull TypeToken<O> valueType() {
+        return this.valueType;
     }
 }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/compound/CompoundParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/compound/CompoundParser.java
@@ -27,8 +27,6 @@ import cloud.commandframework.CommandComponent;
 import cloud.commandframework.arguments.aggregate.AggregateCommandParser;
 import cloud.commandframework.arguments.aggregate.AggregateResultMapper;
 import cloud.commandframework.arguments.parser.ArgumentParser;
-import cloud.commandframework.arguments.suggestion.Suggestion;
-import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.types.tuples.Tuple;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -80,20 +78,5 @@ public final class CompoundParser<T extends Tuple, C, O> implements AggregateCom
             final T tuple = this.tupleFactory.apply(values);
             return CompletableFuture.completedFuture(this.mapper.apply(commandContext.getSender(), tuple));
         };
-    }
-
-    @Override
-    public @NonNull List<@NonNull Suggestion> suggestions(
-            final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
-    ) {
-        /*
-        This method will be called n times, each time for each of the internal types.
-        The problem is that we need to then know which of the parsers to forward the
-        suggestion request to. This is done by storing the number of parsed subtypes
-        in the context, so we can then extract that number and forward the request
-         */
-        final int argument = commandContext.getOrDefault("__parsing_argument__", 1) - 1;
-        return this.components.get(argument).parser().suggestions(commandContext, input);
     }
 }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/flags/CommandFlagParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/flags/CommandFlagParser.java
@@ -144,7 +144,7 @@ public final class CommandFlagParser<C> implements ArgumentParser.FutureArgument
 
     @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public @NonNull List<@NonNull Suggestion> suggestions(
+    public @NonNull CompletableFuture<List<@NonNull Suggestion>> suggestionsFuture(
             final @NonNull CommandContext<C> commandContext,
             final @NonNull String input
     ) {
@@ -214,7 +214,7 @@ public final class CommandFlagParser<C> implements ArgumentParser.FutureArgument
             if (suggestCombined) {
                 suggestions.add(Suggestion.simple(input));
             }
-            return suggestions;
+            return CompletableFuture.completedFuture(suggestions);
         } else {
             CommandFlag<?> currentFlag = null;
             if (lastArg.startsWith("--")) { // --long
@@ -240,12 +240,12 @@ public final class CommandFlagParser<C> implements ArgumentParser.FutureArgument
             if (currentFlag != null
                     && commandContext.hasPermission(currentFlag.permission())
                     && currentFlag.commandComponent() != null) {
-                return (List<Suggestion>) ((SuggestionProvider) currentFlag.commandComponent().suggestionProvider())
-                        .suggestions(commandContext, input);
+                final SuggestionProvider suggestionProvider = currentFlag.commandComponent().suggestionProvider();
+                return suggestionProvider.suggestionsFuture(commandContext, input);
             }
         }
         commandContext.store(FLAG_META_KEY, "");
-        return this.suggestions(commandContext, input);
+        return this.suggestionsFuture(commandContext, input);
     }
 
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/parser/ArgumentParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/parser/ArgumentParser.java
@@ -221,5 +221,30 @@ public interface ArgumentParser<C, T> extends SuggestionProvider<C> {
                 @NonNull CommandContext<@NonNull C> commandContext,
                 @NonNull CommandInput commandInput
         );
+
+        @Override
+        default @NonNull List<@NonNull Suggestion> suggestions(
+                @NonNull CommandContext<C> context,
+                @NonNull String input
+        ) {
+            try {
+                return this.suggestionsFuture(context, input).join();
+            } catch (final CompletionException exception) {
+                final Throwable cause = exception.getCause();
+                if (cause instanceof RuntimeException) {
+                    throw (RuntimeException) cause;
+                }
+                throw exception;
+            }
+        }
+
+        @Override
+        @NonNull
+        default CompletableFuture<@NonNull List<@NonNull Suggestion>> suggestionsFuture(
+                @NonNull CommandContext<C> context,
+                @NonNull String input
+        ) {
+            return CompletableFuture.completedFuture(Collections.emptyList());
+        }
     }
 }

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/aggregate/AggregateCommandParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/aggregate/AggregateCommandParserTest.java
@@ -1,0 +1,173 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.arguments.aggregate;
+
+import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.context.CommandInput;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static cloud.commandframework.arguments.standard.IntegerParser.integerParser;
+import static cloud.commandframework.arguments.standard.StringParser.stringParser;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AggregateCommandParserTest {
+
+    @Mock
+    private CommandContext<Object> commandContext;
+
+    @Test
+    void testParsing() {
+        // Arrange
+        final AggregateCommandParser<Object, OutputType> parser = AggregateCommandParser.builder()
+                .withComponent("number", integerParser())
+                .withComponent("string", stringParser())
+                .withMapper(
+                        OutputType.class,
+                        (commandContext, context) ->
+                                CompletableFuture.completedFuture( new OutputType(context.get("number"), context.get("string"))))
+                .build();
+
+        // Act
+        final OutputType outputType = parser.parseFuture(this.commandContext, CommandInput.of("10 abc")).join();
+
+        // Assert
+        assertThat(outputType).isNotNull();
+        assertThat(outputType.number()).isEqualTo(10);
+        assertThat(outputType.string()).isEqualTo("abc");
+    }
+
+    @Test
+    void testMultiLevelAggregateParsing() {
+        // Arrange
+        final AggregateCommandParser<Object, OutputType> inner = AggregateCommandParser.builder()
+                .withComponent("number", integerParser())
+                .withComponent("string", stringParser())
+                .withMapper(
+                        OutputType.class,
+                        (commandContext, context) ->
+                                CompletableFuture.completedFuture( new OutputType(context.get("number"), context.get("string")))
+                ).build();
+        final AggregateCommandParser<Object, OutputType> parser = AggregateCommandParser.builder()
+                .withComponent("inner", inner)
+                .withMapper(
+                        OutputType.class,
+                        (commandContext, context) -> CompletableFuture.completedFuture(context.get("inner"))
+                ).build();
+
+        // Act
+        final OutputType outputType = parser.parseFuture(this.commandContext, CommandInput.of("10 abc")).join();
+
+        // Assert
+        assertThat(outputType).isNotNull();
+        assertThat(outputType.number()).isEqualTo(10);
+        assertThat(outputType.string()).isEqualTo("abc");
+    }
+
+    @Test
+    void testSuggestionsFirstArgument() {
+        // Arrange
+        final AggregateCommandParser<Object, OutputType> parser = AggregateCommandParser.builder()
+                .withComponent("number", integerParser(), (ctx, in) -> Arrays.asList(
+                        Suggestion.simple("1"),
+                        Suggestion.simple("2"),
+                        Suggestion.simple("3")
+                )).withComponent("string", stringParser())
+                .withMapper(
+                        OutputType.class,
+                        (commandContext, context) ->
+                                CompletableFuture.completedFuture( new OutputType(context.get("number"), context.get("string"))))
+                .build();
+
+        // Act
+        final List<Suggestion> suggestions = parser.suggestionsFuture(this.commandContext, "").join();
+
+        // Assert
+        assertThat(suggestions).containsExactly(
+                Suggestion.simple("1"),
+                Suggestion.simple("2"),
+                Suggestion.simple("3")
+        );
+    }
+
+    @Test
+    void testSuggestionsSecondArgument() {
+        // Arrange
+        final AggregateCommandParser<Object, OutputType> parser = AggregateCommandParser.builder()
+                .withComponent("number", integerParser())
+                .withComponent("string", stringParser(), (ctx, in) -> Arrays.asList(
+                        Suggestion.simple("a"),
+                        Suggestion.simple("b"),
+                        Suggestion.simple("c")
+                ))
+                .withMapper(
+                        OutputType.class,
+                        (commandContext, context) ->
+                                CompletableFuture.completedFuture( new OutputType(context.get("number"), context.get("string"))))
+                .build();
+        when(this.commandContext.contains("number")).thenReturn(true);
+
+        // Act
+        final List<Suggestion> suggestions = parser.suggestionsFuture(this.commandContext, "").join();
+
+        // Assert
+        assertThat(suggestions).containsExactly(
+                Suggestion.simple("a"),
+                Suggestion.simple("b"),
+                Suggestion.simple("c")
+        );
+    }
+
+
+    private static final class OutputType {
+
+        private final int number;
+        private final String string;
+
+        OutputType(final int number, final @NonNull String string) {
+            this.number = number;
+            this.string = string;
+        }
+
+        int number() {
+            return this.number;
+        }
+
+        @NonNull String string() {
+            return this.string;
+        }
+    }
+}

--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/CloudBrigadierManager.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/CloudBrigadierManager.java
@@ -26,7 +26,7 @@ package cloud.commandframework.brigadier;
 import cloud.commandframework.Command;
 import cloud.commandframework.CommandComponent;
 import cloud.commandframework.CommandManager;
-import cloud.commandframework.arguments.compound.CompoundParser;
+import cloud.commandframework.arguments.aggregate.AggregateCommandParser;
 import cloud.commandframework.arguments.flags.CommandFlagParser;
 import cloud.commandframework.arguments.parser.ArgumentParser;
 import cloud.commandframework.arguments.parser.MappedArgumentParser;
@@ -480,27 +480,24 @@ public final class CloudBrigadierManager<C, S> {
             final com.mojang.brigadier.@NonNull Command<S> executor,
             final SuggestionProvider<S> suggestionProvider
     ) {
-        if (root.component().parser() instanceof CompoundParser) {
-            final CompoundParser<?, C, ?> compoundParser =
-                    (CompoundParser<?, C, ?>) root.component().parser();
-            final Object[] parsers = compoundParser.parsers();
-            final Object[] types = compoundParser.types();
-            final Object[] names = compoundParser.names();
+        if (root.component().parser() instanceof AggregateCommandParser) {
+            final AggregateCommandParser<C, ?> aggregateParser = (AggregateCommandParser<C, ?>) root.component().parser();
+            final List<? extends CommandComponent<?>> components = aggregateParser.components();
 
             /* Build nodes backwards */
-            final ArgumentBuilder<S, ?>[] argumentBuilders = new ArgumentBuilder[parsers.length];
+            final ArgumentBuilder<S, ?>[] argumentBuilders = new ArgumentBuilder[components.size()];
 
-            for (int i = parsers.length - 1; i >= 0; i--) {
-                @SuppressWarnings("unchecked") final ArgumentParser<C, ?> parser = (ArgumentParser<C, ?>) parsers[i];
-                final Pair<ArgumentType<?>, SuggestionProvider<S>> pair = this.getArgument(
-                        TypeToken.get((Class<?>) types[i]),
-                        parser
-                );
-                final SuggestionProvider<S> provider = pair.getSecond() == delegateSuggestions() ? suggestionProvider
+            for (int i = components.size() - 1; i >= 0; i--) {
+                final CommandComponent<C> component = (CommandComponent<C>) components.get(i);
+
+                final ArgumentParser<C, ?> parser = component.parser();
+                final Pair<ArgumentType<?>, SuggestionProvider<S>> pair = this.getArgument(component.valueType(), parser);
+                final SuggestionProvider<S> provider = pair.getSecond() == delegateSuggestions()
+                        ? suggestionProvider
                         : pair.getSecond();
 
                 final ArgumentBuilder<S, ?> fragmentBuilder = RequiredArgumentBuilder
-                        .<S, Object>argument((String) names[i], (ArgumentType<Object>) pair.getFirst())
+                        .<S, Object>argument(component.name(), (ArgumentType<Object>) pair.getFirst())
                         .suggests(provider)
                         .requires(sender -> permissionChecker.test(
                                 sender,
@@ -512,18 +509,18 @@ public final class CloudBrigadierManager<C, S> {
                         ));
                 argumentBuilders[i] = fragmentBuilder;
 
-                if (forceExecutor || ((i == parsers.length - 1) && (root.isLeaf() || !root.component().required()))) {
+                if (forceExecutor || ((i == components.size() - 1) && (root.isLeaf() || !root.component().required()))) {
                     fragmentBuilder.executes(executor);
                 }
 
                 /* Link all previous builder to this one */
-                if ((i + 1) < parsers.length) {
+                if ((i + 1) < components.size()) {
                     fragmentBuilder.then(argumentBuilders[i + 1]);
                 }
             }
 
             for (final cloud.commandframework.internal.CommandNode<C> node : root.children()) {
-                argumentBuilders[parsers.length - 1]
+                argumentBuilders[components.size() - 1]
                         .then(this.constructCommandNode(forceExecutor, node, permissionChecker, executor, suggestionProvider));
             }
 

--- a/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/builder/BuilderExample.java
+++ b/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/builder/BuilderExample.java
@@ -27,6 +27,7 @@ import cloud.commandframework.CommandManager;
 import cloud.commandframework.bukkit.BukkitCommandManager;
 import cloud.commandframework.bukkit.CloudBukkitCapabilities;
 import cloud.commandframework.examples.bukkit.ExamplePlugin;
+import cloud.commandframework.examples.bukkit.builder.feature.AggregateCommandExample;
 import cloud.commandframework.examples.bukkit.builder.feature.CommandBeanExample;
 import cloud.commandframework.examples.bukkit.builder.feature.CompoundArgumentExample;
 import cloud.commandframework.examples.bukkit.builder.feature.ConfirmationExample;
@@ -56,6 +57,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 public final class BuilderExample {
 
     private static final List<BuilderFeature> FEATURES = Arrays.asList(
+            new AggregateCommandExample(),
             new CommandBeanExample(),
             new CompoundArgumentExample(),
             new ConfirmationExample(),

--- a/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/builder/feature/AggregateCommandExample.java
+++ b/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/builder/feature/AggregateCommandExample.java
@@ -68,12 +68,12 @@ public final class AggregateCommandExample implements BuilderFeature {
                 .withComponent("x", integerParser())
                 .withComponent("y", integerParser())
                 .withComponent("z", integerParser())
-                .withMapper(Location.class, (commandContext, aggregateCommandContext) -> {
+                .withDirectMapper(Location.class, (commandContext, aggregateCommandContext) -> {
                     final World world = aggregateCommandContext.get("world");
                     final int x = aggregateCommandContext.get("x");
                     final int y = aggregateCommandContext.get("y");
                     final int z = aggregateCommandContext.get("z");
-                    return CompletableFuture.completedFuture(new Location(world, x, y, z));
+                    return new Location(world, x, y, z);
                 })
                 .build();
         manager.command(

--- a/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/builder/feature/AggregateCommandExample.java
+++ b/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/builder/feature/AggregateCommandExample.java
@@ -1,0 +1,71 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.examples.bukkit.builder.feature;
+
+import cloud.commandframework.arguments.aggregate.AggregateCommandParser;
+import cloud.commandframework.bukkit.BukkitCommandManager;
+import cloud.commandframework.examples.bukkit.ExamplePlugin;
+import cloud.commandframework.examples.bukkit.builder.BuilderFeature;
+import java.util.concurrent.CompletableFuture;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import static cloud.commandframework.arguments.standard.IntegerParser.integerParser;
+import static cloud.commandframework.bukkit.parsers.WorldParser.worldParser;
+
+/**
+ * Example showcasing the aggregate command parser system.
+ */
+public final class AggregateCommandExample implements BuilderFeature {
+
+    @Override
+    public void registerFeature(
+            @NonNull final ExamplePlugin examplePlugin,
+            @NonNull final BukkitCommandManager<CommandSender> manager
+    ) {
+        final AggregateCommandParser<CommandSender, Location> locationParser = AggregateCommandParser.<CommandSender>builder()
+                .withComponent("world", worldParser())
+                .withComponent("x", integerParser())
+                .withComponent("y", integerParser())
+                .withComponent("z", integerParser())
+                .withMapper(Location.class, (commandContext, aggregateCommandContext) -> {
+                    final World world = aggregateCommandContext.get("world");
+                    final int x = aggregateCommandContext.get("x");
+                    final int y = aggregateCommandContext.get("y");
+                    final int z = aggregateCommandContext.get("z");
+                    return CompletableFuture.completedFuture(new Location(world, x, y, z));
+                })
+                .build();
+        manager.command(
+                manager.commandBuilder("builder")
+                        .literal("aggregate")
+                        .required("location", locationParser)
+                        .senderType(Player.class)
+                        .handler(commandContext -> commandContext.getSender().teleport(commandContext.<Location>get("location")))
+        );
+    }
+}


### PR DESCRIPTION
Aggregate parsers is a more flexible version of the compound parser.

Example:
```java
final AggregateCommandParser<CommandSender, Location> locationParser = AggregateCommandParser<CommandSender>builder()
    .withComponent("world", worldParser())
    .withComponent("x", integerParser())
    .withComponent("y", integerParser())
    .withComponent("z", integerParser())
    .withMapper(Location.class, (commandContext, aggregateCommandContext) -> {
        final World world = aggregateCommandContext.get("world");
        final int x = aggregateCommandContext.get("x");
        final int y = aggregateCommandContext.get("y");
        final int z = aggregateCommandContext.get("z");
        return CompletableFuture.completedFuture(new Location(world, x, y, z));
     }).build();
```