### PR TITLE
build: use immutables

### DIFF
--- a/build-logic/src/main/kotlin/cloud.base-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cloud.base-conventions.gradle.kts
@@ -36,7 +36,7 @@ tasks {
             )
             disableWarningsInGeneratedCode.set(true)
         }
-        options.compilerArgs.addAll(listOf("-Xlint:-processing", "-Werror"))
+        options.compilerArgs.addAll(listOf("-Xlint:-processing,-classfile", "-Werror"))
     }
 }
 
@@ -68,7 +68,8 @@ spotless {
 dependencies {
     compileOnlyApi(libs.checkerQual)
     compileOnlyApi(libs.apiguardian)
-    compileOnlyApi(libs.immutables)
+
+    compileOnly(libs.immutables)
     annotationProcessor(libs.immutables)
 
     testImplementation(libs.jupiterEngine)

--- a/build-logic/src/main/kotlin/cloud.base-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cloud.base-conventions.gradle.kts
@@ -34,6 +34,7 @@ tasks {
                 "CatchAndPrintStackTrace",
                 "InlineMeSuggester"
             )
+            disableWarningsInGeneratedCode.set(true)
         }
         options.compilerArgs.addAll(listOf("-Xlint:-processing", "-Werror"))
     }
@@ -67,6 +68,8 @@ spotless {
 dependencies {
     compileOnlyApi(libs.checkerQual)
     compileOnlyApi(libs.apiguardian)
+    compileOnlyApi(libs.immutables)
+    annotationProcessor(libs.immutables)
 
     testImplementation(libs.jupiterEngine)
     testImplementation(libs.jupiterParams)

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/ArgumentDescriptor.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/ArgumentDescriptor.java
@@ -25,45 +25,25 @@ package cloud.commandframework.annotations;
 
 import cloud.commandframework.Description;
 import cloud.commandframework.arguments.suggestion.SuggestionProvider;
+import cloud.commandframework.internal.ImmutableBuilder;
 import java.lang.reflect.Parameter;
-import java.util.Objects;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
+@ImmutableBuilder
+@Value.Immutable
 @API(status = API.Status.STABLE, since = "2.0.0")
-public final class ArgumentDescriptor implements Descriptor {
-
-    private final Parameter parameter;
-    private final String name;
-    private final String parserName;
-    private final String suggestions;
-    private final String defaultValue;
-    private final Description description;
+public interface ArgumentDescriptor extends Descriptor {
 
     /**
      * Creates a new builder.
      *
      * @return the created builder
      */
-    public static @NonNull Builder builder() {
-        return new Builder();
-    }
-
-    private ArgumentDescriptor(
-            final @NonNull Parameter parameter,
-            final @NonNull String name,
-            final @Nullable String parserName,
-            final @Nullable String suggestions,
-            final @Nullable String defaultValue,
-            final @Nullable Description description
-    ) {
-        this.parameter = parameter;
-        this.name = name;
-        this.parserName = parserName;
-        this.suggestions = suggestions;
-        this.defaultValue = defaultValue;
-        this.description = description;
+    static ImmutableArgumentDescriptor.@NonNull Builder builder() {
+        return ImmutableArgumentDescriptor.builder();
     }
 
     /**
@@ -71,9 +51,7 @@ public final class ArgumentDescriptor implements Descriptor {
      *
      * @return the parameter
      */
-    public @NonNull Parameter parameter() {
-        return this.parameter;
-    }
+    @NonNull Parameter parameter();
 
     /**
      * Returns the argument name
@@ -81,21 +59,14 @@ public final class ArgumentDescriptor implements Descriptor {
      * @return the argument name
      */
     @Override
-    public @NonNull String name() {
-        if (this.name.equals(AnnotationParser.INFERRED_ARGUMENT_NAME)) {
-            return this.parameter.getName();
-        }
-        return this.name;
-    }
+    @NonNull String name();
 
     /**
      * Returns the name of the parser to use. If {@code null} the default parser for the parameter type will be used.
      *
      * @return the parser name, or {@code null}
      */
-    public @Nullable String parserName() {
-        return this.parserName;
-    }
+    @Nullable String parserName();
 
     /**
      * Returns the name of the suggestion provider to use. If the string is {@code null}, the default
@@ -109,175 +80,19 @@ public final class ArgumentDescriptor implements Descriptor {
      *
      * @return the name of the suggestion provider, or {@code null}
      */
-    public @Nullable String suggestions() {
-        return this.suggestions;
-    }
+    @Nullable String suggestions();
 
     /**
      * Returns the default value.
      *
      * @return the default value, or {@code null}
      */
-    public @Nullable String defaultValue() {
-        return this.defaultValue;
-    }
+    @Nullable String defaultValue();
 
     /**
      * Returns the description of the argument.
      *
      * @return the argument description, or {@code null}
      */
-    public @Nullable Description description() {
-        return this.description;
-    }
-
-    @Override
-    public boolean equals(final Object object) {
-        if (this == object) {
-            return true;
-        }
-        if (object == null || getClass() != object.getClass()) {
-            return false;
-        }
-        ArgumentDescriptor that = (ArgumentDescriptor) object;
-        return Objects.equals(this.parameter, that.parameter)
-                && Objects.equals(this.name, that.name)
-                && Objects.equals(this.parserName, that.parserName)
-                && Objects.equals(this.suggestions, that.suggestions)
-                && Objects.equals(this.defaultValue, that.defaultValue)
-                && Objects.equals(this.description, that.description);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(this.parameter, this.name, this.parserName, this.suggestions, this.defaultValue, this.description);
-    }
-
-
-    public static final class Builder {
-
-        private final Parameter parameter;
-        private final String name;
-        private final String parserName;
-        private final String suggestions;
-        private final String defaultValue;
-        private final Description description;
-
-        private Builder(
-                final @Nullable Parameter parameter,
-                final @Nullable String name,
-                final @Nullable String parserName,
-                final @Nullable String suggestions,
-                final @Nullable String defaultValue,
-                final @Nullable Description description
-        ) {
-            this.parameter = parameter;
-            this.name = name;
-            this.parserName = parserName;
-            this.suggestions = suggestions;
-            this.defaultValue = defaultValue;
-            this.description = description;
-        }
-
-        private Builder() {
-            this(null, null, null, null, null, null);
-        }
-
-        /**
-         * Returns an updated builder with the given {@code parameter}.
-         *
-         * @param parameter the new parameter
-         * @return the builder containing the updated parameter
-         */
-        public @NonNull Builder parameter(final @NonNull Parameter parameter) {
-            return new Builder(parameter, this.name, this.parserName, this.suggestions, this.defaultValue, this.description);
-        }
-
-        /**
-         * Returns an updated builder with the given {@code name}.
-         * <p>
-         * This can be set to {@link AnnotationParser#INFERRED_ARGUMENT_NAME} to infer the argument name
-         * from the parameter name.
-         *
-         * @param name the new name
-         * @return the builder containing the updated name
-         */
-        public @NonNull Builder name(final @NonNull String name) {
-            return new Builder(this.parameter, name, this.parserName, this.suggestions, this.defaultValue, this.description);
-        }
-
-        /**
-         * Returns an updated builder with the given {@code parserName}.
-         *
-         * @param parserName the new parserName
-         * @return the builder containing the updated parserName
-         */
-        public @NonNull Builder parserName(final @Nullable String parserName) {
-            final String nullableName;
-            if (parserName != null && parserName.isEmpty()) {
-                nullableName = null;
-            } else {
-                nullableName = parserName;
-            }
-            return new Builder(this.parameter, this.name, nullableName, this.suggestions, this.defaultValue, this.description);
-        }
-
-        /**
-         * Returns an updated builder with the given {@code suggestions}.
-         *
-         * @param suggestions the new suggestions
-         * @return the builder containing the updated suggestions
-         */
-        public @NonNull Builder suggestions(final @Nullable String suggestions) {
-            final String nullableName;
-            if (suggestions != null && suggestions.isEmpty()) {
-                nullableName = null;
-            } else {
-                nullableName = suggestions;
-            }
-            return new Builder(this.parameter, this.name, this.parserName, nullableName, this.defaultValue, this.description);
-        }
-
-        /**
-         * Returns an updated builder with the given {@code defaultValue}.
-         *
-         * @param defaultValue the new default value
-         * @return the builder containing the updated default value
-         */
-        public @NonNull Builder defaultValue(final @Nullable String defaultValue) {
-            final String nullableName;
-            if (defaultValue != null && defaultValue.isEmpty()) {
-                nullableName = null;
-            } else {
-                nullableName = defaultValue;
-            }
-            return new Builder(this.parameter, this.name, this.parserName, this.suggestions, nullableName, this.description);
-        }
-
-        /**
-         * Returns an updated builder with the given {@code description}.
-         *
-         * @param description the new description
-         * @return the builder containing the updated description
-         */
-        public @NonNull Builder description(final @Nullable Description description) {
-            return new Builder(this.parameter, this.name, this.parserName, this.suggestions, this.defaultValue, description);
-        }
-
-        /**
-         * Returns the build argument descriptor.
-         *
-         * @return the argument descriptor
-         */
-        public @NonNull ArgumentDescriptor build() {
-            return new ArgumentDescriptor(
-                    Objects.requireNonNull(this.parameter, "parameter"),
-                    Objects.requireNonNull(this.name, "name"),
-                    this.parserName,
-                    this.suggestions,
-                    this.defaultValue,
-                    this.description
-            );
-        }
-    }
+    @Nullable Description description();
 }

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/ArgumentExtractorImpl.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/ArgumentExtractorImpl.java
@@ -39,6 +39,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 class ArgumentExtractorImpl implements ArgumentExtractor {
 
+    private static @Nullable String nullIfEmpty(final @NonNull String string) {
+        if (string.isEmpty()) {
+            return null;
+        }
+        return string;
+    }
+
     private final Function<@NonNull Argument, @Nullable Description> descriptionMapper;
 
     ArgumentExtractorImpl() {
@@ -55,14 +62,23 @@ class ArgumentExtractorImpl implements ArgumentExtractor {
             if (!parameter.isAnnotationPresent(Argument.class)) {
                 continue;
             }
+
             final Argument argument = parameter.getAnnotation(Argument.class);
+
+            final String name;
+            if (argument.value().equals(AnnotationParser.INFERRED_ARGUMENT_NAME)) {
+                name = parameter.getName();
+            } else {
+                name = argument.value();
+            }
+
             final ArgumentDescriptor argumentDescriptor = ArgumentDescriptor.builder()
                     .parameter(parameter)
-                    .name(argument.value())
-                    .parserName(argument.parserName())
-                    .defaultValue(argument.defaultValue())
+                    .name(name)
+                    .parserName(nullIfEmpty(argument.parserName()))
+                    .defaultValue(nullIfEmpty(argument.defaultValue()))
                     .description(this.descriptionMapper.apply(argument))
-                    .suggestions(argument.suggestions())
+                    .suggestions(nullIfEmpty(argument.suggestions()))
                     .build();
             arguments.add(argumentDescriptor);
         }

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/CommandDescriptor.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/CommandDescriptor.java
@@ -23,52 +23,28 @@
 //
 package cloud.commandframework.annotations;
 
+import cloud.commandframework.internal.ImmutableBuilder;
 import java.lang.reflect.Method;
-import java.util.Collections;
 import java.util.List;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.immutables.value.Value;
 
+@ImmutableBuilder
+@Value.Immutable
 @API(status = API.Status.STABLE, since = "2.0.0")
-public final class CommandDescriptor implements Descriptor {
-
-    private final Method method;
-    private final List<@NonNull SyntaxFragment> syntax;
-    private final String commandToken;
-    private final Class<?> requiredSender;
-
-    /**
-     * Creates a new command descriptor.
-     *
-     * @param method         the command method
-     * @param syntax         the command syntax
-     * @param commandToken   the root command name
-     * @param requiredSender the required sender type
-     */
-    public CommandDescriptor(
-            final @NonNull Method method,
-            final @NonNull List<@NonNull SyntaxFragment> syntax,
-            final @NonNull String commandToken,
-            final @NonNull Class<?> requiredSender
-    ) {
-        this.method = method;
-        this.syntax = syntax;
-        this.commandToken = commandToken;
-        this.requiredSender = requiredSender;
-    }
+public interface CommandDescriptor extends Descriptor {
 
     /**
      * Returns the command method.
      *
      * @return the command method
      */
-    public @NonNull Method method() {
-        return this.method;
-    }
+    @NonNull Method method();
 
     @Override
-    public @NonNull String name() {
-        return this.commandToken;
+    default @NonNull String name() {
+        return this.commandToken();
     }
 
     /**
@@ -76,25 +52,19 @@ public final class CommandDescriptor implements Descriptor {
      *
      * @return the syntax fragments
      */
-    public @NonNull List<@NonNull SyntaxFragment> syntax() {
-        return Collections.unmodifiableList(this.syntax);
-    }
+    @NonNull List<@NonNull SyntaxFragment> syntax();
 
     /**
      * Returns the root command name.
      *
      * @return the name of the root command
      */
-    public @NonNull String commandToken() {
-        return this.commandToken;
-    }
+    @NonNull String commandToken();
 
     /**
      * Returns the required sender type.
      *
      * @return the required sender type
      */
-    public @NonNull Class<?> requiredSender() {
-        return this.requiredSender;
-    }
+    @NonNull Class<?> requiredSender();
 }

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/CommandExtractorImpl.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/CommandExtractorImpl.java
@@ -70,12 +70,12 @@ final class CommandExtractorImpl implements CommandExtractor {
             for (final CommandMethod commandMethod : commands) {
                 final String syntax = syntaxPrefix + this.annotationParser.processString(commandMethod.value());
                 commandDescriptors.add(
-                        new CommandDescriptor(
-                                method,
-                                this.annotationParser.syntaxParser().parseSyntax(method, syntax),
-                                syntax.split(" ")[0].split("\\|")[0],
-                                commandMethod.requiredSender()
-                        )
+                        ImmutableCommandDescriptor.builder()
+                                .method(method)
+                                .syntax(this.annotationParser.syntaxParser().parseSyntax(method, syntax))
+                                .commandToken(syntax.split(" ")[0].split("\\|")[0])
+                                .requiredSender(commandMethod.requiredSender())
+                                .build()
                 );
             }
         }

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagDescriptor.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagDescriptor.java
@@ -25,56 +25,27 @@ package cloud.commandframework.annotations;
 
 import cloud.commandframework.Description;
 import cloud.commandframework.arguments.suggestion.SuggestionProvider;
+import cloud.commandframework.internal.ImmutableBuilder;
 import cloud.commandframework.permission.CommandPermission;
 import java.lang.reflect.Parameter;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Set;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.immutables.value.Value;
 
+@ImmutableBuilder
+@Value.Immutable
 @API(status = API.Status.STABLE, since = "2.0.0")
-public final class FlagDescriptor implements Descriptor {
-
-    private final Parameter parameter;
-    private final String name;
-    private final Set<@NonNull String> aliases;
-    private final String parserName;
-    private final String suggestions;
-    private final CommandPermission permission;
-    private final Description description;
-    private final boolean repeatable;
+public interface FlagDescriptor extends Descriptor {
 
     /**
      * Creates a new builder.
      *
      * @return the created builder
      */
-    public static @NonNull Builder builder() {
-        return new Builder();
-    }
-
-    private FlagDescriptor(
-            final @NonNull Parameter parameter,
-            final @NonNull String name,
-            final @NonNull Collection<@NonNull String> aliases,
-            final @Nullable String parserName,
-            final @Nullable String suggestions,
-            final @Nullable CommandPermission permission,
-            final @Nullable Description description,
-            final boolean repeatable
-    ) {
-        this.parameter = parameter;
-        this.name = name;
-        this.aliases = Collections.unmodifiableSet(new HashSet<>(aliases));
-        this.parserName = parserName;
-        this.suggestions = suggestions;
-        this.permission = permission;
-        this.description = description;
-        this.repeatable = repeatable;
+    static ImmutableFlagDescriptor.@NonNull Builder builder() {
+        return ImmutableFlagDescriptor.builder();
     }
 
     /**
@@ -82,9 +53,7 @@ public final class FlagDescriptor implements Descriptor {
      *
      * @return the parameter
      */
-    public @NonNull Parameter parameter() {
-        return this.parameter;
-    }
+    @NonNull Parameter parameter();
 
     /**
      * Returns the flag name.
@@ -92,30 +61,21 @@ public final class FlagDescriptor implements Descriptor {
      * @return the flag name
      */
     @Override
-    public @NonNull String name() {
-        if (this.name.equals(AnnotationParser.INFERRED_ARGUMENT_NAME)) {
-            return this.parameter.getName();
-        }
-        return this.name;
-    }
+    @NonNull String name();
 
     /**
      * Returns an unmodifiable view of the flag aliases.
      *
      * @return the flag aliases
      */
-    public @NonNull Collection<@NonNull String> aliases() {
-        return this.aliases;
-    }
+    @NonNull Collection<@NonNull String> aliases();
 
     /**
      * Returns the name of the parser to use. If {@code null} the default parser for the parameter type will be used.
      *
      * @return the parser name, or {@code null}
      */
-    public @Nullable String parserName() {
-        return this.parserName;
-    }
+    @Nullable String parserName();
 
     /**
      * Returns the name of the suggestion provider to use. If the string is {@code null}, the default
@@ -129,290 +89,26 @@ public final class FlagDescriptor implements Descriptor {
      *
      * @return the name of the suggestion provider, or {@code null}
      */
-    public @Nullable String suggestions() {
-        return this.suggestions;
-    }
+    @Nullable String suggestions();
 
     /**
      * Returns the permission of the flag.
      *
      * @return the flag permission, or {@code null}
      */
-    public @Nullable CommandPermission permission() {
-        return this.permission;
-    }
+    @Nullable CommandPermission permission();
 
     /**
      * Returns the description of the flag.
      *
      * @return the flag description, or {@code null}
      */
-    public @Nullable Description description() {
-        return this.description;
-    }
+    @Nullable Description description();
 
     /**
      * Returns whether the flag is repeatable.
      *
      * @return whether the flag is repeatable
      */
-    public boolean repeatable() {
-        return this.repeatable;
-    }
-
-    @Override
-    public boolean equals(final Object object) {
-        if (this == object) {
-            return true;
-        }
-        if (object == null || getClass() != object.getClass()) {
-            return false;
-        }
-        FlagDescriptor that = (FlagDescriptor) object;
-        return Objects.equals(this.parameter, that.parameter)
-                && Objects.equals(this.name, that.name)
-                && Objects.equals(this.aliases, that.aliases)
-                && Objects.equals(this.parserName, that.parserName)
-                && Objects.equals(this.suggestions, that.suggestions)
-                && Objects.equals(this.permission, that.permission)
-                && Objects.equals(this.description, that.description)
-                && this.repeatable == that.repeatable;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(
-                this.parameter,
-                this.name,
-                this.aliases,
-                this.parserName,
-                this.suggestions,
-                this.permission,
-                this.description,
-                this.repeatable
-        );
-    }
-
-
-    @API(status = API.Status.STABLE, since = "2.0.0")
-    public static final class Builder {
-
-        private final Parameter parameter;
-        private final String name;
-        private final Collection<String> aliases;
-        private final String parserName;
-        private final String suggestions;
-        private final CommandPermission permission;
-        private final Description description;
-        private final boolean repeatable;
-
-        private Builder(
-                final @Nullable Parameter parameter,
-                final @Nullable String name,
-                final @NonNull Collection<String> aliases,
-                final @Nullable String parserName,
-                final @Nullable String suggestions,
-                final @Nullable CommandPermission permission,
-                final @Nullable Description description,
-                final boolean repeatable
-        ) {
-            this.parameter = parameter;
-            this.name = name;
-            this.aliases = aliases;
-            this.parserName = parserName;
-            this.suggestions = suggestions;
-            this.permission = permission;
-            this.description = description;
-            this.repeatable = repeatable;
-        }
-
-        private Builder() {
-            this(null, null, Collections.emptySet(), null, null, null, null, false);
-        }
-
-        /**
-         * Returns an updated builder with the given {@code parameter}.
-         *
-         * @param parameter the new parameter
-         * @return the builder containing the updated parameter
-         */
-        public @NonNull Builder parameter(final @NonNull Parameter parameter) {
-            return new Builder(
-                    parameter,
-                    this.name,
-                    this.aliases,
-                    this.parserName,
-                    this.suggestions,
-                    this.permission,
-                    this.description,
-                    this.repeatable
-            );
-        }
-
-        /**
-         * Returns an updated builder with the given {@code name}.
-         * <p>
-         * This can be set to {@link AnnotationParser#INFERRED_ARGUMENT_NAME} to infer the flag name
-         * from the parameter name.
-         *
-         * @param name the new name
-         * @return the builder containing the updated name
-         */
-        public @NonNull Builder name(final @NonNull String name) {
-            return new Builder(
-                    this.parameter,
-                    name,
-                    this.aliases,
-                    this.parserName,
-                    this.suggestions,
-                    this.permission,
-                    this.description,
-                    this.repeatable
-            );
-        }
-
-        /**
-         * Returns an updated builder with the given {@code aliases}.
-         *
-         * @param aliases the new aliases
-         * @return the builder containing the updated aliases
-         */
-        public @NonNull Builder aliases(final @NonNull Collection<@NonNull String> aliases) {
-            return new Builder(
-                    this.parameter,
-                    this.name,
-                    aliases,
-                    this.parserName,
-                    this.suggestions,
-                    this.permission,
-                    this.description,
-                    this.repeatable
-            );
-        }
-
-        /**
-         * Returns an updated builder with the given {@code parserName}.
-         *
-         * @param parserName the new parserName
-         * @return the builder containing the updated parserName
-         */
-        public @NonNull Builder parserName(final @Nullable String parserName) {
-            final String nullableName;
-            if (parserName != null && parserName.isEmpty()) {
-                nullableName = null;
-            } else {
-                nullableName = parserName;
-            }
-            return new Builder(
-                    this.parameter,
-                    this.name,
-                    this.aliases,
-                    nullableName,
-                    this.suggestions,
-                    this.permission,
-                    this.description,
-                    this.repeatable
-            );
-        }
-
-        /**
-         * Returns an updated builder with the given {@code suggestions}.
-         *
-         * @param suggestions the new suggestions
-         * @return the builder containing the updated suggestions
-         */
-        public @NonNull Builder suggestions(final @Nullable String suggestions) {
-            final String nullableName;
-            if (suggestions != null && suggestions.isEmpty()) {
-                nullableName = null;
-            } else {
-                nullableName = suggestions;
-            }
-            return new Builder(
-                    this.parameter,
-                    this.name,
-                    this.aliases,
-                    this.parserName,
-                    nullableName,
-                    this.permission,
-                    this.description,
-                    this.repeatable
-            );
-        }
-
-        /**
-         * Returns an updated builder with the given {@code permission}.
-         *
-         * @param permission the new permission
-         * @return the builder containing the updated permission
-         */
-        public @NonNull Builder permission(final @Nullable CommandPermission permission) {
-            return new Builder(
-                    this.parameter,
-                    this.name,
-                    this.aliases,
-                    this.parserName,
-                    this.suggestions,
-                    permission,
-                    this.description,
-                    this.repeatable
-            );
-        }
-
-        /**
-         * Returns an updated builder with the given {@code description}.
-         *
-         * @param description the new description
-         * @return the builder containing the updated description
-         */
-        public @NonNull Builder description(final @Nullable Description description) {
-            return new Builder(
-                    this.parameter,
-                    this.name,
-                    this.aliases,
-                    this.parserName,
-                    this.suggestions,
-                    this.permission,
-                    description,
-                    this.repeatable
-            );
-        }
-
-        /**
-         * Returns an updated builder with the given {@code repeatable} value.
-         *
-         * @param repeatable whether the flag is repeatable
-         * @return the builder containing the updated repeatable value
-         */
-        public @NonNull Builder repeatable(final boolean repeatable) {
-            return new Builder(
-                    this.parameter,
-                    this.name,
-                    this.aliases,
-                    this.parserName,
-                    this.suggestions,
-                    this.permission,
-                    this.description,
-                    repeatable
-            );
-        }
-
-        /**
-         * Returns the built flag descriptor.
-         *
-         * @return the flag descriptor
-         */
-        public @NonNull FlagDescriptor build() {
-            return new FlagDescriptor(
-                    Objects.requireNonNull(this.parameter, "parameter"),
-                    Objects.requireNonNull(this.name, "name"),
-                    Objects.requireNonNull(this.aliases, "aliases"),
-                    this.parserName,
-                    this.suggestions,
-                    this.permission,
-                    this.description,
-                    this.repeatable
-            );
-        }
-    }
+    boolean repeatable();
 }

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagExtractorImpl.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/FlagExtractorImpl.java
@@ -31,8 +31,16 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class FlagExtractorImpl implements FlagExtractor {
+
+    private static @Nullable String nullIfEmpty(final @NonNull String string) {
+        if (string.isEmpty()) {
+            return null;
+        }
+        return string;
+    }
 
     private final AnnotationParser<?> annotationParser;
 
@@ -50,15 +58,22 @@ final class FlagExtractorImpl implements FlagExtractor {
             final Flag flag = parameter.getAnnotation(Flag.class);
             final String flagName = this.annotationParser.processString(flag.value());
 
+            final String name;
+            if (flagName.equals(AnnotationParser.INFERRED_ARGUMENT_NAME)) {
+                name = parameter.getName();
+            } else {
+                name = flagName;
+            }
+
             final FlagDescriptor flagDescriptor = FlagDescriptor.builder()
                     .parameter(parameter)
-                    .name(flagName)
+                    .name(name)
                     .description(Description.of(this.annotationParser.processString(flag.description())))
                     .aliases(this.annotationParser.processStrings(Arrays.asList(flag.aliases())))
                     .permission(Permission.of(this.annotationParser.processString(flag.permission())))
                     .repeatable(flag.repeatable())
-                    .parserName(this.annotationParser.processString(flag.parserName()))
-                    .suggestions(this.annotationParser.processString(flag.suggestions()))
+                    .parserName(nullIfEmpty(this.annotationParser.processString(flag.parserName())))
+                    .suggestions(nullIfEmpty(this.annotationParser.processString(flag.suggestions())))
                     .build();
             flags.add(flagDescriptor);
         }

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/ArgumentDrivenCommandsTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/ArgumentDrivenCommandsTest.java
@@ -30,6 +30,7 @@ import cloud.commandframework.annotations.ArgumentExtractor;
 import cloud.commandframework.annotations.ArgumentMode;
 import cloud.commandframework.annotations.CommandDescriptor;
 import cloud.commandframework.annotations.CommandExtractor;
+import cloud.commandframework.annotations.ImmutableCommandDescriptor;
 import cloud.commandframework.annotations.SyntaxFragment;
 import cloud.commandframework.annotations.SyntaxParser;
 import cloud.commandframework.annotations.TestCommandManager;
@@ -96,7 +97,7 @@ class ArgumentDrivenCommandsTest {
                 }
                 final ArgumentDescriptor argumentDescriptor = ArgumentDescriptor.builder()
                         .parameter(parameter)
-                        .name(AnnotationParser.INFERRED_ARGUMENT_NAME)
+                        .name(parameter.getName())
                         .build();
                 arguments.add(argumentDescriptor);
             }
@@ -157,13 +158,14 @@ class ArgumentDrivenCommandsTest {
                 if (!commandMethod) {
                     continue;
                 }
+
                 commandDescriptors.add(
-                        new CommandDescriptor(
-                                method,
-                                this.annotationParser.syntaxParser().parseSyntax(method, ""),
-                                commandName,
-                                Object.class
-                        )
+                        ImmutableCommandDescriptor.builder()
+                                .method(method)
+                                .syntax(this.annotationParser.syntaxParser().parseSyntax(method, ""))
+                                .commandToken(commandName)
+                                .requiredSender(Object.class)
+                                .build()
                 );
             }
             return commandDescriptors;

--- a/cloud-core/src/main/java/cloud/commandframework/CommandDescription.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandDescription.java
@@ -23,10 +23,13 @@
 //
 package cloud.commandframework;
 
-import java.util.Objects;
+import cloud.commandframework.internal.ImmutableImpl;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.immutables.value.Value;
 
+@ImmutableImpl
+@Value.Immutable
 @SuppressWarnings("unused")
 @API(status = API.Status.STABLE, since = "2.0.0")
 public interface CommandDescription extends Describable {
@@ -39,7 +42,7 @@ public interface CommandDescription extends Describable {
      * @return the description instance
      */
     static @NonNull CommandDescription empty() {
-        return new CommandDescriptionImpl(Description.empty());
+        return CommandDescriptionImpl.of(Description.empty(), Description.empty());
     }
 
     /**
@@ -53,7 +56,7 @@ public interface CommandDescription extends Describable {
             final @NonNull Description description,
             final @NonNull Description verboseDescription
     ) {
-        return new CommandDescriptionImpl(description, verboseDescription);
+        return CommandDescriptionImpl.of(description, verboseDescription);
     }
 
     /**
@@ -65,7 +68,7 @@ public interface CommandDescription extends Describable {
      * @return the description instance
      */
     static @NonNull CommandDescription commandDescription(final @NonNull Description description) {
-        return new CommandDescriptionImpl(description);
+        return CommandDescriptionImpl.of(description, description);
     }
 
     /**
@@ -79,7 +82,7 @@ public interface CommandDescription extends Describable {
             final @NonNull String description,
             final @NonNull String verboseDescription
     ) {
-        return new CommandDescriptionImpl(Description.of(description), Description.of(verboseDescription));
+        return CommandDescriptionImpl.of(Description.of(description), Description.of(verboseDescription));
     }
 
     /**
@@ -91,7 +94,7 @@ public interface CommandDescription extends Describable {
      * @return the description instance
      */
     static @NonNull CommandDescription commandDescription(final @NonNull String description) {
-        return new CommandDescriptionImpl(Description.of(description));
+        return CommandDescriptionImpl.of(Description.of(description), Description.of(description));
     }
 
     /**
@@ -116,60 +119,5 @@ public interface CommandDescription extends Describable {
      */
     default boolean isEmpty() {
         return this.description().equals(Description.empty());
-    }
-
-
-    final class CommandDescriptionImpl implements CommandDescription {
-
-        private final Description description;
-        private final Description verboseDescription;
-
-        private CommandDescriptionImpl(
-                final @NonNull Description description,
-                final @NonNull Description verboseDescription
-        ) {
-            this.description = description;
-            this.verboseDescription = verboseDescription;
-        }
-
-        private CommandDescriptionImpl(
-                final @NonNull Description description
-        ) {
-            this(description, description);
-        }
-
-        @Override
-        public @NonNull Description description() {
-            return this.description;
-        }
-
-        @Override
-        public @NonNull Description verboseDescription() {
-            return this.verboseDescription;
-        }
-
-        @Override
-        public boolean equals(final Object object) {
-            if (this == object) {
-                return true;
-            }
-            if (object == null || getClass() != object.getClass()) {
-                return false;
-            }
-            final CommandDescriptionImpl that = (CommandDescriptionImpl) object;
-            return Objects.equals(this.description, that.description)
-                    && Objects.equals(this.verboseDescription, that.verboseDescription);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(this.description, this.verboseDescription);
-        }
-
-        @Override
-        public String toString() {
-            return "CommandDescriptionImpl{description=" + this.description
-                    + ", verboseDescription=" + this.verboseDescription + '}';
-        }
     }
 }

--- a/cloud-core/src/main/java/cloud/commandframework/Description.java
+++ b/cloud-core/src/main/java/cloud/commandframework/Description.java
@@ -23,8 +23,10 @@
 //
 package cloud.commandframework;
 
+import cloud.commandframework.internal.ImmutableImpl;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.immutables.value.Value;
 
 import static java.util.Objects.requireNonNull;
 
@@ -33,8 +35,12 @@ import static java.util.Objects.requireNonNull;
  *
  * @since 2.0.0
  */
+@ImmutableImpl
+@Value.Immutable
 @API(status = API.Status.STABLE, since = "2.0.0")
 public interface Description {
+
+    Description EMPTY = DescriptionImpl.of("");
 
     /**
      * Returns an empty command description.
@@ -42,7 +48,7 @@ public interface Description {
      * @return Command description
      */
     static @NonNull Description empty() {
-        return DescriptionImpl.EMPTY;
+        return EMPTY;
     }
 
     /**
@@ -53,9 +59,9 @@ public interface Description {
      */
     static @NonNull Description of(final @NonNull String string) {
         if (requireNonNull(string, "string").isEmpty()) {
-            return DescriptionImpl.EMPTY;
+            return empty();
         } else {
-            return new DescriptionImpl(string);
+            return DescriptionImpl.of(string);
         }
     }
 

--- a/cloud-core/src/main/java/cloud/commandframework/internal/ImmutableBuilder.java
+++ b/cloud-core/src/main/java/cloud/commandframework/internal/ImmutableBuilder.java
@@ -21,47 +21,33 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-package cloud.commandframework;
+package cloud.commandframework.internal;
 
-import java.util.Objects;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import org.apiguardian.api.API;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.immutables.value.Value;
 
+/**
+ * Annotation that generates immutables classes with builders.
+ */
+@Value.Style(
+        typeImmutableEnclosing = "*",
+        typeAbstract = "*",
+        deferCollectionAllocation = true,
+        optionalAcceptNullable = true,
+        jdkOnly = true, // We do not want any runtime dependencies!
+        allParameters = true,
+        headerComments = true,
+        jacksonIntegration = false,
+        builderVisibility = Value.Style.BuilderVisibility.SAME,
+        defaultAsDefault = true
+)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PACKAGE})
+@Retention(RetentionPolicy.SOURCE)
 @API(status = API.Status.INTERNAL, since = "2.0.0")
-final class DescriptionImpl implements Description {
+public @interface ImmutableBuilder {
 
-    static final DescriptionImpl EMPTY = new DescriptionImpl("");
-
-    private final String description;
-
-    DescriptionImpl(final @NonNull String description) {
-        this.description = description;
-    }
-
-    @Override
-    public @NonNull String textDescription() {
-        return this.description;
-    }
-
-    @Override
-    public @NonNull String toString() {
-        return this.description;
-    }
-
-    @Override
-    public boolean equals(final Object object) {
-        if (this == object) {
-            return true;
-        }
-        if (object == null || getClass() != object.getClass()) {
-            return false;
-        }
-        final DescriptionImpl that = (DescriptionImpl) object;
-        return Objects.equals(this.description, that.description);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(this.description);
-    }
 }

--- a/cloud-core/src/main/java/cloud/commandframework/internal/ImmutableImpl.java
+++ b/cloud-core/src/main/java/cloud/commandframework/internal/ImmutableImpl.java
@@ -44,7 +44,8 @@ import org.immutables.value.Value;
         headerComments = true,
         jacksonIntegration = false,
         visibility = Value.Style.ImplementationVisibility.PACKAGE,
-        builderVisibility = Value.Style.BuilderVisibility.PACKAGE
+        builderVisibility = Value.Style.BuilderVisibility.PACKAGE,
+        defaults = @Value.Immutable(builder = false)
 )
 @Target({ElementType.TYPE, ElementType.METHOD, ElementType.PACKAGE})
 @Retention(RetentionPolicy.SOURCE)

--- a/cloud-core/src/main/java/cloud/commandframework/internal/ImmutableImpl.java
+++ b/cloud-core/src/main/java/cloud/commandframework/internal/ImmutableImpl.java
@@ -21,27 +21,34 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-package cloud.commandframework.brigadier.node;
+package cloud.commandframework.internal;
 
-import cloud.commandframework.brigadier.suggestion.SuggestionsType;
-import cloud.commandframework.internal.ImmutableBuilder;
-import com.mojang.brigadier.arguments.ArgumentType;
-import com.mojang.brigadier.suggestion.SuggestionProvider;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import org.apiguardian.api.API;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.immutables.value.Value;
 
-@ImmutableBuilder
-@Value.Immutable
+/**
+ * Annotation that generates immutable classes suffixed with "Impl".
+ */
+@Value.Style(
+        typeImmutable = "*Impl",
+        typeImmutableEnclosing = "*",
+        typeAbstract = "*",
+        deferCollectionAllocation = true,
+        optionalAcceptNullable = true,
+        jdkOnly = true, // We do not want any runtime dependencies!
+        allParameters = true,
+        headerComments = true,
+        jacksonIntegration = false,
+        visibility = Value.Style.ImplementationVisibility.PACKAGE,
+        builderVisibility = Value.Style.BuilderVisibility.PACKAGE
+)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PACKAGE})
+@Retention(RetentionPolicy.SOURCE)
 @API(status = API.Status.INTERNAL, since = "2.0.0")
-interface ArgumentMapping<S> {
+public @interface ImmutableImpl {
 
-    @NonNull ArgumentType<?> argumentType();
-
-    default @NonNull SuggestionsType suggestionsType() {
-        return SuggestionsType.BRIGADIER_SUGGESTIONS;
-    }
-
-    @Nullable SuggestionProvider<S> suggestionProvider();
 }

--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/node/LiteralBrigadierNodeFactory.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/node/LiteralBrigadierNodeFactory.java
@@ -287,15 +287,15 @@ public final class LiteralBrigadierNodeFactory<C, S> implements BrigadierNodeFac
 
         final SuggestionProvider<S> suggestionProvider = mapping.makeSuggestionProvider(argumentParser);
         if (suggestionProvider == BrigadierMapping.delegateSuggestions()) {
-            return new ArgumentMapping<>(
-                    (ArgumentType) ((Function) mapping.mapper()).apply(argumentParser),
-                    SuggestionsType.CLOUD_SUGGESTIONS
-            );
+            return ImmutableArgumentMapping.<S>builder()
+                    .argumentType((ArgumentType) ((Function) mapping.mapper()).apply(argumentParser))
+                    .suggestionsType(SuggestionsType.CLOUD_SUGGESTIONS)
+                    .build();
         }
-        return new ArgumentMapping<>(
-                (ArgumentType) ((Function) mapping.mapper()).apply(argumentParser),
-                suggestionProvider
-        );
+        return ImmutableArgumentMapping.<S>builder()
+                .argumentType((ArgumentType) ((Function) mapping.mapper()).apply(argumentParser))
+                .suggestionProvider(suggestionProvider)
+                .build();
     }
 
     /**
@@ -311,9 +311,14 @@ public final class LiteralBrigadierNodeFactory<C, S> implements BrigadierNodeFac
         if (argumentTypeSupplier != null) {
             final ArgumentType<?> argumentType = argumentTypeSupplier.create();
             if (argumentType != null) {
-                return new ArgumentMapping<>(argumentType);
+                return ImmutableArgumentMapping.<S>builder()
+                        .argumentType(argumentType)
+                        .build();
             }
         }
-        return new ArgumentMapping<>(StringArgumentType.word(), SuggestionsType.CLOUD_SUGGESTIONS);
+        return ImmutableArgumentMapping.<S>builder()
+                .argumentType(StringArgumentType.word())
+                .suggestionsType(SuggestionsType.CLOUD_SUGGESTIONS)
+                .build();
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ errorprone = "2.16"
 geantyref = "1.3.14"
 jmh = "1.36"
 apiguardian = "1.1.2"
+immutables = "2.9.2"
 
 # integration
 guice = "4.2.3"
@@ -72,6 +73,7 @@ geantyref = { group = "io.leangen.geantyref", name = "geantyref", version.ref = 
 jmhCore = { group = "org.openjdk.jmh", name = "jmh-core", version.ref = "jmh" }
 jmhGeneratorAnnprocess = { group = "org.openjdk.jmh", name = "jmh-generator-annprocess", version.ref = "jmh" }
 apiguardian = { group = "org.apiguardian", name = "apiguardian-api", version.ref = "apiguardian" }
+immutables = { group = "org.immutables", name = "value", version.ref = "immutables" }
 
 # integration
 guice = { group = "com.google.inject", name = "guice", version.ref = "guice" }


### PR DESCRIPTION
this adds immutables and two custom styles:

- `ImmutableImpl`: Creates a package-private immutable implementation of the interface
- `ImmutableBuilder`: Creates a public immutable implementation together with a public builder

I switched some classes over to immutables to both sanity-check the setup and get started on some code cleanup :)

We need to add two annotations to each class we want to generate code for. The alternative is to have a separate module with the style annotations and a META-INF entry that we depend on, but that's gross.