### PR TITLE
feature(core): exception handling

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
@@ -43,6 +43,7 @@ import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.context.CommandContextFactory;
 import cloud.commandframework.context.CommandInput;
 import cloud.commandframework.context.StandardCommandContextFactory;
+import cloud.commandframework.exceptions.handling.ExceptionController;
 import cloud.commandframework.execution.CommandExecutionCoordinator;
 import cloud.commandframework.execution.CommandResult;
 import cloud.commandframework.execution.CommandSuggestionProcessor;
@@ -106,6 +107,7 @@ public abstract class CommandManager<C> {
     private final CommandTree<C> commandTree;
     private final SuggestionFactory<C, ? extends Suggestion> suggestionFactory;
     private final Set<CloudCapability> capabilities = new HashSet<>();
+    private final ExceptionController<C> exceptionController = new ExceptionController<>();
 
     private CaptionVariableReplacementHandler captionVariableReplacementHandler = new SimpleCaptionVariableReplacementHandler();
     private CommandSyntaxFormatter<C> commandSyntaxFormatter = new StandardCommandSyntaxFormatter<>();
@@ -162,11 +164,8 @@ public abstract class CommandManager<C> {
      * after parsing by a {@link CommandPostprocessor}. In the case that a command was filtered out at any of the
      * execution stages, the future will complete with {@code null}.
      * <p>
-     * The future may also complete exceptionally. The command manager contains some utilities that allow users to
-     * register exception handlers ({@link #registerExceptionHandler(Class, BiConsumer)} and these can be retrieved using
-     * {@link #getExceptionHandler(Class)}, or used with {@link #handleException(Object, Class, Exception, BiConsumer)}. It
-     * is highly recommended that these methods are used in the command manager, as it allows users of the command manager
-     * to override the exception handling as they wish.
+     * The future may also complete exceptionally.
+     * These exceptions may be handled using exception handlers registered in the {@link #exceptionController()}.
      *
      * @param commandSender Sender of the command
      * @param input         Input provided by the sender. Prefixes should be removed before the method is being called, and
@@ -928,6 +927,19 @@ public abstract class CommandManager<C> {
             return null;
         }
         return (BiConsumer<C, E>) consumer;
+    }
+
+    /**
+     * Returns the exception controller.
+     * <p>
+     * The exception controller is responsible for exception handler registration.
+     *
+     * @return the exception controller
+     * @since 2.0.0
+     */
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    public final @NonNull ExceptionController<C> exceptionController() {
+        return this.exceptionController;
     }
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/handling/ExceptionContext.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/handling/ExceptionContext.java
@@ -1,0 +1,108 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.exceptions.handling;
+
+import cloud.commandframework.context.CommandContext;
+import java.util.Objects;
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+@SuppressWarnings("unused")
+@API(status = API.Status.STABLE, since = "2.0.0")
+public interface ExceptionContext<C, T extends Throwable> {
+
+    /**
+     * Returns the exception.
+     *
+     * @return the exception
+     */
+    @NonNull T exception();
+
+    /**
+     * Returns the command context.
+     *
+     * @return the command context
+     */
+    @NonNull CommandContext<C> context();
+
+    /**
+     * Returns the exception controller that created this context instance.
+     *
+     * @return the controller
+     */
+    @NonNull ExceptionController<C> controller();
+
+
+    @API(status = API.Status.INTERNAL, since = "2.0.0")
+    final class ExceptionContextImpl<C, T extends Throwable> implements ExceptionContext<C, T> {
+
+        private final T exception;
+        private final CommandContext<C> context;
+        private final ExceptionController<C> controller;
+
+        ExceptionContextImpl(
+                final @NonNull T exception,
+                final @NonNull CommandContext<C> context,
+                final @NonNull ExceptionController<C> controller
+        ) {
+            this.exception = exception;
+            this.context = context;
+            this.controller = controller;
+        }
+
+        @Override
+        public @NonNull T exception() {
+            return this.exception;
+        }
+
+        @Override
+        public @NonNull CommandContext<C> context() {
+            return this.context;
+        }
+
+        @Override
+        public @NonNull ExceptionController<C> controller() {
+            return this.controller;
+        }
+
+        @Override
+        public boolean equals(final Object object) {
+            if (this == object) {
+                return true;
+            }
+            if (object == null || getClass() != object.getClass()) {
+                return false;
+            }
+            final ExceptionContextImpl<?, ?> that = (ExceptionContextImpl<?, ?>) object;
+            return Objects.equals(this.exception, that.exception)
+                    && Objects.equals(this.context, that.context)
+                    && Objects.equals(this.controller, that.controller);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.exception, this.context, this.controller);
+        }
+    }
+}

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/handling/ExceptionContextFactory.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/handling/ExceptionContextFactory.java
@@ -1,0 +1,58 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.exceptions.handling;
+
+import cloud.commandframework.context.CommandContext;
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+@API(status = API.Status.INTERNAL, since = "2.0.0")
+public final class ExceptionContextFactory<C> {
+
+    private final ExceptionController<C> controller;
+
+    /**
+     * Creates a new factory.
+     *
+     * @param controller the controller
+     */
+    public ExceptionContextFactory(final @NonNull ExceptionController<C> controller) {
+        this.controller = controller;
+    }
+
+    /**
+     * Creates a new exception context.
+     *
+     * @param <T>       the exception type
+     * @param context   the command context
+     * @param exception the exception
+     * @return the created context
+     */
+    public <T extends Throwable> @NonNull ExceptionContext<C, T> createContext(
+            final @NonNull CommandContext<C> context,
+            final @NonNull T exception
+    ) {
+        return new ExceptionContext.ExceptionContextImpl<>(exception, context, this.controller);
+    }
+}

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/handling/ExceptionController.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/handling/ExceptionController.java
@@ -1,0 +1,200 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.exceptions.handling;
+
+import cloud.commandframework.context.CommandContext;
+import io.leangen.geantyref.TypeToken;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.common.returnsreceiver.qual.This;
+
+/**
+ * The controller handles registrations of exception handlers, as well as the routing of incoming exceptions to the handlers.
+ *
+ * @param <C> the command sender type
+ * @since 2.0.0
+ */
+@SuppressWarnings("unused")
+@API(status = API.Status.STABLE, since = "2.0.0")
+public final class ExceptionController<C> {
+
+    private final ExceptionContextFactory<C> exceptionContextFactory = new ExceptionContextFactory<>(this);
+    private final Map<@NonNull Type, @NonNull LinkedList<@NonNull ExceptionHandlerRegistration<C, ?>>> registrations;
+
+    /**
+     * Creates a new exception controller.
+     */
+    public ExceptionController() {
+        this.registrations = new HashMap<>();
+    }
+
+    /**
+     * Attempts to handle the given {@code exception} gracefully.
+     * <p>
+     * The controller will attempt to find exception handlers for the exception type, and any of its supertypes.
+     * Only one exception handler will get to fully handle the exception.
+     * <p>
+     * If no exception handler was able to handle the exception, the exception will be re-thrown.
+     * The thrown exception might be different from the initial exception in the case that
+     * any of the exception handlers throws a new exception.
+     *
+     * @param <T>            the exception type
+     * @param commandContext the command context
+     * @param exception      the exception
+     * @throws Throwable any exception left unhandled is re-thrown and should be handled by the caller
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public <T extends Throwable> void handleException(
+            final @NonNull CommandContext<C> commandContext,
+            final @NonNull T exception
+    ) throws Throwable {
+        final ExceptionContext<C, T> exceptionContext = this.exceptionContextFactory.createContext(commandContext, exception);
+
+        Class<?> exceptionClass = exception.getClass();
+        while (exceptionClass != Object.class) {
+            final List<ExceptionHandlerRegistration<C, ?>> registrations = this.registrations(exceptionClass);
+            for (final ExceptionHandlerRegistration<C, ?> registration : registrations) {
+                if (!((Predicate) registration.exceptionFilter()).test(exception)) {
+                    continue;
+                }
+
+                try {
+                    ((ExceptionHandlerRegistration) registration).exceptionHandler().handle(exceptionContext);
+                } catch (final Throwable throwable) {
+                    if (throwable.equals(exception)) {
+                        continue;
+                    }
+                    // We try to handle the new exception instead.
+                    this.handleException(commandContext, throwable);
+                }
+                return;
+            }
+            exceptionClass = exceptionClass.getSuperclass();
+        }
+
+        // If nothing was able to handle the exception, then we re-throw.
+        throw exception;
+    }
+
+    /**
+     * Registers the given {@code registration}.
+     * <p>
+     * The ordering mappers when multiple handlers are registered for the same exception type.
+     * The last registered handler will get priority.
+     *
+     * @param <T>          the exception type handled by the exception handler
+     * @param registration the exception handler registration
+     * @return {@code this} exception controller
+     */
+    public synchronized <T extends Throwable> @NonNull @This ExceptionController<C> register(
+            final @NonNull ExceptionHandlerRegistration<C, T> registration
+    ) {
+        this.registrations.computeIfAbsent(registration.exceptionType().getType(), t -> new LinkedList<>())
+                .addFirst(registration);
+        return this;
+    }
+
+    /**
+     * Decorates a registration builder and registers the result.
+     * <p>
+     * The ordering mappers when multiple handlers are registered for the same exception type.
+     * The last registered handler will get priority.
+     *
+     * @param <T>            the exception type handled by the exception handler
+     * @param exceptionType  the exception type handled by the exception handler
+     * @param decorator     the builder decorator
+     * @return {@code this} exception controller
+     */
+    public synchronized <T extends Throwable> @NonNull @This ExceptionController<C> register(
+            final @NonNull TypeToken<T> exceptionType,
+            final ExceptionHandlerRegistration.@NonNull BuilderDecorator<C, T> decorator
+    ) {
+        return this.register(decorator.decorate(ExceptionHandlerRegistration.builder(exceptionType)).build());
+    }
+
+    /**
+     * Decorates a registration builder and registers the result.
+     * <p>
+     * The ordering mappers when multiple handlers are registered for the same exception type.
+     * The last registered handler will get priority.
+     *
+     * @param <T>            the exception type handled by the exception handler
+     * @param exceptionType  the exception type handled by the exception handler
+     * @param decorator     the builder decorator
+     * @return {@code this} exception controller
+     */
+    public synchronized <T extends Throwable> @NonNull @This ExceptionController<C> register(
+            final @NonNull Class<T> exceptionType,
+            final ExceptionHandlerRegistration.@NonNull BuilderDecorator<C, T> decorator
+    ) {
+        return this.register(decorator.decorate(ExceptionHandlerRegistration.builder(TypeToken.get(exceptionType))).build());
+    }
+
+    /**
+     * Registers the given {@code exceptionHandler}.
+     * <p>
+     * The ordering mappers when multiple handlers are registered for the same exception type.
+     * The last registered handler will get priority.
+     *
+     * @param <T>              the exception type handled by the exception handler
+     * @param exceptionType    the exception type handled by the exception handler
+     * @param exceptionHandler the exception handler
+     * @return {@code this} exception controller
+     */
+    public synchronized <T extends Throwable> @NonNull @This ExceptionController<C> registerHandler(
+            final @NonNull TypeToken<T> exceptionType,
+            final @NonNull ExceptionHandler<C, T> exceptionHandler
+    ) {
+        return this.register(ExceptionHandlerRegistration.of(exceptionType, exceptionHandler));
+    }
+
+    /**
+     * Registers the given {@code exceptionHandler}.
+     * <p>
+     * The ordering mappers when multiple handlers are registered for the same exception type.
+     * The last registered handler will get priority.
+     *
+     * @param <T>              the exception type handled by the exception handler
+     * @param exceptionType    the exception type handled by the exception handler
+     * @param exceptionHandler the exception handler
+     * @return {@code this} exception controller
+     */
+    public synchronized <T extends Throwable> @NonNull @This ExceptionController<C> registerHandler(
+            final @NonNull Class<T> exceptionType,
+            final @NonNull ExceptionHandler<C, T> exceptionHandler
+    ) {
+        return this.register(ExceptionHandlerRegistration.of(TypeToken.get(exceptionType), exceptionHandler));
+    }
+
+    private @NonNull List<@NonNull ExceptionHandlerRegistration<C, ?>> registrations(final @NonNull Type type) {
+        return Collections.unmodifiableList(this.registrations.getOrDefault(type, new LinkedList<>()));
+    }
+}

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/handling/ExceptionHandler.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/handling/ExceptionHandler.java
@@ -1,0 +1,63 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.exceptions.handling;
+
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Handles an exception thrown during command parsing &amp; execution.
+ *
+ * @param <C> the command sender type
+ * @param <T> the exception type
+ * @since 2.0.0
+ */
+@FunctionalInterface
+@API(status = API.Status.STABLE, since = "2.0.0")
+public interface ExceptionHandler<C, T extends Throwable> {
+
+    /**
+     * Returns an exception handler that does nothing.
+     *
+     * @param <C> the command sender type
+     * @param <T> the exception type
+     * @return the exception handler
+     */
+    static <C, T extends Throwable> @NonNull ExceptionHandler<C, T> noopHandler() {
+        return ctx -> {};
+    }
+
+    /**
+     * Handles the exception in the given {@code context}.
+     * <p>
+     * Any exception thrown by the handler will be handled by the {@link ExceptionController}.
+     * <p>
+     * If the {@link ExceptionContext#exception()} is re-thrown, then the next exception handler in
+     * line will get to handle the exception instead.
+     *
+     * @param context the exception context
+     * @throws Exception any exception thrown by the handler
+     */
+    void handle(@NonNull ExceptionContext<C, T> context) throws Throwable;
+}

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/handling/ExceptionHandlerRegistration.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/handling/ExceptionHandlerRegistration.java
@@ -1,0 +1,190 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.exceptions.handling;
+
+import io.leangen.geantyref.TypeToken;
+import java.util.function.Predicate;
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Used to register a {@link ExceptionHandler} in the {@link ExceptionController}.
+ *
+ * @param <C> the command sender type
+ * @param <T> the exception type
+ * @since 2.0.0
+ */
+@SuppressWarnings("unused")
+@API(status = API.Status.STABLE, since = "2.0.0")
+public final class ExceptionHandlerRegistration<C, T extends Throwable> {
+
+    /**
+     * Returns a new registration.
+     *
+     * @param <C>              the command sender type
+     * @param <T>              the exception type
+     * @param exceptionType    the type handled by the exception handler
+     * @param exceptionHandler the exception handler
+     * @return the created registration
+     */
+    public static <C, T extends Throwable> @NonNull ExceptionHandlerRegistration<C, T> of(
+            final @NonNull TypeToken<T> exceptionType,
+            final @NonNull ExceptionHandler<C, T> exceptionHandler
+    ) {
+       return ExceptionHandlerRegistration.<C, T>builder(exceptionType).exceptionHandler(exceptionHandler).build();
+    }
+
+    /**
+     * Returns a builder.
+     * <p>
+     * The builder is immutable, and each method results in a new builder instance.
+     *
+     * @param <C>           the command sender type
+     * @param <T>           the exception type
+     * @param exceptionType the type handled by the exception handler
+     * @return the builder
+     */
+    public static <C, T extends Throwable> @NonNull ExceptionControllerBuilder<C, T> builder(
+            final @NonNull TypeToken<T> exceptionType
+    ) {
+        return new ExceptionControllerBuilder<>(exceptionType);
+    }
+
+    private final TypeToken<T> exceptionType;
+    private final ExceptionHandler<C, T> exceptionHandler;
+    private final Predicate<T> exceptionFilter;
+
+    private ExceptionHandlerRegistration(
+            final @NonNull TypeToken<T> exceptionType,
+            final @NonNull ExceptionHandler<C, T> exceptionHandler,
+            final @NonNull Predicate<T> exceptionFilter
+    ) {
+        this.exceptionType = exceptionType;
+        this.exceptionHandler = exceptionHandler;
+        this.exceptionFilter = exceptionFilter;
+    }
+
+    /**
+     * Returns the exception type handler by this handler.
+     * <p>
+     * More precise exception types will always get higher priority when selecting the exception handlers
+     * for any given exception.
+     *
+     * @return the exception type
+     */
+    public @NonNull TypeToken<T> exceptionType() {
+        return this.exceptionType;
+    }
+
+    /**
+     * Returns the exception handler.
+     *
+     * @return the exception handler
+     */
+    public @NonNull ExceptionHandler<C, T> exceptionHandler() {
+        return this.exceptionHandler;
+    }
+
+    /**
+     * Returns the exception filter.
+     * <p>
+     * Exceptions should only be handled by the {@link #exceptionHandler()} if the predicate evaluates to {@code true}.
+     *
+     * @return the exception filter
+     */
+    public @NonNull Predicate<T> exceptionFilter() {
+        return this.exceptionFilter;
+    }
+
+
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    public static final class ExceptionControllerBuilder<C, T extends Throwable> {
+
+        private final TypeToken<T> exceptionType;
+        private final ExceptionHandler<C, T> exceptionHandler;
+        private final Predicate<T> exceptionFilter;
+
+        private ExceptionControllerBuilder(
+                final @NonNull TypeToken<T> exceptionType,
+                final @NonNull ExceptionHandler<C, T> exceptionHandler,
+                final @NonNull Predicate<T> exceptionFilter
+        ) {
+            this.exceptionType = exceptionType;
+            this.exceptionHandler = exceptionHandler;
+            this.exceptionFilter = exceptionFilter;
+        }
+
+        private ExceptionControllerBuilder(
+                final @NonNull TypeToken<T> exceptionType
+        ) {
+            this(exceptionType, ExceptionHandler.noopHandler(), exception -> true);
+        }
+
+        /**
+         * Returns a new builder with the given {@code exceptionHandler}.
+         *
+         * @param exceptionHandler the new exception handler
+         * @return new builder instance
+         */
+        public @NonNull ExceptionControllerBuilder<C, T> exceptionHandler(
+                final @NonNull ExceptionHandler<C, T> exceptionHandler
+        ) {
+            return new ExceptionControllerBuilder<>(this.exceptionType, exceptionHandler, this.exceptionFilter);
+        }
+
+        /**
+         * Returns a new builder with the given {@code exceptionFilter}.
+         *
+         * @param exceptionFilter the new filter, only exceptions that evaluate to {@code true} will be handled by the handler
+         * @return new builder instance
+         */
+        public @NonNull ExceptionControllerBuilder<C, T> exceptionFilter(
+                final @NonNull Predicate<T> exceptionFilter
+        ) {
+            return new ExceptionControllerBuilder<>(this.exceptionType, this.exceptionHandler, exceptionFilter);
+        }
+
+        /**
+         * Builds a registration from this builder.
+         *
+         * @return the registration
+         */
+        public @NonNull ExceptionHandlerRegistration<C, T> build() {
+            return new ExceptionHandlerRegistration<>(this.exceptionType, this.exceptionHandler, this.exceptionFilter);
+        }
+    }
+
+    @FunctionalInterface
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    public interface BuilderDecorator<C, T extends Throwable> {
+
+        /**
+         * Decorates the given {@code builder} and returns the updated builder.
+         *
+         * @param builder the builder
+         * @return the updated builder
+         */
+        @NonNull ExceptionControllerBuilder<C, T> decorate(@NonNull ExceptionControllerBuilder<C, T> builder);
+    }
+}

--- a/cloud-core/src/main/java/cloud/commandframework/exceptions/handling/package-info.java
+++ b/cloud-core/src/main/java/cloud/commandframework/exceptions/handling/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Cloud's exception handling system.
+ *
+ * @since 2.0.0
+ */
+package cloud.commandframework.exceptions.handling;

--- a/cloud-core/src/test/java/cloud/commandframework/exceptions/handling/ExceptionControllerTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/exceptions/handling/ExceptionControllerTest.java
@@ -1,0 +1,155 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.exceptions.handling;
+
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.exceptions.NoSuchCommandException;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@SuppressWarnings("unchecked")
+@ExtendWith(MockitoExtension.class)
+class ExceptionControllerTest {
+
+    @Mock
+    private CommandContext<Object> commandContext;
+
+    private ExceptionController<Object> exceptionController;
+    private ExceptionContextFactory<Object> exceptionContextFactory;
+
+    @BeforeEach
+    void setup() {
+        this.exceptionController = new ExceptionController<>();
+        this.exceptionContextFactory = new ExceptionContextFactory<>(this.exceptionController);
+    }
+
+    @Test
+    void HandleException_PreciseType_ExceptionHandled() throws Throwable {
+        // Arrange
+        final ExceptionHandler<Object, NoSuchCommandException> exceptionHandler = mock(ExceptionHandler.class);
+        this.exceptionController.registerHandler(NoSuchCommandException.class, exceptionHandler);
+        final NoSuchCommandException exception =  new NoSuchCommandException(
+                new Object(),
+                Collections.emptyList(),
+                ""
+        );
+
+        // Act
+        this.exceptionController.handleException(this.commandContext, exception);
+
+        // Assert
+        verify(exceptionHandler).handle(this.exceptionContextFactory.createContext(this.commandContext, exception));
+    }
+
+    @Test
+    void HandleException_ParentType_ExceptionHandled() throws Throwable {
+        // Arrange
+        final ExceptionHandler<Object, Throwable> exceptionHandler = mock(ExceptionHandler.class);
+        this.exceptionController.registerHandler(Throwable.class, exceptionHandler);
+        final NoSuchCommandException exception =  new NoSuchCommandException(
+                new Object(),
+                Collections.emptyList(),
+                ""
+        );
+
+        // Act
+        this.exceptionController.handleException(this.commandContext, exception);
+
+        // Assert
+        verify(exceptionHandler).handle(this.exceptionContextFactory.createContext(this.commandContext, exception));
+    }
+
+    @Test
+    void HandleException_NoFallback_ExceptionReThrown() {
+        // Arrange
+        final NoSuchCommandException exception =  new NoSuchCommandException(
+                new Object(),
+                Collections.emptyList(),
+                ""
+        );
+
+        // Act
+        final NoSuchCommandException result = assertThrows(
+                NoSuchCommandException.class,
+                () -> this.exceptionController.handleException(this.commandContext, exception)
+        );
+
+        // Assert
+        assertThat(result).isEqualTo(exception);
+    }
+
+    @Test
+    void HandleException_ExceptionRethrown_ExceptionHandled() throws Throwable {
+        // Arrange
+        final ExceptionHandler<Object, NoSuchCommandException> exceptionHandler = ctx -> {
+            throw ctx.exception();
+        };
+        final ExceptionHandler<Object, NoSuchCommandException> fallbackHandler = mock(ExceptionHandler.class);
+        this.exceptionController.registerHandler(NoSuchCommandException.class, fallbackHandler);
+        this.exceptionController.registerHandler(NoSuchCommandException.class, exceptionHandler);
+        final NoSuchCommandException exception =  new NoSuchCommandException(
+                new Object(),
+                Collections.emptyList(),
+                ""
+        );
+
+        // Act
+        this.exceptionController.handleException(this.commandContext, exception);
+
+        // Assert
+        verify(fallbackHandler).handle(this.exceptionContextFactory.createContext(this.commandContext, exception));
+    }
+
+    @Test
+    void HandleException_NewExceptionThrown_ExceptionHandled() throws Throwable {
+        // Arrange
+        final RuntimeException runtimeException = new RuntimeException("test :)");
+        final ExceptionHandler<Object, NoSuchCommandException> exceptionHandler = ctx -> {
+            throw runtimeException;
+        };
+        final ExceptionHandler<Object, Throwable> fallbackHandler = mock(ExceptionHandler.class);
+        this.exceptionController.registerHandler(NoSuchCommandException.class, exceptionHandler);
+        this.exceptionController.registerHandler(Throwable.class, fallbackHandler);
+        final NoSuchCommandException exception =  new NoSuchCommandException(
+                new Object(),
+                Collections.emptyList(),
+                ""
+        );
+
+        // Act
+        this.exceptionController.handleException(this.commandContext, exception);
+
+        // Assert
+        verify(fallbackHandler).handle(this.exceptionContextFactory.createContext(this.commandContext, runtimeException));
+    }
+}


### PR DESCRIPTION
This introduces a new exception handling system that allows us to register exception handlers for both the precise exception types _and_ their super types. This system also allows us to register multiple exception handlers for the same exception type.

Before we make use of this API in the platform implementations I want to make sure that it's refined. Feedback is very welcome :)