### PR TITLE
chore(core): extract settings from `CommandManager`

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
@@ -65,12 +65,13 @@ import cloud.commandframework.permission.Permission;
 import cloud.commandframework.permission.PredicatePermission;
 import cloud.commandframework.services.ServicePipeline;
 import cloud.commandframework.services.State;
+import cloud.commandframework.setting.Configurable;
+import cloud.commandframework.setting.ManagerSetting;
 import cloud.commandframework.state.RegistrationState;
 import cloud.commandframework.state.Stateful;
 import io.leangen.geantyref.TypeToken;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -98,9 +99,9 @@ import org.checkerframework.common.returnsreceiver.qual.This;
 public abstract class CommandManager<C> implements Stateful<RegistrationState> {
 
     private final Map<Class<? extends Exception>, BiConsumer<C, ? extends Exception>> exceptionHandlers = new HashMap<>();
-    private final EnumSet<ManagerSettings> managerSettings = EnumSet.of(
-            ManagerSettings.ENFORCE_INTERMEDIARY_PERMISSIONS);
 
+    private final Configurable<ManagerSetting> settings = Configurable.enumConfigurable(ManagerSetting.class)
+            .set(ManagerSetting.ENFORCE_INTERMEDIARY_PERMISSIONS, true);
     private final CommandContextFactory<C> commandContextFactory = new StandardCommandContextFactory<>(this);
     private final ServicePipeline servicePipeline = ServicePipeline.builder().build();
     private final ParserRegistry<C> parserRegistry = new StandardParserRegistry<>();
@@ -1049,34 +1050,14 @@ public abstract class CommandManager<C> implements Stateful<RegistrationState> {
     }
 
     /**
-     * Get a command manager setting
+     * Returns a {@link Configurable} instance that can be used to modify the settings for this command manager instance.
      *
-     * @param setting Setting
-     * @return {@code true} if the setting is activated or {@code false} if it's not
-     * @see #setSetting(ManagerSettings, boolean) Update a manager setting
+     * @return settings instance
+     * @since 2.0.0
      */
-    public boolean getSetting(final @NonNull ManagerSettings setting) {
-        return this.managerSettings.contains(setting);
-    }
-
-    /**
-     * Update a command manager setting
-     *
-     * @param setting Setting to update
-     * @param value   Value. In most cases {@code true} will enable a feature, whereas {@code false} will disable it.
-     *                The value passed to the method will be reflected in {@link #getSetting(ManagerSettings)}
-     * @see #getSetting(ManagerSettings) Get a manager setting
-     */
-    @SuppressWarnings("unused")
-    public void setSetting(
-            final @NonNull ManagerSettings setting,
-            final boolean value
-    ) {
-        if (value) {
-            this.managerSettings.add(setting);
-        } else {
-            this.managerSettings.remove(setting);
-        }
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    public @NonNull Configurable<ManagerSetting> settings() {
+        return this.settings;
     }
 
     /**
@@ -1120,66 +1101,14 @@ public abstract class CommandManager<C> implements Stateful<RegistrationState> {
      * Check if command registration is allowed.
      * <p>
      * On platforms where unsafe registration is possible, this can be overridden by enabling the
-     * {@link ManagerSettings#ALLOW_UNSAFE_REGISTRATION} setting.
+     * {@link ManagerSetting#ALLOW_UNSAFE_REGISTRATION} setting.
      *
      * @return {@code true} if the registration is allowed, else {@code false}
      * @since 1.2.0
      */
     @API(status = API.Status.STABLE, since = "1.2.0")
     public boolean isCommandRegistrationAllowed() {
-        return this.getSetting(ManagerSettings.ALLOW_UNSAFE_REGISTRATION) || this.state.get() != RegistrationState.AFTER_REGISTRATION;
-    }
-
-
-    /**
-     * Configurable command related settings
-     *
-     * @see CommandManager#setSetting(ManagerSettings, boolean) Set a manager setting
-     * @see CommandManager#getSetting(ManagerSettings) Get a manager setting
-     */
-    @API(status = API.Status.STABLE)
-    public enum ManagerSettings {
-        /**
-         * Do not create a compound permission and do not look greedily
-         * for child permission values, if a preceding command in the tree path
-         * has a command handler attached
-         */
-        ENFORCE_INTERMEDIARY_PERMISSIONS,
-
-        /**
-         * Force sending of an empty suggestion (i.e. a singleton list containing an empty string)
-         * when no suggestions are present
-         */
-        FORCE_SUGGESTION,
-
-        /**
-         * Allow registering commands even when doing so has the potential to produce inconsistent results.
-         * <p>
-         * For example, if a platform serializes the command tree and sends it to clients,
-         * this will allow modifying the command tree after it has been sent, as long as these modifications are not blocked by
-         * the underlying platform
-         *
-         * @since 1.2.0
-         */
-        @API(status = API.Status.STABLE, since = "1.2.0")
-        ALLOW_UNSAFE_REGISTRATION,
-
-        /**
-         * Enables overriding of existing commands on supported platforms.
-         *
-         * @since 1.2.0
-         */
-        @API(status = API.Status.STABLE, since = "1.2.0")
-        OVERRIDE_EXISTING_COMMANDS,
-
-        /**
-         * Allows parsing flags at any position after the last literal by appending flag argument nodes between each command node.
-         * It can have some conflicts when integrating with other command systems like Brigadier,
-         * and code inspecting the command tree may need to be adjusted.
-         *
-         * @since 1.8.0
-         */
-        @API(status = API.Status.EXPERIMENTAL, since = "1.8.0")
-        LIBERAL_FLAG_PARSING
+        return this.settings().get(ManagerSetting.ALLOW_UNSAFE_REGISTRATION)
+                || this.state.get() != RegistrationState.AFTER_REGISTRATION;
     }
 }

--- a/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
@@ -44,6 +44,7 @@ import cloud.commandframework.internal.CommandNode;
 import cloud.commandframework.internal.SuggestionContext;
 import cloud.commandframework.permission.CommandPermission;
 import cloud.commandframework.permission.OrPermission;
+import cloud.commandframework.setting.ManagerSetting;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1031,7 +1032,7 @@ public final class CommandTree<C> {
      */
     private int flagStartIndex(final @NonNull List<CommandComponent<C>> components) {
         // Append flags after the last static argument
-        if (this.commandManager.getSetting(CommandManager.ManagerSettings.LIBERAL_FLAG_PARSING)) {
+        if (this.commandManager.settings().get(ManagerSetting.LIBERAL_FLAG_PARSING)) {
             for (int i = components.size() - 1; i >= 0; i--) {
                 if (components.get(i).type() == CommandComponent.ComponentType.LITERAL) {
                     return i;
@@ -1139,9 +1140,7 @@ public final class CommandTree<C> {
             /* Now also check if there's a command handler attached to an upper level node */
             if (commandArgumentNode.component() != null && commandArgumentNode.component().owningCommand() != null) {
                 final Command<C> command = commandArgumentNode.component().owningCommand();
-                if (this
-                        .commandManager()
-                        .getSetting(CommandManager.ManagerSettings.ENFORCE_INTERMEDIARY_PERMISSIONS)) {
+                if (this.commandManager().settings().get(ManagerSetting.ENFORCE_INTERMEDIARY_PERMISSIONS)) {
                     permission = command.commandPermission();
                 } else {
                     permission = OrPermission.of(Arrays.asList(permission, command.commandPermission()));

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/DelegatingSuggestionFactory.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/DelegatingSuggestionFactory.java
@@ -28,6 +28,7 @@ import cloud.commandframework.CommandTree;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.context.CommandInput;
 import cloud.commandframework.services.State;
+import cloud.commandframework.setting.ManagerSetting;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -89,14 +90,14 @@ final class DelegatingSuggestionFactory<C, S extends Suggestion> implements Sugg
         context.store("__raw_input__", commandInput.copy());
 
         if (this.commandManager.preprocessContext(context, commandInput) != State.ACCEPTED) {
-            if (this.commandManager.getSetting(CommandManager.ManagerSettings.FORCE_SUGGESTION)) {
+            if (this.commandManager.settings().get(ManagerSetting.FORCE_SUGGESTION)) {
                 return CompletableFuture.completedFuture(SINGLE_EMPTY_SUGGESTION);
             }
             return CompletableFuture.completedFuture(Collections.emptyList());
         }
 
         return this.commandTree.getSuggestions(context, commandInput).thenApply(suggestions -> {
-            if (this.commandManager.getSetting(CommandManager.ManagerSettings.FORCE_SUGGESTION) && suggestions.isEmpty()) {
+            if (this.commandManager.settings().get(ManagerSetting.FORCE_SUGGESTION) && suggestions.isEmpty()) {
                 return SINGLE_EMPTY_SUGGESTION;
             }
             return suggestions;

--- a/cloud-core/src/main/java/cloud/commandframework/setting/Configurable.java
+++ b/cloud-core/src/main/java/cloud/commandframework/setting/Configurable.java
@@ -1,0 +1,66 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.setting;
+
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.common.returnsreceiver.qual.This;
+
+/**
+ * Something with configurable {@link Setting settings}.
+ *
+ * @param <S> setting type
+ * @since 2.0.0
+ */
+@API(status = API.Status.STABLE, since = "2.0.0")
+public interface Configurable<S extends Setting> {
+
+    /**
+     * Returns a new {@link Configurable} instance for the given {@link E enum type}.
+     *
+     * @param <E>       enum type
+     * @param enumClass enum class
+     * @return the configurable
+     */
+    static <E extends Enum<E> & Setting> @NonNull Configurable<E> enumConfigurable(final @NonNull Class<E> enumClass) {
+        return new EnumConfigurable<>(enumClass);
+    }
+
+    /**
+     * Updates the {@code value} of the given {@code setting}.
+     *
+     * @param setting setting to update
+     * @param value   new value
+     * @return {@code this}
+     */
+    @This @NonNull Configurable<S> set(@NonNull S setting, boolean value);
+
+    /**
+     * Returns the value of the given {@code setting}
+     *
+     * @param setting setting to retrieve the value for
+     * @return the value
+     */
+    boolean get(@NonNull S setting);
+}

--- a/cloud-core/src/main/java/cloud/commandframework/setting/EnumConfigurable.java
+++ b/cloud-core/src/main/java/cloud/commandframework/setting/EnumConfigurable.java
@@ -1,0 +1,56 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.setting;
+
+import java.util.EnumSet;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.common.returnsreceiver.qual.This;
+
+final class EnumConfigurable<S extends Enum<S> & Setting> implements Configurable<S> {
+
+    private final EnumSet<S> settings;
+
+    EnumConfigurable(final @NonNull Class<S> settingClass) {
+        this.settings = EnumSet.noneOf(settingClass);
+    }
+
+    EnumConfigurable(final @NonNull S defaultSetting) {
+        this.settings = EnumSet.of(defaultSetting);
+    }
+
+    @Override
+    public @This @NonNull EnumConfigurable<S> set(final @NonNull S setting, final boolean value) {
+        if (value) {
+            this.settings.add(setting);
+        } else {
+            this.settings.remove(setting);
+        }
+        return this;
+    }
+
+    @Override
+    public boolean get(final @NonNull S setting) {
+        return this.settings.contains(setting);
+    }
+}

--- a/cloud-core/src/main/java/cloud/commandframework/setting/ManagerSetting.java
+++ b/cloud-core/src/main/java/cloud/commandframework/setting/ManagerSetting.java
@@ -1,0 +1,79 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.setting;
+
+import cloud.commandframework.CommandManager;
+import org.apiguardian.api.API;
+
+/**
+ * Configurable command related settings
+ *
+ * @see CommandManager#settings() to access the settings
+ * @since 2.0.0
+ */
+@API(status = API.Status.STABLE, since = "2.0.0")
+public enum ManagerSetting implements Setting {
+    /**
+     * Do not create a compound permission and do not look greedily
+     * for child permission values, if a preceding command in the tree path
+     * has a command handler attached
+     */
+    ENFORCE_INTERMEDIARY_PERMISSIONS,
+
+    /**
+     * Force sending of an empty suggestion (i.e. a singleton list containing an empty string)
+     * when no suggestions are present
+     */
+    FORCE_SUGGESTION,
+
+    /**
+     * Allow registering commands even when doing so has the potential to produce inconsistent results.
+     * <p>
+     * For example, if a platform serializes the command tree and sends it to clients,
+     * this will allow modifying the command tree after it has been sent, as long as these modifications are not blocked by
+     * the underlying platform
+     *
+     * @since 1.2.0
+     */
+    @API(status = API.Status.STABLE, since = "1.2.0")
+    ALLOW_UNSAFE_REGISTRATION,
+
+    /**
+     * Enables overriding of existing commands on supported platforms.
+     *
+     * @since 1.2.0
+     */
+    @API(status = API.Status.STABLE, since = "1.2.0")
+    OVERRIDE_EXISTING_COMMANDS,
+
+    /**
+     * Allows parsing flags at any position after the last literal by appending flag argument nodes between each command node.
+     * It can have some conflicts when integrating with other command systems like Brigadier,
+     * and code inspecting the command tree may need to be adjusted.
+     *
+     * @since 1.8.0
+     */
+    @API(status = API.Status.EXPERIMENTAL, since = "1.8.0")
+    LIBERAL_FLAG_PARSING
+}

--- a/cloud-core/src/main/java/cloud/commandframework/setting/Setting.java
+++ b/cloud-core/src/main/java/cloud/commandframework/setting/Setting.java
@@ -1,0 +1,36 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.setting;
+
+import org.apiguardian.api.API;
+
+/**
+ * Something that represents a setting that can be configured.
+ *
+ * @since 2.0.0
+ */
+@API(status = API.Status.STABLE, since = "2.0.0")
+public interface Setting {
+
+}

--- a/cloud-core/src/main/java/cloud/commandframework/setting/package-info.java
+++ b/cloud-core/src/main/java/cloud/commandframework/setting/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Utilities for settings.
+ */
+package cloud.commandframework.setting;

--- a/cloud-core/src/test/java/cloud/commandframework/CommandRegistrationStateTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandRegistrationStateTest.java
@@ -24,6 +24,7 @@
 package cloud.commandframework;
 
 import cloud.commandframework.internal.CommandRegistrationHandler;
+import cloud.commandframework.setting.ManagerSetting;
 import cloud.commandframework.state.RegistrationState;
 import org.junit.jupiter.api.Test;
 
@@ -89,7 +90,7 @@ public class CommandRegistrationStateTest {
     @Test
     void testAllowUnsafeRegistration() {
         final CommandManager<TestCommandSender> manager = createManager();
-        manager.setSetting(CommandManager.ManagerSettings.ALLOW_UNSAFE_REGISTRATION, true);
+        manager.settings().set(ManagerSetting.ALLOW_UNSAFE_REGISTRATION, true);
         manager.command(manager.commandBuilder("test").handler(ctx -> {
         }));
         manager.transitionOrThrow(

--- a/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
@@ -30,6 +30,7 @@ import cloud.commandframework.arguments.standard.StringParser;
 import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.execution.FilteringCommandSuggestionProcessor;
+import cloud.commandframework.setting.ManagerSetting;
 import cloud.commandframework.types.tuples.Pair;
 import cloud.commandframework.types.tuples.Triplet;
 import java.util.Collections;
@@ -700,7 +701,7 @@ class CommandSuggestionsTest {
     void testFlagYieldingGreedyStringWithLiberalFlagArgument() {
         // Arrange
         this.manager = createManager();
-        this.manager.setSetting(CommandManager.ManagerSettings.LIBERAL_FLAG_PARSING, true);
+        this.manager.settings().set(ManagerSetting.LIBERAL_FLAG_PARSING, true);
         this.manager.command(
                 this.manager.commandBuilder("command")
                         .required("string", greedyFlagYieldingStringParser(),
@@ -730,7 +731,7 @@ class CommandSuggestionsTest {
     void testFlagYieldingStringArrayWithLiberalFlagArgument() {
         // Arrange
         this.manager = createManager();
-        this.manager.setSetting(CommandManager.ManagerSettings.LIBERAL_FLAG_PARSING, true);
+        this.manager.settings().set(ManagerSetting.LIBERAL_FLAG_PARSING, true);
         this.manager.command(
                 this.manager.commandBuilder("command")
                         .required("array", flagYieldingStringArrayParser())
@@ -760,7 +761,7 @@ class CommandSuggestionsTest {
     void testTextFlagCompletion(final @NonNull String input, final @NonNull List<@NonNull Suggestion> expectedSuggestions) {
         // Arrange
         this.manager = createManager();
-        this.manager.setSetting(CommandManager.ManagerSettings.LIBERAL_FLAG_PARSING, true);
+        this.manager.settings().set(ManagerSetting.LIBERAL_FLAG_PARSING, true);
         this.manager.command(
                 this.manager.commandBuilder("command")
                         .flag(manager.flagBuilder("flag").withAliases("f").withComponent(enumParser(TestEnum.class)).build())

--- a/cloud-core/src/test/java/cloud/commandframework/ParserRegistryTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/ParserRegistryTest.java
@@ -30,6 +30,7 @@ import cloud.commandframework.arguments.parser.ParserRegistry;
 import cloud.commandframework.arguments.parser.StandardParameters;
 import cloud.commandframework.arguments.parser.StandardParserRegistry;
 import cloud.commandframework.arguments.standard.IntegerParser;
+import cloud.commandframework.setting.ManagerSetting;
 import io.leangen.geantyref.TypeToken;
 import java.lang.annotation.Annotation;
 import java.util.Collections;
@@ -136,7 +137,7 @@ public class ParserRegistryTest {
 
         // When
         final Optional<?> parserOptional = parserRegistry.createParser(
-                TypeToken.get(CommandManager.ManagerSettings.class),
+                TypeToken.get(ManagerSetting.class),
                 ParserParameters.empty()
         );
 

--- a/cloud-core/src/test/java/cloud/commandframework/feature/ArbitraryPositionFlagTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/feature/ArbitraryPositionFlagTest.java
@@ -28,6 +28,7 @@ import cloud.commandframework.TestCommandSender;
 import cloud.commandframework.arguments.flags.CommandFlagParser;
 import cloud.commandframework.exceptions.ArgumentParseException;
 import cloud.commandframework.execution.CommandResult;
+import cloud.commandframework.setting.ManagerSetting;
 import com.google.common.truth.ThrowableSubject;
 import java.util.Arrays;
 import java.util.List;
@@ -48,7 +49,7 @@ class ArbitraryPositionFlagTest {
     @BeforeEach
     void setup() {
         this.commandManager = createManager();
-        this.commandManager.setSetting(CommandManager.ManagerSettings.LIBERAL_FLAG_PARSING, true);
+        this.commandManager.settings().set(ManagerSetting.LIBERAL_FLAG_PARSING, true);
 
         this.commandManager.command(
                 this.commandManager.commandBuilder("test")

--- a/cloud-core/src/test/java/cloud/commandframework/settings/EnumConfigurableTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/settings/EnumConfigurableTest.java
@@ -1,0 +1,84 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.settings;
+
+import cloud.commandframework.setting.Configurable;
+import cloud.commandframework.setting.Setting;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+class EnumConfigurableTest {
+
+    private Configurable<TestSetting> configurable;
+
+    @BeforeEach
+    void setup() {
+        this.configurable = Configurable.enumConfigurable(TestSetting.class);
+    }
+
+    @Test
+    void testGetNonExisting() {
+        // Arrange
+        final TestSetting setting = TestSetting.FOO;
+
+        // Act
+        final boolean result = this.configurable.get(setting);
+
+        // Assert
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void testSetTrue() {
+        // Arrange
+        final TestSetting setting = TestSetting.FOO;
+
+        // Act
+        this.configurable.set(setting, true);
+
+        // Assert
+        assertThat(this.configurable.get(setting)).isTrue();
+    }
+
+    @Test
+    void testSetFalse() {
+        // Arrange
+        final TestSetting setting = TestSetting.FOO;
+        this.configurable.set(setting, true);
+
+        // Act
+        this.configurable.set(setting, false);
+
+        // Assert
+        assertThat(this.configurable.get(setting)).isFalse();
+    }
+
+
+    enum TestSetting implements Setting {
+        FOO,
+        BAR
+    }
+}

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitPluginRegistrationHandler.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitPluginRegistrationHandler.java
@@ -25,8 +25,8 @@ package cloud.commandframework.bukkit;
 
 import cloud.commandframework.Command;
 import cloud.commandframework.CommandComponent;
-import cloud.commandframework.CommandManager;
 import cloud.commandframework.internal.CommandRegistrationHandler;
+import cloud.commandframework.setting.ManagerSetting;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -92,7 +92,7 @@ public class BukkitPluginRegistrationHandler<C> implements CommandRegistrationHa
                 this.bukkitCommandManager
         );
 
-        if (this.bukkitCommandManager.getSetting(CommandManager.ManagerSettings.OVERRIDE_EXISTING_COMMANDS)) {
+        if (this.bukkitCommandManager.settings().get(ManagerSetting.OVERRIDE_EXISTING_COMMANDS)) {
             this.bukkitCommands.remove(label);
             aliases.forEach(this.bukkitCommands::remove);
         }


### PR DESCRIPTION
This is done for the same reason as extracting the states out of the command manager.

CommandManager itself could have been made a `Configurable`, but it's a bit clunky, and it feels better to have the actual settings be separated from the command manager instance.