### PR TITLE
chore: refactor injection services

### DIFF
--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/MethodCommandExecutionHandler.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/MethodCommandExecutionHandler.java
@@ -29,6 +29,7 @@ import cloud.commandframework.arguments.flags.FlagContext;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.CommandExecutionException;
 import cloud.commandframework.execution.CommandExecutionHandler;
+import io.leangen.geantyref.TypeToken;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
@@ -166,7 +167,7 @@ public class MethodCommandExecutionHandler<C> implements CommandExecutionHandler
                     arguments.add(new ParameterValue(parameter, null, commandContext.sender()));
                 } else {
                     final Optional<?> value = this.context.injectorRegistry.getInjectable(
-                            parameter.getType(),
+                            TypeToken.get(parameter.getParameterizedType()),
                             commandContext,
                             AnnotationAccessor.of(AnnotationAccessor.of(parameter), this.annotationAccessor)
                     );

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/ParameterInjectionTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/ParameterInjectionTest.java
@@ -1,0 +1,119 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.annotations.feature;
+
+import cloud.commandframework.CommandManager;
+import cloud.commandframework.annotations.AnnotationParser;
+import cloud.commandframework.annotations.CommandMethod;
+import cloud.commandframework.annotations.TestCommandManager;
+import cloud.commandframework.annotations.TestCommandSender;
+import cloud.commandframework.annotations.injection.ParameterInjector;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.execution.CommandResult;
+import io.leangen.geantyref.TypeToken;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+class ParameterInjectionTest {
+
+    private CommandManager<TestCommandSender> commandManager;
+    private AnnotationParser<TestCommandSender> annotationParser;
+
+    @BeforeEach
+    void setup() {
+        this.commandManager = new TestCommandManager();
+        this.annotationParser = new AnnotationParser<>(this.commandManager, TestCommandSender.class);
+    }
+
+    @Test
+    void testInjection() {
+        // Arrange
+        this.commandManager.parameterInjectorRegistry().registerInjector(Integer.class, ParameterInjector.constantInjector(5));
+        this.commandManager.parameterInjectorRegistry().registerInjector(new TypeToken<StringWrapper>() {
+        }, ParameterInjector.constantInjector(new StringWrapper("abc")));
+        this.commandManager.parameterInjectorRegistry().registerInjector(new TypeToken<Wrapper<Boolean>>() {
+        }, ParameterInjector.constantInjector(new Wrapper<>(true)));
+        this.commandManager.parameterInjectorRegistry().registerInjector(SomeImplementation.class,
+                ParameterInjector.constantInjector(new SomeImplementation()));
+        this.annotationParser.parse(new TestClass());
+
+        // Act
+        final CommandResult<?> result = this.commandManager.executeCommand(new TestCommandSender(), "command").join();
+
+        // Assert
+        assertThat(result.getCommandContext().<Integer>get("result-integer")).isEqualTo(5);
+        assertThat(result.getCommandContext().<String>get("result-string")).isEqualTo("abc");
+        assertThat(result.getCommandContext().<Boolean>get("result-boolean")).isEqualTo(true);
+        assertThat(result.getCommandContext().<SomeInterface>get("result-someInterface")).isInstanceOf(SomeImplementation.class);
+    }
+
+
+    static class TestClass {
+
+        @CommandMethod("command")
+        public void injectedMethod(
+                final @NonNull CommandContext<?> context,
+                final Integer integer,
+                final @NonNull Wrapper<String> stringWrapper,
+                final @NonNull Wrapper<Boolean> booleanWrapper,
+                final @NonNull SomeInterface someInterface
+        ) {
+            context.set("result-integer", integer);
+            context.set("result-string", stringWrapper.object());
+            context.set("result-boolean", booleanWrapper.object());
+            context.set("result-someInterface", someInterface);
+        }
+    }
+
+    static class Wrapper<T> {
+
+        private final T object;
+
+        Wrapper(final @NonNull T object) {
+            this.object = object;
+        }
+
+        final @NonNull T object() {
+            return this.object;
+        }
+    }
+
+    static class StringWrapper extends Wrapper<String> {
+
+        StringWrapper(final @NonNull String string) {
+            super(string);
+        }
+    }
+
+    interface SomeInterface {
+
+    }
+
+    static class SomeImplementation implements SomeInterface {
+
+    }
+}

--- a/cloud-core/src/main/java/cloud/commandframework/annotations/injection/GuiceInjectionService.java
+++ b/cloud-core/src/main/java/cloud/commandframework/annotations/injection/GuiceInjectionService.java
@@ -24,10 +24,11 @@
 package cloud.commandframework.annotations.injection;
 
 import cloud.commandframework.annotations.AnnotationAccessor;
-import cloud.commandframework.context.CommandContext;
-import cloud.commandframework.types.tuples.Triplet;
+import com.google.inject.BindingAnnotation;
 import com.google.inject.ConfigurationException;
 import com.google.inject.Injector;
+import com.google.inject.Key;
+import java.lang.annotation.Annotation;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -35,11 +36,44 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 /**
  * {@link InjectionService Injection service} that injects using a Guice {@link Injector}
  *
+ * <p>You should not put {@link com.google.inject.Inject} annotation on your methods.
+ * Ignore the warning says 'Binding annotation @YourAnnotation without {@literal @Inject} declared'.</p>
+ *
  * @param <C> Command sender type
  * @since 1.4.0
  */
 @API(status = API.Status.STABLE, since = "1.4.0")
 public final class GuiceInjectionService<C> implements InjectionService<C> {
+
+    /**
+     * Creates a Guice key for the given class and annotation accessor.
+     *
+     * <p>If the annotation accessor contains a binding annotation, the key will be created with that annotation.
+     * Otherwise, the key will be created without a binding annotation.</p>
+     *
+     * <p>If the annotation accessor contains multiple binding annotations, the first one will be used.</p>
+     *
+     * @param <T>                type of the key
+     * @param clazz              class to create key for
+     * @param annotationAccessor annotation accessor to create key for
+     * @return the created key
+     */
+    private static <T> @NonNull Key<T> createKey(
+            final @NonNull Class<T> clazz,
+            final @NonNull AnnotationAccessor annotationAccessor
+    ) {
+        final Annotation bindingAnnotation = annotationAccessor
+                .annotations()
+                .stream()
+                .filter(annotation -> annotation.annotationType().isAnnotationPresent(BindingAnnotation.class))
+                .findFirst()
+                .orElse(null);
+        if (bindingAnnotation == null) {
+            return Key.get(clazz);
+        } else {
+            return Key.get(clazz, bindingAnnotation);
+        }
+    }
 
     private final Injector injector;
 
@@ -48,23 +82,22 @@ public final class GuiceInjectionService<C> implements InjectionService<C> {
     }
 
     /**
-     * Create a new Guice injection service that wraps the given injector
+     * Creates a new Guice injection service that wraps the given injector
      *
-     * @param injector Injector to wrap
-     * @param <C>      Command sender type
+     * @param <C>      command sender type
+     * @param injector injector to wrap
      * @return the created injection service
      */
-    public static <C> GuiceInjectionService<C> create(final @NonNull Injector injector) {
+    public static <C> @NonNull GuiceInjectionService<C> create(final @NonNull Injector injector) {
         return new GuiceInjectionService<>(injector);
     }
 
     @Override
-    @SuppressWarnings("EmptyCatch")
-    public @Nullable Object handle(final @NonNull Triplet<CommandContext<C>, Class<?>, AnnotationAccessor> triplet) {
+    public @Nullable Object handle(final @NonNull InjectionRequest<C> request) {
         try {
-            return this.injector.getInstance(triplet.getSecond());
+            return this.injector.getInstance(createKey(request.injectedClass(), request.annotationAccessor()));
         } catch (final ConfigurationException ignored) {
+            return null;
         }
-        return null;
     }
 }

--- a/cloud-core/src/main/java/cloud/commandframework/annotations/injection/InjectionRequest.java
+++ b/cloud-core/src/main/java/cloud/commandframework/annotations/injection/InjectionRequest.java
@@ -1,0 +1,105 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.annotations.injection;
+
+import cloud.commandframework.annotations.AnnotationAccessor;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.internal.ImmutableImpl;
+import io.leangen.geantyref.GenericTypeReflector;
+import io.leangen.geantyref.TypeToken;
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.immutables.value.Value;
+
+@ImmutableImpl
+@Value.Immutable
+@API(status = API.Status.STABLE, since = "2.0.0")
+public interface InjectionRequest<C> {
+
+    /**
+     * Creates a new injection request.
+     *
+     * @param <C>                command sender type
+     * @param context            context associated with the request
+     * @param injectedType       type that is being injected
+     * @param annotationAccessor associated annotation accessor
+     * @return the request
+     */
+    static <C> @NonNull InjectionRequest<C> of(
+            final @NonNull CommandContext<C> context,
+            final @NonNull TypeToken<?> injectedType,
+            final @NonNull AnnotationAccessor annotationAccessor
+    ) {
+        return InjectionRequestImpl.of(context, injectedType, annotationAccessor);
+    }
+
+    /**
+     * Creates a new injection request.
+     *
+     * @param <C>          command sender type
+     * @param context      context associated with the request
+     * @param injectedType type that is being injected
+     * @return the request
+     */
+    static <C> @NonNull InjectionRequest<C> of(
+            final @NonNull CommandContext<C> context,
+            final @NonNull TypeToken<?> injectedType
+    ) {
+        return InjectionRequestImpl.of(context, injectedType, AnnotationAccessor.empty());
+    }
+
+    /**
+     * Returns the context associated with the request.
+     *
+     * @return the context
+     */
+    @NonNull CommandContext<C> commandContext();
+
+    /**
+     * Returns the type that is being injected.
+     *
+     * @return the injected type
+     */
+    @NonNull TypeToken<?> injectedType();
+
+    /**
+     * Returns the type that is being injected.
+     *
+     * @return the injected type
+     */
+    @Value.Derived
+    default @NonNull Class<?> injectedClass() {
+        return GenericTypeReflector.erase(this.injectedType().getType());
+    }
+
+    /**
+     * Returns an annotation accessor that can be used to access the annotations of the field that is being
+     * injected.
+     *
+     * <p>If no field is injected then {@link AnnotationAccessor#empty()} will be returned.</p>
+     *
+     * @return the annotation accessor
+     */
+    @NonNull AnnotationAccessor annotationAccessor();
+}

--- a/cloud-core/src/main/java/cloud/commandframework/annotations/injection/InjectionService.java
+++ b/cloud-core/src/main/java/cloud/commandframework/annotations/injection/InjectionService.java
@@ -23,23 +23,21 @@
 //
 package cloud.commandframework.annotations.injection;
 
-import cloud.commandframework.annotations.AnnotationAccessor;
-import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.services.types.Service;
-import cloud.commandframework.types.tuples.Triplet;
 import org.apiguardian.api.API;
 
 /**
  * Service that can be registered to the {@link ParameterInjectorRegistry} in order to provide
- * custom injection support. This can be used to integrate the Cloud with existing dependency
- * injection frameworks.
+ * custom injection support.
  *
- * @param <C> Command sender type
- * @since 1.4.0
+ * <p>This can be used to integrate the Cloud with existing dependency
+ * injection frameworks.</p>
+ *
+ * @param <C> command sender type
+ * @since 2.0.0
  */
 @FunctionalInterface
-@API(status = API.Status.STABLE, since = "1.4.0")
-public interface InjectionService<C> extends
-        Service<Triplet<CommandContext<C>, Class<?>, AnnotationAccessor>, Object> {
+@API(status = API.Status.STABLE, since = "2.0.0")
+public interface InjectionService<C> extends Service<InjectionRequest<C>, Object> {
 
 }

--- a/cloud-core/src/main/java/cloud/commandframework/annotations/injection/ParameterInjector.java
+++ b/cloud-core/src/main/java/cloud/commandframework/annotations/injection/ParameterInjector.java
@@ -25,6 +25,7 @@ package cloud.commandframework.annotations.injection;
 
 import cloud.commandframework.annotations.AnnotationAccessor;
 import cloud.commandframework.context.CommandContext;
+import java.util.Objects;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -44,25 +45,67 @@ public interface ParameterInjector<C, T> {
     /**
      * Returns a parameter injector that always injects {@code value}.
      *
-     * @param <C>   the command sender type
-     * @param <T>   the type of the value
-     * @param value the value to inject
+     * @param <C>   command sender type
+     * @param <T>   type of the value
+     * @param value value to inject
      * @return the injector
      * @since 2.0.0
      */
     @API(status = API.Status.STABLE, since = "2.0.0")
-    static <C, T> @NonNull ParameterInjector<C, T> constantInjector(@NonNull T value) {
-        return (context, annotationAccessor) -> value;
+    static <C, T> @NonNull ParameterInjector<C, T> constantInjector(final @NonNull T value) {
+        return new ConstantInjector<>(value);
     }
 
     /**
-     * Attempt to create a value that should then be injected into the CommandMethod
-     * annotated method. If the injector cannot (or shouldn't) create a value, it is free to return {@code null}.
+     * Attempts to create a value that should then be injected into the CommandMethod
+     * annotated method.
      *
-     * @param context            Command context that is requesting the injection
-     * @param annotationAccessor Annotation accessor proxying the method and parameter which the value is being injected into
-     * @return The value, if it could be created. Else {@code null}, in which case no value will be injected
+     * <p>If the injector cannot (or shouldn't) create a value, it is free to return {@code null}.</p>
+     *
+     * @param context            command context that is requesting the injection
+     * @param annotationAccessor annotation accessor proxying the method and parameter which the value is being injected into
+     * @return the value if it could be created, else {@code null} in which case no value will be injected
      *         by this particular injector
      */
     @Nullable T create(@NonNull CommandContext<C> context, @NonNull AnnotationAccessor annotationAccessor);
+
+
+    final class ConstantInjector<C, T> implements ParameterInjector<C, T> {
+
+        private final T value;
+
+        private ConstantInjector(final @NonNull T value) {
+            this.value = value;
+        }
+
+        @Override
+        public @NonNull T create(
+                final @NonNull CommandContext<C> context,
+                final @NonNull AnnotationAccessor annotationAccessor
+        ) {
+            return this.value;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || this.getClass() != o.getClass()) {
+                return false;
+            }
+            final ConstantInjector<?, ?> that = (ConstantInjector<?, ?>) o;
+            return Objects.equals(this.value, that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.value);
+        }
+
+        @Override
+        public String toString() {
+            return "ConstantInjector{value=" + this.value + '}';
+        }
+    }
 }

--- a/cloud-core/src/main/java/cloud/commandframework/context/CommandContext.java
+++ b/cloud-core/src/main/java/cloud/commandframework/context/CommandContext.java
@@ -34,6 +34,7 @@ import cloud.commandframework.captions.CaptionVariable;
 import cloud.commandframework.keys.CloudKey;
 import cloud.commandframework.keys.MutableCloudKeyContainer;
 import cloud.commandframework.permission.Permission;
+import io.leangen.geantyref.TypeToken;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -367,8 +368,8 @@ public class CommandContext<C> implements MutableCloudKeyContainer {
      * Attempts to retrieve a value that has been registered to the associated command manager's
      * {@link cloud.commandframework.annotations.injection.ParameterInjectorRegistry}.
      *
-     * @param clazz class of type to inject
      * @param <T>   type to inject
+     * @param clazz class of type to inject
      * @return optional that may contain the created value
      * @since 1.3.0
      */
@@ -380,6 +381,25 @@ public class CommandContext<C> implements MutableCloudKeyContainer {
             );
         }
         return this.commandManager.parameterInjectorRegistry().getInjectable(clazz, this, AnnotationAccessor.empty());
+    }
+
+    /**
+     * Attempts to retrieve a value that has been registered to the associated command manager's
+     * {@link cloud.commandframework.annotations.injection.ParameterInjectorRegistry}.
+     *
+     * @param <T>  type to inject
+     * @param type type to inject
+     * @return optional that may contain the created value
+     * @since 2.0.0
+     */
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    public <@NonNull T> @NonNull Optional<T> inject(final @NonNull TypeToken<T> type) {
+        if (this.commandManager == null) {
+            throw new UnsupportedOperationException(
+                    "Cannot retrieve injectable values from a command context that is not associated with a command manager"
+            );
+        }
+        return this.commandManager.parameterInjectorRegistry().getInjectable(type, this, AnnotationAccessor.empty());
     }
 
     @Override


### PR DESCRIPTION
- Use an immutable interface rather than a triplet as the input to injection services
- Allow injection using `TypeToken`

This also pulls in the changes from #473.