### PR TITLE
chore(core): extract state handling

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/state/RegistrationState.java
+++ b/cloud-core/src/main/java/cloud/commandframework/state/RegistrationState.java
@@ -1,0 +1,56 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.state;
+
+import org.apiguardian.api.API;
+
+/**
+ * The point in the registration lifecycle for this commands manager
+ *
+ * @since 2.0.0
+ */
+@API(status = API.Status.STABLE, since = "2.0.0")
+public enum RegistrationState implements State {
+
+    /**
+     * The point when no commands have been registered yet.
+     * <p>
+     * At this point, all configuration options can be changed.
+     */
+    BEFORE_REGISTRATION,
+    /**
+     * When at least one command has been registered, and more commands have been registered.
+     * <p>
+     * In this state, some options that affect how commands are registered with the platform are frozen. Some platforms
+     * will remain in this state for their lifetime.
+     */
+    REGISTERING,
+    /**
+     * Once registration has been completed.
+     * <p>
+     * At this point, the command manager is effectively immutable. On platforms where command registration happens via
+     * callback, this state is achieved the first time the manager's callback is executed for registration.
+     */
+    AFTER_REGISTRATION
+}

--- a/cloud-core/src/main/java/cloud/commandframework/state/State.java
+++ b/cloud-core/src/main/java/cloud/commandframework/state/State.java
@@ -1,0 +1,35 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.state;
+
+import org.apiguardian.api.API;
+
+/**
+ * Something that represents a state in a state machine.
+ *
+ * @since 2.0.0
+ */
+@API(status = API.Status.STABLE, since = "2.0.0")
+public interface State {
+}

--- a/cloud-core/src/main/java/cloud/commandframework/state/Stateful.java
+++ b/cloud-core/src/main/java/cloud/commandframework/state/Stateful.java
@@ -1,0 +1,92 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.state;
+
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * A simple state machine.
+ *
+ * @param <S> the state type
+ * @since 2.0.0
+ */
+@API(status = API.Status.STABLE, since = "2.0.0")
+public interface Stateful<S extends State> {
+
+    /**
+     * Returns the current state.
+     *
+     * @return the current state
+     */
+    @NonNull S state();
+
+    /**
+     * Transitions from the {@code in} state to the {@code out} state, unless the current {@link #state()}
+     * is identical to the {@code out} state.
+     *
+     * @param in  the starting state
+     * @param out the ending state
+     * @return {@code true} if the state transition was successful, or the current state is identical to the {@code out} state
+     */
+    boolean transitionIfPossible(@NonNull S in, @NonNull S out);
+
+    /**
+     * Requires that the current {@link #state()} is equal to the {@code expected} state, and fails
+     * exceptionally if the states are different.
+     *
+     * @param expected the expected state
+     * @throws IllegalStateException if the current {@link #state()} is different from the {@code expected} state
+     */
+    default void requireState(final @NonNull S expected) {
+        if (this.state().equals(expected)) {
+            return;
+        }
+        throw new IllegalStateException(String.format(
+                "This operation requires the command manager to be in state '%s', but it is in '%s'",
+                expected,
+                this.state()
+        ));
+    }
+
+    /**
+     * Transitions from the {@code in} state to the {@code out} state, unless the current {@link #state()}
+     * is identical to the {@code out} state.
+     *
+     * @param in  the starting state
+     * @param out the ending state
+     * @throws IllegalStateException if state transition is not possible
+     */
+    default void transitionOrThrow(final @NonNull S in, final @NonNull S out) {
+        if (this.transitionIfPossible(in, out)) {
+            return;
+        }
+        throw new IllegalStateException(String.format(
+                "The current state is '%s' but we expected a state of '%s' or '%s'",
+                this.state(),
+                in,
+                out
+        ));
+    }
+}

--- a/cloud-core/src/main/java/cloud/commandframework/state/package-info.java
+++ b/cloud-core/src/main/java/cloud/commandframework/state/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Utilities for creating a state machine and enforcing safe state transitions.
+ */
+package cloud.commandframework.state;

--- a/cloud-core/src/test/java/cloud/commandframework/CommandRegistrationStateTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandRegistrationStateTest.java
@@ -24,6 +24,7 @@
 package cloud.commandframework;
 
 import cloud.commandframework.internal.CommandRegistrationHandler;
+import cloud.commandframework.state.RegistrationState;
 import org.junit.jupiter.api.Test;
 
 import static cloud.commandframework.util.TestUtils.createManager;
@@ -35,7 +36,7 @@ public class CommandRegistrationStateTest {
     @Test
     void testInitialState() {
         final CommandManager<TestCommandSender> manager = createManager();
-        assertEquals(CommandManager.RegistrationState.BEFORE_REGISTRATION, manager.registrationState());
+        assertEquals(RegistrationState.BEFORE_REGISTRATION, manager.state());
     }
 
     @Test
@@ -45,7 +46,7 @@ public class CommandRegistrationStateTest {
         manager.command(manager.commandBuilder("test").handler(ctx -> {
         }));
 
-        assertEquals(CommandManager.RegistrationState.REGISTERING, manager.registrationState());
+        assertEquals(RegistrationState.REGISTERING, manager.state());
     }
 
     @Test
@@ -57,7 +58,7 @@ public class CommandRegistrationStateTest {
         manager.command(manager.commandBuilder("test2").handler(ctx -> {
         }));
 
-        assertEquals(CommandManager.RegistrationState.REGISTERING, manager.registrationState());
+        assertEquals(RegistrationState.REGISTERING, manager.state());
     }
 
     @Test
@@ -78,8 +79,8 @@ public class CommandRegistrationStateTest {
         }));
 
         manager.transitionOrThrow(
-                CommandManager.RegistrationState.REGISTERING,
-                CommandManager.RegistrationState.AFTER_REGISTRATION
+                RegistrationState.REGISTERING,
+                RegistrationState.AFTER_REGISTRATION
         );
         assertThrows(IllegalStateException.class, () -> manager.command(manager.commandBuilder("test2").handler(ctx -> {
         })));
@@ -92,8 +93,8 @@ public class CommandRegistrationStateTest {
         manager.command(manager.commandBuilder("test").handler(ctx -> {
         }));
         manager.transitionOrThrow(
-                CommandManager.RegistrationState.REGISTERING,
-                CommandManager.RegistrationState.AFTER_REGISTRATION
+                RegistrationState.REGISTERING,
+                RegistrationState.AFTER_REGISTRATION
         );
         manager.command(manager.commandBuilder("unsafe").handler(ctx -> {
         }));

--- a/cloud-core/src/test/java/cloud/commandframework/state/StatefulTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/state/StatefulTest.java
@@ -1,0 +1,108 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.state;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class StatefulTest {
+
+    private Stateful<TestState> stateful;
+
+    @BeforeEach
+    void setup() {
+        this.stateful = new TestStateful();
+    }
+
+    @Test
+    void RequireState_ExpectedState_Success() {
+        // Act & Assert
+        this.stateful.requireState(TestState.A);
+    }
+
+    @Test
+    void RequireState_UnexpectedState_ThrowsException() {
+        // Act & Assert
+        assertThrows(
+                IllegalStateException.class,
+                () -> this.stateful.requireState(TestState.B)
+        );
+    }
+
+    @Test
+    void TransitionOrThrow_ExpectedInState_Success() {
+        // Act
+        this.stateful.transitionOrThrow(TestState.A, TestState.B);
+
+        // Assert
+        assertThat(this.stateful.state()).isEqualTo(TestState.B);
+    }
+
+    @Test
+    void TransitionOrThrow_ExpectedOutState_Success() {
+        // Act
+        this.stateful.transitionOrThrow(TestState.C, TestState.A);
+
+        // Assert
+        assertThat(this.stateful.state()).isEqualTo(TestState.A);
+    }
+
+    @Test
+    void TransitionOrThrow_UnexpectedState_ThrowsException() {
+        // Act & Assert
+        assertThrows(
+                IllegalStateException.class,
+                () -> this.stateful.transitionOrThrow(TestState.B, TestState.C)
+        );
+    }
+
+
+    static final class TestStateful implements Stateful<TestState> {
+
+        private TestState state = TestState.A;
+
+        @Override
+        public @NonNull TestState state() {
+            return this.state;
+        }
+
+        @Override
+        public boolean transitionIfPossible(final @NonNull TestState in, final @NonNull TestState out) {
+            if (this.state == in) {
+                this.state = out;
+            }
+            return this.state == out;
+        }
+    }
+
+    enum TestState implements State {
+        A,
+        B,
+        C
+    }
+}

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandManager.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandManager.java
@@ -59,6 +59,7 @@ import cloud.commandframework.bukkit.parsers.selector.SingleEntitySelectorParser
 import cloud.commandframework.bukkit.parsers.selector.SinglePlayerSelectorParser;
 import cloud.commandframework.execution.CommandExecutionCoordinator;
 import cloud.commandframework.execution.FilteringCommandSuggestionProcessor;
+import cloud.commandframework.state.RegistrationState;
 import cloud.commandframework.tasks.TaskFactory;
 import cloud.commandframework.tasks.TaskRecipe;
 import io.leangen.geantyref.TypeToken;

--- a/cloud-minecraft/cloud-cloudburst/src/main/java/cloud/commandframework/cloudburst/CloudburstCommandManager.java
+++ b/cloud-minecraft/cloud-cloudburst/src/main/java/cloud/commandframework/cloudburst/CloudburstCommandManager.java
@@ -27,6 +27,7 @@ import cloud.commandframework.CommandManager;
 import cloud.commandframework.CommandTree;
 import cloud.commandframework.execution.CommandExecutionCoordinator;
 import cloud.commandframework.execution.FilteringCommandSuggestionProcessor;
+import cloud.commandframework.state.RegistrationState;
 import java.util.function.Function;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudburstmc.server.command.CommandSender;
@@ -92,7 +93,7 @@ public class CloudburstCommandManager<C> extends CommandManager<C> {
 
     @Override
     public final boolean isCommandRegistrationAllowed() {
-        return this.registrationState() != RegistrationState.AFTER_REGISTRATION;
+        return this.state() != RegistrationState.AFTER_REGISTRATION;
     }
 
     final @NonNull Function<@NonNull CommandSender, @NonNull C> getCommandSenderMapper() {

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperCommandManager.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperCommandManager.java
@@ -31,6 +31,7 @@ import cloud.commandframework.bukkit.CloudBukkitCapabilities;
 import cloud.commandframework.execution.CommandExecutionCoordinator;
 import cloud.commandframework.paper.suggestions.SuggestionListener;
 import cloud.commandframework.paper.suggestions.SuggestionListenerFactory;
+import cloud.commandframework.state.RegistrationState;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import org.bukkit.Bukkit;


### PR DESCRIPTION
`CommandManager` is becoming very bloated, and it's becoming hard to both navigate and test.

I'd like to see as much logic as possible being extracted out of the implementation into smaller more maintainable interfaces/classes, with individual test classes (We've already started doing this with the extraction of error handling into the controller, etc). 