### PR TITLE
feat: improve the command builder api

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/Command.java
+++ b/cloud-core/src/main/java/cloud/commandframework/Command.java
@@ -44,6 +44,7 @@ import cloud.commandframework.types.tuples.Pair;
 import cloud.commandframework.types.tuples.Triplet;
 import io.leangen.geantyref.TypeToken;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -1997,6 +1998,32 @@ public class Command<C> {
         @API(status = API.Status.STABLE, since = "1.7.0")
         public @NonNull CommandExecutionHandler<C> handler() {
             return this.commandExecutionHandler;
+        }
+
+        /**
+         * Sets a new command execution handler that invokes the given {@code handler} before the current
+         * {@link #handler() handler}.
+         *
+         * @param handler the handler to invoke before the current handler
+         * @return new builder instance
+         * @since 2.0.0
+         */
+        @API(status = API.Status.STABLE, since = "2.0.0")
+        public @NonNull Builder<C> prependHandler(final @NonNull CommandExecutionHandler<C> handler) {
+            return this.handler(CommandExecutionHandler.delegatingExecutionHandler(Arrays.asList(handler, this.handler())));
+        }
+
+        /**
+         * Sets a new command execution handler that invokes the given {@code handler} after the current
+         * {@link #handler() handler}.
+         *
+         * @param handler the handler to invoke after the current handler
+         * @return new builder instance
+         * @since 2.0.0
+         */
+        @API(status = API.Status.STABLE, since = "2.0.0")
+        public @NonNull Builder<C> appendHandler(final @NonNull CommandExecutionHandler<C> handler) {
+            return this.handler(CommandExecutionHandler.delegatingExecutionHandler(Arrays.asList(this.handler(), handler)));
         }
 
         /**

--- a/cloud-core/src/main/java/cloud/commandframework/execution/CommandExecutionHandler.java
+++ b/cloud-core/src/main/java/cloud/commandframework/execution/CommandExecutionHandler.java
@@ -25,6 +25,7 @@ package cloud.commandframework.execution;
 
 import cloud.commandframework.Command;
 import cloud.commandframework.context.CommandContext;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -153,7 +154,15 @@ public interface CommandExecutionHandler<C> {
         private MulticastDelegateFutureCommandExecutionHandler(
                 final @NonNull List<@NonNull CommandExecutionHandler<C>> handlers
         ) {
-            this.handlers = Collections.unmodifiableList(handlers);
+            final List<CommandExecutionHandler<C>> unwrappedHandlers = new ArrayList<>();
+            for (final CommandExecutionHandler<C> handler : handlers) {
+                if (handler instanceof MulticastDelegateFutureCommandExecutionHandler) {
+                    unwrappedHandlers.addAll(((MulticastDelegateFutureCommandExecutionHandler<C>) handler).handlers);
+                } else {
+                    unwrappedHandlers.add(handler);
+                }
+            }
+            this.handlers = Collections.unmodifiableList(unwrappedHandlers);
         }
 
         @Override

--- a/cloud-kotlin/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/MutableCommandBuilder.kt
+++ b/cloud-kotlin/cloud-kotlin-extensions/src/main/kotlin/cloud/commandframework/kotlin/MutableCommandBuilder.kt
@@ -605,6 +605,30 @@ public class MutableCommandBuilder<C : Any>(
     }
 
     /**
+     * Sets a new command execution handler that invokes the given {@code handler} before the current
+     * {@link #handler() handler}.
+     *
+     * @param handler the handler to invoke before the current handler
+     * @return this mutable builder
+     * @since 2.0.0
+     */
+    public fun prependHandler(handler: CommandExecutionHandler<C>): MutableCommandBuilder<C> = mutate {
+        it.prependHandler(handler)
+    }
+
+    /**
+     * Sets a new command execution handler that invokes the given {@code handler} after the current
+     * {@link #handler() handler}.
+     *
+     * @param handler the handler to invoke after the current handler
+     * @return this mutable builder
+     * @since 2.0.0
+     */
+    public fun appendHandler(handler: CommandExecutionHandler<C>): MutableCommandBuilder<C> = mutate {
+        it.appendHandler(handler)
+    }
+
+    /**
      * Add a new flag component to this command
      *
      * @param name name of the flag


### PR DESCRIPTION
Current changes:
- `Command.Builder` has two new methods: `prependHandler` & `appendHandler`
- `MulticastDelegateFutureCommandExecutionHandler` will unwrap inner multicast handlers.