### PR TITLE
feat: introduce SuggestionLike

### DIFF
--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/suggestions/MethodSuggestionProvider.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/suggestions/MethodSuggestionProvider.java
@@ -24,6 +24,7 @@
 package cloud.commandframework.annotations.suggestions;
 
 import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionLike;
 import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.context.CommandContext;
 import java.lang.invoke.MethodHandle;
@@ -66,7 +67,7 @@ public final class MethodSuggestionProvider<C> implements SuggestionProvider<C> 
     }
 
     @Override
-    public @NonNull CompletableFuture<Iterable<@NonNull Suggestion>> suggestionsFuture(
+    public @NonNull CompletableFuture<Iterable<? extends @NonNull SuggestionLike>> suggestionsFuture(
             final @NonNull CommandContext<C> context,
             final @NonNull String input
     ) {
@@ -86,7 +87,9 @@ public final class MethodSuggestionProvider<C> implements SuggestionProvider<C> 
      * @since 2.0.0
      */
     @SuppressWarnings("rawtypes")
-    public static @NonNull CompletableFuture<Iterable<@NonNull Suggestion>> mapSuggestions(final @NonNull Object input) {
+    public static @NonNull CompletableFuture<Iterable<? extends @NonNull SuggestionLike>> mapSuggestions(
+            final @NonNull Object input
+    ) {
         if (input instanceof CompletableFuture) {
             return mapSuggestions((CompletableFuture) input);
         }
@@ -113,7 +116,7 @@ public final class MethodSuggestionProvider<C> implements SuggestionProvider<C> 
      * @since 2.0.0
      */
     @SuppressWarnings("unchecked")
-    public static @NonNull Iterable<@NonNull Suggestion> mapCompleted(final @NonNull Object input) {
+    public static @NonNull Iterable<? extends @NonNull SuggestionLike> mapCompleted(final @NonNull Object input) {
         final List<?> suggestions;
         if (input instanceof List) {
             suggestions = (List<?>) input;
@@ -138,8 +141,8 @@ public final class MethodSuggestionProvider<C> implements SuggestionProvider<C> 
         }
 
         final Object suggestion = suggestions.get(0);
-        if (suggestion instanceof Suggestion) {
-            return (List<Suggestion>) suggestions;
+        if (suggestion instanceof SuggestionLike) {
+            return (List<SuggestionLike>) suggestions;
         } else if (suggestion instanceof String) {
             return suggestions.stream().map(Object::toString).map(Suggestion::simple).collect(Collectors.toList());
         } else {

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/MethodSuggestionProviderTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/MethodSuggestionProviderTest.java
@@ -29,6 +29,7 @@ import cloud.commandframework.annotations.TestCommandManager;
 import cloud.commandframework.annotations.TestCommandSender;
 import cloud.commandframework.annotations.suggestions.Suggestions;
 import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionLike;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.context.CommandContextFactory;
 import cloud.commandframework.context.StandardCommandContextFactory;
@@ -70,7 +71,7 @@ class MethodSuggestionProviderTest {
         );
 
         // Act
-        final Iterable<Suggestion> suggestions =
+        final Iterable<? extends SuggestionLike> suggestions =
                 this.commandManager.parserRegistry()
                         .getSuggestionProvider("suggestions")
                         .orElseThrow(NullPointerException::new)

--- a/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
@@ -29,6 +29,7 @@ import cloud.commandframework.arguments.aggregate.AggregateCommandParser;
 import cloud.commandframework.arguments.flags.CommandFlagParser;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionLike;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.context.CommandInput;
 import cloud.commandframework.context.ParsingContext;
@@ -729,7 +730,8 @@ public final class CommandTree<C> {
         return component.suggestionProvider()
                 .suggestionsFuture(context.commandContext(), input)
                 .thenApply(suggestionsToAdd -> {
-                    for (Suggestion suggestion : suggestionsToAdd) {
+                    for (SuggestionLike suggestionLike : suggestionsToAdd) {
+                        final Suggestion suggestion = suggestionLike.asSuggestion();
                         if (suggestion.suggestion().equals(input) || !suggestion.suggestion().startsWith(input)) {
                             continue;
                         }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParser.java
@@ -26,7 +26,7 @@ package cloud.commandframework.arguments.aggregate;
 import cloud.commandframework.CommandComponent;
 import cloud.commandframework.arguments.parser.ArgumentParser;
 import cloud.commandframework.arguments.parser.ParserDescriptor;
-import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionLike;
 import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.context.CommandInput;
@@ -109,7 +109,7 @@ public interface AggregateCommandParser<C, O> extends ArgumentParser.FutureArgum
     }
 
     @Override
-    default @NonNull CompletableFuture<@NonNull Iterable<@NonNull Suggestion>> suggestionsFuture(
+    default @NonNull CompletableFuture<@NonNull Iterable<? extends @NonNull SuggestionLike>> suggestionsFuture(
             final @NonNull CommandContext<C> context,
             final @NonNull String input
     ) {

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/flags/CommandFlagParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/flags/CommandFlagParser.java
@@ -26,6 +26,7 @@ package cloud.commandframework.arguments.flags;
 import cloud.commandframework.CommandComponent;
 import cloud.commandframework.arguments.parser.ArgumentParser;
 import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionLike;
 import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.captions.Caption;
 import cloud.commandframework.captions.CaptionVariable;
@@ -143,7 +144,7 @@ public final class CommandFlagParser<C> implements ArgumentParser.FutureArgument
 
     @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public @NonNull CompletableFuture<Iterable<@NonNull Suggestion>> suggestionsFuture(
+    public @NonNull CompletableFuture<Iterable<? extends @NonNull SuggestionLike>> suggestionsFuture(
             final @NonNull CommandContext<C> commandContext,
             final @NonNull String input
     ) {

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/BlockingSuggestionProvider.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/BlockingSuggestionProvider.java
@@ -50,10 +50,10 @@ interface BlockingSuggestionProvider<C> extends SuggestionProvider<C> {
      * @param input   the current input
      * @return the suggestions
      */
-    @NonNull Iterable<@NonNull Suggestion> suggestions(@NonNull CommandContext<C> context, @NonNull String input);
+    @NonNull Iterable<? extends @NonNull SuggestionLike> suggestions(@NonNull CommandContext<C> context, @NonNull String input);
 
     @Override
-    default @NonNull CompletableFuture<@NonNull Iterable<@NonNull Suggestion>> suggestionsFuture(
+    default @NonNull CompletableFuture<@NonNull Iterable<? extends @NonNull SuggestionLike>> suggestionsFuture(
             final @NonNull CommandContext<C> context,
             final @NonNull String input
     ) {
@@ -89,7 +89,7 @@ interface BlockingSuggestionProvider<C> extends SuggestionProvider<C> {
         );
 
         @Override
-        default @NonNull Iterable<@NonNull Suggestion> suggestions(
+        default @NonNull Iterable<? extends @NonNull SuggestionLike> suggestions(
                 final @NonNull CommandContext<C> context,
                 final @NonNull String input
         ) {

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/SuggestionLike.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/SuggestionLike.java
@@ -25,43 +25,19 @@ package cloud.commandframework.arguments.suggestion;
 
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.common.returnsreceiver.qual.This;
 
+/**
+ * Something that behaves like a {@link Suggestion}.
+ *
+ * @since 2.0.0
+ */
 @API(status = API.Status.STABLE, since = "2.0.0")
-public interface Suggestion extends SuggestionLike {
+public interface SuggestionLike {
 
     /**
-     * Returns a simple suggestion that returns the given {@code suggestion}
+     * Returns the suggestion that is represented by this instance.
      *
-     * @param suggestion the suggestion string
-     * @return the created suggestion
+     * @return the suggestion
      */
-    static @NonNull Suggestion simple(final @NonNull String suggestion) {
-        return new SimpleSuggestion(suggestion);
-    }
-
-    /**
-     * Returns a string representation of this suggestion, which can be parsed by the parser that suggested it
-     *
-     * @return the suggestions
-     */
-    @NonNull String suggestion();
-
-    /**
-     * Returns a copy of this suggestion instance using the given {@code suggestion}
-     *
-     * @param suggestion the suggestion string
-     * @return the new suggestion
-     */
-    @NonNull Suggestion withSuggestion(@NonNull String suggestion);
-
-    /**
-     * Returns {@code this}.
-     *
-     * @return {@code this}
-     */
-    @Override
-    default @This @NonNull Suggestion asSuggestion() {
-        return this;
-    }
+    @NonNull Suggestion asSuggestion();
 }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/SuggestionProvider.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/SuggestionProvider.java
@@ -49,7 +49,7 @@ public interface SuggestionProvider<C> {
      * @param input   the current input
      * @return the suggestions
      */
-    @NonNull CompletableFuture<@NonNull Iterable<@NonNull Suggestion>> suggestionsFuture(
+    @NonNull CompletableFuture<@NonNull Iterable<? extends @NonNull SuggestionLike>> suggestionsFuture(
             @NonNull CommandContext<C> context,
             @NonNull String input
     );
@@ -100,7 +100,7 @@ public interface SuggestionProvider<C> {
      * @return suggestion provider
      */
     static <C> @NonNull SuggestionProvider<C> suggesting(
-            final @NonNull Suggestion @NonNull... suggestions
+            final @NonNull SuggestionLike @NonNull... suggestions
     ) {
         return suggesting(Arrays.asList(suggestions));
     }
@@ -126,7 +126,7 @@ public interface SuggestionProvider<C> {
      * @return suggestion provider
      */
     static <C> @NonNull SuggestionProvider<C> suggesting(
-            final @NonNull Iterable<@NonNull Suggestion> suggestions
+            final @NonNull Iterable<@NonNull ? extends SuggestionLike> suggestions
     ) {
         return blocking((ctx, input) -> suggestions);
     }

--- a/cloud-core/src/main/java/cloud/commandframework/internal/SuggestionContext.java
+++ b/cloud-core/src/main/java/cloud/commandframework/internal/SuggestionContext.java
@@ -24,6 +24,7 @@
 package cloud.commandframework.internal;
 
 import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionLike;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.context.CommandInput;
 import cloud.commandframework.execution.CommandSuggestionProcessor;
@@ -82,7 +83,7 @@ public final class SuggestionContext<C> {
      *
      * @param suggestions the suggestions to add
      */
-    public void addSuggestions(final @NonNull Iterable<@NonNull Suggestion> suggestions) {
+    public void addSuggestions(final @NonNull Iterable<? extends @NonNull SuggestionLike> suggestions) {
         suggestions.forEach(this::addSuggestion);
     }
 
@@ -91,8 +92,8 @@ public final class SuggestionContext<C> {
      *
      * @param suggestion the suggestion to add
      */
-    public void addSuggestion(final @NonNull Suggestion suggestion) {
-        final Suggestion result = this.processor.process(this.preprocessingContext, suggestion);
+    public void addSuggestion(final @NonNull SuggestionLike suggestion) {
+        final Suggestion result = this.processor.process(this.preprocessingContext, suggestion.asSuggestion());
         if (result == null) {
             return;
         }

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/aggregate/AggregateCommandParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/aggregate/AggregateCommandParserTest.java
@@ -24,6 +24,7 @@
 package cloud.commandframework.arguments.aggregate;
 
 import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionLike;
 import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.context.CommandInput;
@@ -110,7 +111,7 @@ class AggregateCommandParserTest {
                 .build();
 
         // Act
-        final Iterable<Suggestion> suggestions = parser.suggestionsFuture(this.commandContext, "").join();
+        final Iterable<? extends SuggestionLike> suggestions = parser.suggestionsFuture(this.commandContext, "").join();
 
         // Assert
         assertThat(suggestions).containsExactly(
@@ -138,7 +139,7 @@ class AggregateCommandParserTest {
         when(this.commandContext.contains("number")).thenReturn(true);
 
         // Act
-        final Iterable<Suggestion> suggestions = parser.suggestionsFuture(this.commandContext, "").join();
+        final Iterable<? extends SuggestionLike> suggestions = parser.suggestionsFuture(this.commandContext, "").join();
 
         // Assert
         assertThat(suggestions).containsExactly(

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/BooleanParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/BooleanParserTest.java
@@ -26,6 +26,7 @@ package cloud.commandframework.arguments.standard;
 import cloud.commandframework.TestCommandSender;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionLike;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.context.CommandInput;
 import java.util.List;
@@ -141,7 +142,7 @@ class BooleanParserTest {
         final BooleanParser<TestCommandSender> parser = new BooleanParser<>(liberal);
 
         // Act
-        final Iterable<Suggestion> suggestions = parser.suggestions(
+        final Iterable<? extends SuggestionLike> suggestions = parser.suggestions(
                 this.context,
                 ""
         );

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/ByteParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/ByteParserTest.java
@@ -26,6 +26,7 @@ package cloud.commandframework.arguments.standard;
 import cloud.commandframework.TestCommandSender;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionLike;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.context.CommandInput;
 import java.util.ArrayList;
@@ -152,7 +153,7 @@ class ByteParserTest {
         }
 
         // Act
-        final Iterable<Suggestion> suggestions = parser.suggestions(
+        final Iterable<? extends SuggestionLike> suggestions = parser.suggestions(
                 this.context,
                 ""
         );
@@ -175,7 +176,7 @@ class ByteParserTest {
         }
 
         // Act
-        final Iterable<Suggestion> suggestions = parser.suggestions(
+        final Iterable<? extends SuggestionLike> suggestions = parser.suggestions(
                 this.context,
                 "-"
         );

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/EnumParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/EnumParserTest.java
@@ -26,6 +26,7 @@ package cloud.commandframework.arguments.standard;
 import cloud.commandframework.TestCommandSender;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionLike;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.context.CommandInput;
 import org.junit.jupiter.api.Test;
@@ -95,7 +96,7 @@ class EnumParserTest {
         );
 
         // Act
-        final Iterable<Suggestion> suggestions = parser.suggestions(
+        final Iterable<? extends SuggestionLike> suggestions = parser.suggestions(
                 this.context,
                 ""
         );

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/IntegerParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/IntegerParserTest.java
@@ -26,6 +26,7 @@ package cloud.commandframework.arguments.standard;
 import cloud.commandframework.TestCommandSender;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionLike;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.context.CommandInput;
 import java.util.ArrayList;
@@ -152,7 +153,7 @@ class IntegerParserTest {
         }
 
         // Act
-        final Iterable<Suggestion> suggestions = parser.suggestions(
+        final Iterable<? extends SuggestionLike> suggestions = parser.suggestions(
                 this.context,
                 ""
         );
@@ -175,7 +176,7 @@ class IntegerParserTest {
         }
 
         // Act
-        final Iterable<Suggestion> suggestions = parser.suggestions(
+        final Iterable<? extends SuggestionLike> suggestions = parser.suggestions(
                 this.context,
                 "-"
         );

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/LongParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/LongParserTest.java
@@ -26,6 +26,7 @@ package cloud.commandframework.arguments.standard;
 import cloud.commandframework.TestCommandSender;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionLike;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.context.CommandInput;
 import java.util.ArrayList;
@@ -152,7 +153,7 @@ class LongParserTest {
         }
 
         // Act
-        final Iterable<Suggestion> suggestions = parser.suggestions(
+        final Iterable<? extends SuggestionLike> suggestions = parser.suggestions(
                 this.context,
                 ""
         );
@@ -175,7 +176,7 @@ class LongParserTest {
         }
 
         // Act
-        final Iterable<Suggestion> suggestions = parser.suggestions(
+        final Iterable<? extends SuggestionLike> suggestions = parser.suggestions(
                 this.context,
                 "-"
         );

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/ShortParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/ShortParserTest.java
@@ -26,6 +26,7 @@ package cloud.commandframework.arguments.standard;
 import cloud.commandframework.TestCommandSender;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionLike;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.context.CommandInput;
 import java.util.ArrayList;
@@ -152,7 +153,7 @@ class ShortParserTest {
         }
 
         // Act
-        final Iterable<Suggestion> suggestions = parser.suggestions(
+        final Iterable<? extends SuggestionLike> suggestions = parser.suggestions(
                 this.context,
                 ""
         );
@@ -175,7 +176,7 @@ class ShortParserTest {
         }
 
         // Act
-        final Iterable<Suggestion> suggestions = parser.suggestions(
+        final Iterable<? extends SuggestionLike> suggestions = parser.suggestions(
                 this.context,
                 "-"
         );

--- a/cloud-kotlin/cloud-kotlin-coroutines-annotations/src/main/kotlin/cloud/commandframework/kotlin/coroutines/annotations/KotlinAnnotatedMethods.kt
+++ b/cloud-kotlin/cloud-kotlin-coroutines-annotations/src/main/kotlin/cloud/commandframework/kotlin/coroutines/annotations/KotlinAnnotatedMethods.kt
@@ -28,6 +28,7 @@ import cloud.commandframework.annotations.MethodCommandExecutionHandler
 import cloud.commandframework.annotations.suggestions.MethodSuggestionProvider
 import cloud.commandframework.annotations.suggestions.SuggestionProviderFactory
 import cloud.commandframework.arguments.suggestion.Suggestion
+import cloud.commandframework.arguments.suggestion.SuggestionLike
 import cloud.commandframework.arguments.suggestion.SuggestionProvider
 import cloud.commandframework.context.CommandContext
 import cloud.commandframework.execution.CommandExecutionCoordinator
@@ -186,7 +187,7 @@ private class KotlinSuggestionProvider<C>(
     private val instance: Any
 ) : SuggestionProvider<C> {
 
-    override fun suggestionsFuture(context: CommandContext<C>, input: String): CompletableFuture<Iterable<Suggestion>> {
+    override fun suggestionsFuture(context: CommandContext<C>, input: String): CompletableFuture<Iterable<SuggestionLike>> {
         return coroutineScope.future(coroutineContext) {
             try {
                 kFunction.callSuspend(instance, context, input)

--- a/cloud-kotlin/cloud-kotlin-coroutines-annotations/src/test/kotlin/cloud/commandframework/kotlin/coroutines/annotations/KotlinAnnotatedMethodsTest.kt
+++ b/cloud-kotlin/cloud-kotlin-coroutines-annotations/src/test/kotlin/cloud/commandframework/kotlin/coroutines/annotations/KotlinAnnotatedMethodsTest.kt
@@ -29,6 +29,7 @@ import cloud.commandframework.annotations.Argument
 import cloud.commandframework.annotations.CommandMethod
 import cloud.commandframework.annotations.suggestions.Suggestions
 import cloud.commandframework.arguments.suggestion.Suggestion
+import cloud.commandframework.arguments.suggestion.SuggestionLike
 import cloud.commandframework.context.CommandContext
 import cloud.commandframework.context.StandardCommandContextFactory
 import cloud.commandframework.exceptions.CommandExecutionException
@@ -107,6 +108,7 @@ class KotlinAnnotatedMethodsTest {
         val suggestions = commandManager.parserRegistry().getSuggestionProvider("suspending-suggestions").get()
             .suggestionsFuture(commandContext, "")
             .await()
+            .map(SuggestionLike::asSuggestion)
             .map(Suggestion::suggestion)
             .map(String::toInt)
         assertThat(suggestions).containsExactlyElementsIn(1..10)
@@ -125,6 +127,7 @@ class KotlinAnnotatedMethodsTest {
         val suggestions = commandManager.parserRegistry().getSuggestionProvider("non-suspending-suggestions").get()
             .suggestionsFuture(commandContext, "")
             .await()
+            .map(SuggestionLike::asSuggestion)
             .map(Suggestion::suggestion)
             .map(String::toInt)
         assertThat(suggestions).containsExactlyElementsIn(1..10)

--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/argument/WrappedBrigadierParser.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/argument/WrappedBrigadierParser.java
@@ -25,7 +25,7 @@ package cloud.commandframework.brigadier.argument;
 
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
-import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionLike;
 import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.context.CommandInput;
@@ -161,7 +161,7 @@ public class WrappedBrigadierParser<C, T> implements ArgumentParser<C, T>, Sugge
     }
 
     @Override
-    public final @NonNull CompletableFuture<@NonNull Iterable<@NonNull Suggestion>> suggestionsFuture(
+    public final @NonNull CompletableFuture<@NonNull Iterable<? extends @NonNull SuggestionLike>> suggestionsFuture(
             final @NonNull CommandContext<C> commandContext,
             final @NonNull String input
     ) {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SelectorUtils.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SelectorUtils.java
@@ -26,6 +26,7 @@ package cloud.commandframework.bukkit.parsers.selector;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
 import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionLike;
 import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.brigadier.argument.WrappedBrigadierParser;
 import cloud.commandframework.bukkit.BukkitCommandContextKeys;
@@ -196,7 +197,7 @@ final class SelectorUtils {
         }
 
         @Override
-        public CompletableFuture<Iterable<@NonNull Suggestion>> suggestionsFuture(
+        public CompletableFuture<Iterable<? extends @NonNull SuggestionLike>> suggestionsFuture(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {
@@ -301,7 +302,7 @@ final class SelectorUtils {
         }
 
         @Override
-        public CompletableFuture<Iterable<@NonNull Suggestion>> suggestionsFuture(
+        public CompletableFuture<Iterable<? extends @NonNull SuggestionLike>> suggestionsFuture(
                 final @NonNull CommandContext<C> commandContext,
                 final @NonNull String input
         ) {

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/parser/KeyedWorldParser.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/parser/KeyedWorldParser.java
@@ -28,6 +28,7 @@ import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
 import cloud.commandframework.arguments.parser.ParserDescriptor;
 import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionLike;
 import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.bukkit.internal.CraftBukkitReflection;
 import cloud.commandframework.bukkit.parsers.WorldParser;
@@ -123,7 +124,7 @@ public final class KeyedWorldParser<C> implements ArgumentParser<C, World>, Sugg
     }
 
     @Override
-    public @NonNull CompletableFuture<@NonNull Iterable<@NonNull Suggestion>> suggestionsFuture(
+    public @NonNull CompletableFuture<@NonNull Iterable<? extends @NonNull SuggestionLike>> suggestionsFuture(
             final @NonNull CommandContext<C> commandContext,
             final @NonNull String input
     ) {


### PR DESCRIPTION
This is **not** something we have decided to add to Cloud. This PR is here as a proof-of-concept so that we can discuss whether this is something we're interested in.

It has the downside of making the signatures even more complex. This could be solved by removing the ability to subtype and force all implementations to use `SuggestionLike` in the signature as well.

I personally do not feel like the *Like suffix is a great choice, but after a discussion in the Paper discord (naturally) we couldn't come up with a better one on the spot.