### PR TITLE
feat(annotations): add `@Default`

### DIFF
--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/Argument.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/Argument.java
@@ -74,13 +74,6 @@ public @interface Argument {
     @NonNull String suggestions() default "";
 
     /**
-     * Get the default value
-     *
-     * @return Default value
-     */
-    @NonNull String defaultValue() default "";
-
-    /**
      * The argument description
      *
      * @return Argument description

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/ArgumentExtractorImpl.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/ArgumentExtractorImpl.java
@@ -72,11 +72,16 @@ class ArgumentExtractorImpl implements ArgumentExtractor {
                 name = argument.value();
             }
 
+            String defaultValue = null;
+            if (parameter.isAnnotationPresent(Default.class)) {
+                defaultValue = parameter.getAnnotation(Default.class).value();
+            }
+
             final ArgumentDescriptor argumentDescriptor = ArgumentDescriptor.builder()
                     .parameter(parameter)
                     .name(name)
                     .parserName(nullIfEmpty(argument.parserName()))
-                    .defaultValue(nullIfEmpty(argument.defaultValue()))
+                    .defaultValue(defaultValue)
                     .description(this.descriptionMapper.apply(argument))
                     .suggestions(nullIfEmpty(argument.suggestions()))
                     .build();

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/Default.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/Default.java
@@ -1,0 +1,52 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Used to give an optional command component a
+ * {@link cloud.commandframework.arguments.DefaultValue#parsed(String) parsed default value}.
+ *
+ * @since 2.0.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@API(status = API.Status.STABLE, since = "2.0.0")
+public @interface Default {
+
+    /**
+     * Returns the default value.
+     * <p>
+     * This value will be parsed when the command is being parsed in the case that the optional parameter has been omitted.
+     *
+     * @return the default value
+     */
+    @NonNull String value();
+}

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
@@ -227,7 +227,7 @@ class AnnotationParserTest {
     public void testCommand(
             final TestCommandSender sender,
             @Argument("int") @Range(max = "100") final int argument,
-            @Argument(value = "string", defaultValue = "potato", parserName = "potato") final String string
+            @Argument(value = "string", parserName = "potato") @Default("potato") final String string
     ) {
         System.out.printf("Received int: %d and string '%s'\n", argument, string);
     }

--- a/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/annotations/feature/StringArrayExample.java
+++ b/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/annotations/feature/StringArrayExample.java
@@ -26,6 +26,7 @@ package cloud.commandframework.examples.bukkit.annotations.feature;
 import cloud.commandframework.annotations.AnnotationParser;
 import cloud.commandframework.annotations.Argument;
 import cloud.commandframework.annotations.CommandMethod;
+import cloud.commandframework.annotations.Default;
 import cloud.commandframework.examples.bukkit.ExamplePlugin;
 import cloud.commandframework.examples.bukkit.annotations.AnnotationFeature;
 import org.apache.commons.lang.StringUtils;
@@ -49,7 +50,7 @@ public final class StringArrayExample implements AnnotationFeature {
     @CommandMethod("annotations arraycommand [args]")
     public void arrayCommand(
             final @NonNull CommandSender sender,
-            @Argument(value = "args", defaultValue = "") final @NonNull String[] args
+            @Argument(value = "args") @Default("") final @NonNull String[] args
     ) {
         sender.sendMessage("You wrote: " + StringUtils.join(args, " "));
     }


### PR DESCRIPTION
We're making the annotations more flexible, and #551 makes the presence of `@Argument` optional. It would be convenient to be able to provide default values even when the `@Argument` annotation is not present.