### PR TITLE
feat(core): extract command execution from CommandManager

### DIFF
--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
@@ -97,16 +97,16 @@ class AnnotationParserTest {
     @Test
     void testMethodConstruction() {
         Assertions.assertFalse(commands.isEmpty());
-        manager.executeCommand(new TestCommandSender(), "test literal 10").join();
-        manager.executeCommand(new TestCommandSender(), "t literal 10 o").join();
-        manager.executeCommand(new TestCommandSender(), "proxycommand 10").join();
+        manager.commandExecutor().executeCommand(new TestCommandSender(), "test literal 10").join();
+        manager.commandExecutor().executeCommand(new TestCommandSender(), "t literal 10 o").join();
+        manager.commandExecutor().executeCommand(new TestCommandSender(), "proxycommand 10").join();
         Assertions.assertThrows(CompletionException.class, () ->
-                manager.executeCommand(new TestCommandSender(), "test 101").join());
-        manager.executeCommand(new TestCommandSender(), "flagcommand -p").join();
-        manager.executeCommand(new TestCommandSender(), "flagcommand --print --word peanut").join();
-        manager.executeCommand(new TestCommandSender(), "parserflagcommand -s \"Hello World\"").join();
-        manager.executeCommand(new TestCommandSender(), "parserflagcommand -s \"Hello World\" -o This is a test").join();
-        manager.executeCommand(new TestCommandSender(), "class method").join();
+                manager.commandExecutor().executeCommand(new TestCommandSender(), "test 101").join());
+        manager.commandExecutor().executeCommand(new TestCommandSender(), "flagcommand -p").join();
+        manager.commandExecutor().executeCommand(new TestCommandSender(), "flagcommand --print --word peanut").join();
+        manager.commandExecutor().executeCommand(new TestCommandSender(), "parserflagcommand -s \"Hello World\"").join();
+        manager.commandExecutor().executeCommand(new TestCommandSender(), "parserflagcommand -s \"Hello World\" -o This is a test").join();
+        manager.commandExecutor().executeCommand(new TestCommandSender(), "class method").join();
     }
 
     @Test
@@ -152,7 +152,7 @@ class AnnotationParserTest {
 
     @Test
     void testParameterInjection() {
-        manager.executeCommand(new TestCommandSender(), "injected 10").join();
+        manager.commandExecutor().executeCommand(new TestCommandSender(), "injected 10").join();
     }
 
     @Test
@@ -199,7 +199,7 @@ class AnnotationParserTest {
 
     @Test
     void testInjectedCommand() {
-        manager.executeCommand(new TestCommandSender(), "injected 10").join();
+        manager.commandExecutor().executeCommand(new TestCommandSender(), "injected 10").join();
     }
 
     @Suggestions("cows")

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/exception/MethodExceptionHandlerTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/exception/MethodExceptionHandlerTest.java
@@ -29,6 +29,7 @@ import cloud.commandframework.annotations.TestCommandManager;
 import cloud.commandframework.annotations.TestCommandSender;
 import cloud.commandframework.annotations.injection.ParameterInjector;
 import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.context.StandardCommandContextFactory;
 import cloud.commandframework.exceptions.NoSuchCommandException;
 import cloud.commandframework.exceptions.handling.ExceptionContext;
 import cloud.commandframework.exceptions.handling.ExceptionController;
@@ -50,7 +51,7 @@ class MethodExceptionHandlerTest {
         final CommandManager<TestCommandSender> commandManager = new TestCommandManager();
         this.exceptionController = commandManager.exceptionController();
         this.annotationParser = new AnnotationParser<>(commandManager, TestCommandSender.class);
-        this.context = commandManager.commandContextFactory().create(false, new TestCommandSender());
+        this.context = new StandardCommandContextFactory<>(commandManager).create(false, new TestCommandSender());
         commandManager.parameterInjectorRegistry().registerInjector(Integer.class, ParameterInjector.constantInjector(5));
     }
 

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/ArgumentDrivenCommandsTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/ArgumentDrivenCommandsTest.java
@@ -75,7 +75,7 @@ class ArgumentDrivenCommandsTest {
         this.annotationParser.parse(new ArgumentDrivenCommandClass());
 
         // Act
-        this.commandManager.executeCommand(new TestCommandSender(), "test 3 literal").get();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test 3 literal").get();
     }
 
     private static class TestArgumentExtractor implements ArgumentExtractor {

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/ArgumentWithoutAnnotationTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/ArgumentWithoutAnnotationTest.java
@@ -64,7 +64,7 @@ class ArgumentWithoutAnnotationTest {
         this.annotationParser.parse(new TestClass());
 
         // Assert
-        final CommandResult<?> result = this.commandManager.executeCommand(new TestCommandSender(),
+        final CommandResult<?> result = this.commandManager.commandExecutor().executeCommand(new TestCommandSender(),
                 "command abc 123 true").join();
         final CommandContext<?> context = result.commandContext();
         assertThat(context.<String>get("required")).isEqualTo("abc");

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/RepeatableCommandMethodTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/RepeatableCommandMethodTest.java
@@ -59,8 +59,8 @@ class RepeatableCommandMethodTest {
         this.annotationParser.parse(new TestClass());
 
         // Act
-        final CommandResult<?> result1 = this.commandManager.executeCommand(new TestCommandSender(), "test").join();
-        final CommandResult<?> result2 = this.commandManager.executeCommand(new TestCommandSender(), "test foo").join();
+        final CommandResult<?> result1 = this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test").join();
+        final CommandResult<?> result2 = this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test foo").join();
 
         // Assert
         assertThat(result1.commandContext().<Boolean>get("handled")).isTrue();

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/RepeatableFlagTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/RepeatableFlagTest.java
@@ -53,7 +53,7 @@ class RepeatableFlagTest {
     @Test
     void testRepeatableFlagParsing() {
         // Act
-        final CommandResult<TestCommandSender> result = this.commandManager.executeCommand(
+        final CommandResult<TestCommandSender> result = this.commandManager.commandExecutor().executeCommand(
                 new TestCommandSender(),
                 "test --flag one --flag two --flag three"
         ).join();

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/RequiredSenderDeductionTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/RequiredSenderDeductionTest.java
@@ -68,7 +68,7 @@ class RequiredSenderDeductionTest {
         final SuperSender<?> sender = new StringSender();
 
         // Act
-        this.commandManager.executeCommand(sender, "teststring").join();
+        this.commandManager.commandExecutor().executeCommand(sender, "teststring").join();
     }
 
     @Test
@@ -79,7 +79,7 @@ class RequiredSenderDeductionTest {
         // Act
         assertThrows(
                 CompletionException.class,
-                () -> this.commandManager.executeCommand(sender, "teststring").join()
+                () -> this.commandManager.commandExecutor().executeCommand(sender, "teststring").join()
         );
     }
 

--- a/cloud-core/src/main/java/cloud/commandframework/CommandExecutor.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandExecutor.java
@@ -1,0 +1,101 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework;
+
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.execution.CommandExecutionCoordinator;
+import cloud.commandframework.execution.CommandResult;
+import cloud.commandframework.execution.postprocessor.CommandPostprocessor;
+import cloud.commandframework.execution.preprocessor.CommandPreprocessor;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+@API(status = API.Status.STABLE, since = "2.0.0")
+public interface CommandExecutor<C> {
+
+    /**
+     * Executes a command and get a future that completes with the result. The command may be executed immediately
+     * or at some point in the future, depending on the {@link CommandExecutionCoordinator} used in the command manager.
+     *
+     * <p>The command may also be filtered out by preprocessors (see {@link CommandPreprocessor}) before they are parsed,
+     * or by the {@link CommandComponent} command components during parsing. The execution may also be filtered out
+     * after parsing by a {@link CommandPostprocessor}. In the case that a command was filtered out at any of the
+     * execution stages, the future will complete with {@code null}.</p>
+     *
+     * <p>The future may also complete exceptionally.
+     * These exceptions will be handled using exception handlers registered in the
+     * {@link cloud.commandframework.exceptions.handling.ExceptionController}.
+     * The exceptions will be forwarded to the future, if the exception was transformed during the exception handling, then the
+     * new exception will be present in the completed future.</p>
+     *
+     * @param commandSender Sender of the command
+     * @param input         Input provided by the sender. Prefixes should be removed before the method is being called, and
+     *                      the input here will be passed directly to the command parsing pipeline, after having been tokenized.
+     * @return future that completes with the command result, or {@code null} if the execution was cancelled at any of the
+     *         processing stages.
+     */
+    default @NonNull CompletableFuture<CommandResult<C>> executeCommand(
+            final @NonNull C commandSender,
+            final @NonNull String input
+    ) {
+        return this.executeCommand(commandSender, input, context -> {});
+    }
+
+    /**
+     * Executes a command and get a future that completes with the result. The command may be executed immediately
+     * or at some point in the future, depending on the {@link CommandExecutionCoordinator} used in the command manager.
+     *
+     * <p>The command may also be filtered out by preprocessors (see {@link CommandPreprocessor}) before they are parsed,
+     * or by the {@link CommandComponent} command components during parsing. The execution may also be filtered out
+     * after parsing by a {@link CommandPostprocessor}. In the case that a command was filtered out at any of the
+     * execution stages, the future will complete with {@code null}.</p>
+     *
+     * <p>The future may also complete exceptionally.
+     * These exceptions will be handled using exception handlers registered in the
+     * {@link cloud.commandframework.exceptions.handling.ExceptionController}.
+     * The exceptions will be forwarded to the future, if the exception was transformed during the exception handling, then the
+     * new exception will be present in the completed future.</p>
+     *
+     * @param commandSender   the sender of the command
+     * @param input           the input provided by the sender. Prefixes should be removed before the method is being called, and
+     *                        the input here will be passed directly to the command parsing pipeline, after having been tokenized.
+     * @param contextConsumer consumer that accepts the context before the command is executed
+     * @return future that completes with the command result, or {@code null} if the execution was cancelled at any of the
+     *         processing stages.
+     */
+    @NonNull CompletableFuture<CommandResult<C>> executeCommand(
+            @NonNull C commandSender,
+            @NonNull String input,
+            @NonNull Consumer<CommandContext<C>> contextConsumer
+    );
+
+    /**
+     * Returns the command execution coordinator.
+     *
+     * @return command execution coordinator
+     */
+    @NonNull CommandExecutionCoordinator<C> commandExecutionCoordinator();
+}

--- a/cloud-core/src/main/java/cloud/commandframework/StandardCommandExecutor.java
+++ b/cloud-core/src/main/java/cloud/commandframework/StandardCommandExecutor.java
@@ -1,0 +1,103 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework;
+
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.context.CommandContextFactory;
+import cloud.commandframework.context.CommandInput;
+import cloud.commandframework.exceptions.handling.ExceptionController;
+import cloud.commandframework.execution.CommandExecutionCoordinator;
+import cloud.commandframework.execution.CommandResult;
+import cloud.commandframework.services.State;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.function.Consumer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+final class StandardCommandExecutor<C> implements CommandExecutor<C> {
+
+    private final CommandManager<C> commandManager;
+    private final CommandExecutionCoordinator<C> commandExecutionCoordinator;
+    private final CommandContextFactory<C> commandContextFactory;
+
+    StandardCommandExecutor(
+            final @NonNull CommandManager<C> commandManager,
+            final @NonNull CommandExecutionCoordinator<C> commandExecutionCoordinator,
+            final @NonNull CommandContextFactory<C> commandContextFactory
+    ) {
+        this.commandManager = commandManager;
+        this.commandExecutionCoordinator = commandExecutionCoordinator;
+        this.commandContextFactory = commandContextFactory;
+    }
+
+    @Override
+    public @NonNull CompletableFuture<CommandResult<C>> executeCommand(
+            final @NonNull C commandSender,
+            final @NonNull String input,
+            final @NonNull Consumer<CommandContext<C>> contextConsumer
+    ) {
+        final CommandContext<C> context = this.commandContextFactory.create(false, commandSender);
+        contextConsumer.accept(context);
+        final CommandInput commandInput = CommandInput.of(input);
+        return this.executeCommand(context, commandInput).whenComplete((result, throwable) -> {
+            if (throwable == null) {
+                return;
+            }
+            try {
+                this.commandManager.exceptionController().handleException(
+                        context,
+                        ExceptionController.unwrapCompletionException(throwable)
+                );
+            } catch (final RuntimeException runtimeException) {
+                throw runtimeException;
+            } catch (final Throwable e) {
+                throw new CompletionException(e);
+            }
+        });
+    }
+
+    private @NonNull CompletableFuture<CommandResult<C>> executeCommand(
+            final @NonNull CommandContext<C> context,
+            final @NonNull CommandInput commandInput
+    ) {
+        /* Store a copy of the input queue in the context */
+        context.store("__raw_input__", commandInput.copy());
+        try {
+            if (this.commandManager.preprocessContext(context, commandInput) == State.ACCEPTED) {
+                return this.commandExecutionCoordinator().coordinateExecution(context, commandInput);
+            }
+        } catch (final Exception e) {
+            final CompletableFuture<CommandResult<C>> future = new CompletableFuture<>();
+            future.completeExceptionally(e);
+            return future;
+        }
+        /* Wasn't allowed to execute the command */
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public @NonNull CommandExecutionCoordinator<C> commandExecutionCoordinator() {
+        return this.commandExecutionCoordinator;
+    }
+}

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/parser/ArgumentParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/parser/ArgumentParser.java
@@ -54,7 +54,7 @@ public interface ArgumentParser<C, T> extends SuggestionProviderHolder<C> {
      * Parse command input into a command result.
      * <p>
      * This method may be called when a command chain is being parsed for execution
-     * (using {@link cloud.commandframework.CommandManager#executeCommand(Object, String)})
+     * (using {@link cloud.commandframework.CommandExecutor#executeCommand(Object, String)})
      * or when a command is being parsed to provide context for suggestions
      * (using {@link SuggestionFactory#suggest(Object, String)}).
      * It is possible to use {@link CommandContext#isSuggestions()}} to see what the purpose of the
@@ -82,7 +82,7 @@ public interface ArgumentParser<C, T> extends SuggestionProviderHolder<C> {
      * Returns a future that completes with the result of parsing the given {@code commandInput}.
      * <p>
      * This method may be called when a command chain is being parsed for execution
-     * (using {@link cloud.commandframework.CommandManager#executeCommand(Object, String)})
+     * (using {@link cloud.commandframework.CommandExecutor#executeCommand(Object, String)})
      * or when a command is being parsed to provide context for suggestions
      * (using {@link SuggestionFactory#suggest(Object, String)}).
      * It is possible to use {@link CommandContext#isSuggestions()}} to see what the purpose of the

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/DelegatingSuggestionFactory.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/DelegatingSuggestionFactory.java
@@ -26,6 +26,7 @@ package cloud.commandframework.arguments.suggestion;
 import cloud.commandframework.CommandManager;
 import cloud.commandframework.CommandTree;
 import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.context.CommandContextFactory;
 import cloud.commandframework.context.CommandInput;
 import cloud.commandframework.services.State;
 import cloud.commandframework.setting.ManagerSetting;
@@ -51,15 +52,18 @@ final class DelegatingSuggestionFactory<C, S extends Suggestion> implements Sugg
     private final CommandManager<C> commandManager;
     private final CommandTree<C> commandTree;
     private final SuggestionMapper<S> suggestionMapper;
+    private final CommandContextFactory<C> contextFactory;
 
     DelegatingSuggestionFactory(
             final @NonNull CommandManager<C> commandManager,
             final @NonNull CommandTree<C> commandTree,
-            final @NonNull SuggestionMapper<S> suggestionMapper
+            final @NonNull SuggestionMapper<S> suggestionMapper,
+            final @NonNull CommandContextFactory<C> contextFactory
     ) {
         this.commandManager = commandManager;
         this.commandTree = commandTree;
         this.suggestionMapper = suggestionMapper;
+        this.contextFactory = contextFactory;
     }
 
     @Override
@@ -75,10 +79,7 @@ final class DelegatingSuggestionFactory<C, S extends Suggestion> implements Sugg
 
     @Override
     public @NonNull CompletableFuture<List<@NonNull S>> suggest(final @NonNull C sender, final @NonNull String input) {
-        return this.suggest(
-                this.commandManager.commandContextFactory().create(true /* suggestions */, sender),
-                input
-        );
+        return this.suggest(this.contextFactory.create(true /* suggestions */, sender), input);
     }
 
     private @NonNull CompletableFuture<List<? extends @NonNull Suggestion>> suggestFromTree(

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/SuggestionFactory.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/SuggestionFactory.java
@@ -25,6 +25,7 @@ package cloud.commandframework.arguments.suggestion;
 
 import cloud.commandframework.CommandManager;
 import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.context.CommandContextFactory;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -45,20 +46,23 @@ public interface SuggestionFactory<C, S extends Suggestion> {
      * Returns a suggestion factory that invokes the command tree to create the suggestions, and then maps them
      * to the output type using the given {@code mapper}.
      *
-     * @param <C>     the command sender type
-     * @param <S>     the output suggestion type
-     * @param manager the command manager
-     * @param mapper  the suggestion mapper
+     * @param <C>            the command sender type
+     * @param <S>            the output suggestion type
+     * @param manager        the command manager
+     * @param mapper         the suggestion mapper
+     * @param contextFactory factory producing {@link CommandContext} instances
      * @return the factory
      */
     static <C, S extends Suggestion> @NonNull SuggestionFactory<C, S> delegating(
             final @NonNull CommandManager<C> manager,
-            final @NonNull SuggestionMapper<S> mapper
+            final @NonNull SuggestionMapper<S> mapper,
+            final @NonNull CommandContextFactory<C> contextFactory
     ) {
         return new DelegatingSuggestionFactory<>(
                 manager,
                 manager.commandTree(),
-                mapper
+                mapper,
+                contextFactory
         );
     }
 

--- a/cloud-core/src/test/java/cloud/commandframework/CommandDeletionTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandDeletionTest.java
@@ -68,7 +68,7 @@ class CommandDeletionTest {
         // Arrange
         this.commandManager.command(this.commandManager.commandBuilder("test").build());
         // Pre-assert.
-        this.commandManager.executeCommand(new TestCommandSender(), "test").join();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test").join();
 
         // Act
         this.commandManager.deleteRootCommand("test");
@@ -76,7 +76,7 @@ class CommandDeletionTest {
         // Assert
         final CompletionException completionException = assertThrows(
                 CompletionException.class,
-                () -> this.commandManager.executeCommand(new TestCommandSender(), "test").join()
+                () -> this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test").join()
         );
         assertThat(completionException).hasCauseThat().isInstanceOf(NoSuchCommandException.class);
 
@@ -118,19 +118,19 @@ class CommandDeletionTest {
         // Assert
         final CompletionException completionException = assertThrows(
                 CompletionException.class,
-                () -> this.commandManager.executeCommand(new TestCommandSender(), "test").join()
+                () -> this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test").join()
         );
         assertThat(completionException).hasCauseThat().isInstanceOf(NoSuchCommandException.class);
 
         final CompletionException completionException2 = assertThrows(
                 CompletionException.class,
-                () -> this.commandManager.executeCommand(new TestCommandSender(), "test literal").join()
+                () -> this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test literal").join()
         );
         assertThat(completionException2).hasCauseThat().isInstanceOf(NoSuchCommandException.class);
 
         final CompletionException completionException3 = assertThrows(
                 CompletionException.class,
-                () -> this.commandManager.executeCommand(new TestCommandSender(), "test literal hm").join()
+                () -> this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test literal hm").join()
         );
         assertThat(completionException3).hasCauseThat().isInstanceOf(NoSuchCommandException.class);
 
@@ -148,17 +148,17 @@ class CommandDeletionTest {
         this.commandManager.command(this.commandManager.commandBuilder("hello").literal("test").build());
 
         // Pre-assert.
-        this.commandManager.executeCommand(new TestCommandSender(), "test").join();
-        this.commandManager.executeCommand(new TestCommandSender(), "hello test").join();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test").join();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "hello test").join();
 
         // Act
         this.commandManager.deleteRootCommand("hello");
 
         // Assert
-        this.commandManager.executeCommand(new TestCommandSender(), "test").join();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test").join();
         final CompletionException completionException = assertThrows(
                 CompletionException.class,
-                () -> this.commandManager.executeCommand(new TestCommandSender(), "hello").join()
+                () -> this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "hello").join()
         );
         assertThat(completionException).hasCauseThat().isInstanceOf(NoSuchCommandException.class);
 

--- a/cloud-core/src/test/java/cloud/commandframework/CommandManagerTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandManagerTest.java
@@ -98,10 +98,10 @@ class CommandManagerTest {
         this.commandManager.command(commandC);
 
         // Act
-        this.commandManager.executeCommand(new TestCommandSender(), "test a").join();
-        this.commandManager.executeCommand(new TestCommandSender(), "test b").join();
-        this.commandManager.executeCommand(new TestCommandSender(), "test c").join();
-        this.commandManager.executeCommand(new TestCommandSender(), "test c 123").join();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test a").join();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test b").join();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test c").join();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test c 123").join();
 
         // Assert
         ArgumentCaptor<CommandContext<TestCommandSender>> contextArgumentCaptor = ArgumentCaptor.forClass(

--- a/cloud-core/src/test/java/cloud/commandframework/CommandPerformanceTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandPerformanceTest.java
@@ -60,7 +60,7 @@ final class CommandPerformanceTest {
 
     @Test
     void testLiterals() {
-        final CommandResult<TestCommandSender> result = manager.executeCommand(new TestCommandSender(), literalChain).join();
+        final CommandResult<TestCommandSender> result = manager.commandExecutor().executeCommand(new TestCommandSender(), literalChain).join();
 
         long elapsedTime = 0L;
         int amount = 0;

--- a/cloud-core/src/test/java/cloud/commandframework/CommandPostProcessorTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandPostProcessorTest.java
@@ -67,7 +67,7 @@ class CommandPostProcessorTest {
         );
 
         // Act
-        this.commandManager.executeCommand(new TestCommandSender(), "test").join();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test").join();
 
         // Assert
         verify(executionHandler, never()).executeFuture(notNull());

--- a/cloud-core/src/test/java/cloud/commandframework/CommandPreProcessorTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandPreProcessorTest.java
@@ -61,9 +61,9 @@ public class CommandPreProcessorTest {
 
     @Test
     void testPreprocessing() {
-        Assertions.assertEquals(10, manager.executeCommand(new TestCommandSender(), "10 test value1")
+        Assertions.assertEquals(10, manager.commandExecutor().executeCommand(new TestCommandSender(), "10 test value1")
                 .join().commandContext().<Integer>optional("int").orElse(0));
-        manager.executeCommand(new TestCommandSender(), "aa test value1").join();
+        manager.commandExecutor().executeCommand(new TestCommandSender(), "aa test value1").join();
     }
 
 

--- a/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandTreeTest.java
@@ -176,7 +176,7 @@ class CommandTreeTest {
         );
 
         // Act
-        this.commandManager.executeCommand(new TestCommandSender(), "default 5").join();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "default 5").join();
 
         // Assert
         final ArgumentCaptor<CommandContext<TestCommandSender>> contextArgumentCaptor = ArgumentCaptor.forClass(
@@ -190,8 +190,10 @@ class CommandTreeTest {
 
     @Test
     void invalidCommand() {
-        assertThrows(CompletionException.class, () -> this.commandManager
-                .executeCommand(new TestCommandSender(), "invalid test").join());
+        assertThrows(CompletionException.class, () -> this.commandManager.commandExecutor().executeCommand(
+                new TestCommandSender(),
+                "invalid test"
+        ).join());
     }
 
     @Test
@@ -211,8 +213,8 @@ class CommandTreeTest {
         this.commandManager.command(this.commandManager.commandBuilder("proxy").proxies(toProxy).build());
 
         // Act
-        this.commandManager.executeCommand(new TestCommandSender(), "test unproxied foo 10 anotherliteral").join();
-        this.commandManager.executeCommand(new TestCommandSender(), "proxy foo 10").join();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test unproxied foo 10 anotherliteral").join();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "proxy foo 10").join();
 
         // Assert
         verify(executionHandler, times(2)).executeFuture(notNull());
@@ -247,7 +249,7 @@ class CommandTreeTest {
         final CommandExecutionHandler<TestCommandSender> executionHandler = this.setupFlags();
 
         // Act
-        this.commandManager.executeCommand(new TestCommandSender(), "flags").join();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "flags").join();
 
         // Assert
         final ArgumentCaptor<CommandContext<TestCommandSender>> contextArgumentCaptor = ArgumentCaptor.forClass(
@@ -265,7 +267,7 @@ class CommandTreeTest {
         final CommandExecutionHandler<TestCommandSender> executionHandler = this.setupFlags();
 
         // Act
-        this.commandManager.executeCommand(new TestCommandSender(), "flags --test").join();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "flags --test").join();
 
         // Assert
         final ArgumentCaptor<CommandContext<TestCommandSender>> contextArgumentCaptor = ArgumentCaptor.forClass(
@@ -283,7 +285,7 @@ class CommandTreeTest {
         final CommandExecutionHandler<TestCommandSender> executionHandler = this.setupFlags();
 
         // Act
-        this.commandManager.executeCommand(new TestCommandSender(), "flags -t").join();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "flags -t").join();
 
         // Assert
         final ArgumentCaptor<CommandContext<TestCommandSender>> contextArgumentCaptor = ArgumentCaptor.forClass(
@@ -303,7 +305,7 @@ class CommandTreeTest {
         // Act & Assert
         assertThrows(
                 CompletionException.class, () ->
-                        this.commandManager.executeCommand(new TestCommandSender(), "flags --test --nonexistent").join()
+                        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "flags --test --nonexistent").join()
         );
     }
 
@@ -313,7 +315,7 @@ class CommandTreeTest {
         final CommandExecutionHandler<TestCommandSender> executionHandler = this.setupFlags();
 
         // Act
-        this.commandManager.executeCommand(new TestCommandSender(), "flags --test --test2").join();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "flags --test --test2").join();
 
         // Assert
         final ArgumentCaptor<CommandContext<TestCommandSender>> contextArgumentCaptor = ArgumentCaptor.forClass(
@@ -334,7 +336,7 @@ class CommandTreeTest {
         // Act
         assertThrows(
                 CompletionException.class, () ->
-                        this.commandManager.executeCommand(new TestCommandSender(), "flags --test test2").join()
+                        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "flags --test test2").join()
         );
     }
 
@@ -344,7 +346,7 @@ class CommandTreeTest {
         final CommandExecutionHandler<TestCommandSender> executionHandler = this.setupFlags();
 
         // Act
-        this.commandManager.executeCommand(new TestCommandSender(), "flags --num 500").join();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "flags --num 500").join();
 
         // Assert
         final ArgumentCaptor<CommandContext<TestCommandSender>> contextArgumentCaptor = ArgumentCaptor.forClass(
@@ -362,7 +364,7 @@ class CommandTreeTest {
         final CommandExecutionHandler<TestCommandSender> executionHandler = this.setupFlags();
 
         // Act
-        this.commandManager.executeCommand(new TestCommandSender(), "flags --num 63 --enum potato --test").join();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "flags --num 63 --enum potato --test").join();
 
         // Assert
         final ArgumentCaptor<CommandContext<TestCommandSender>> contextArgumentCaptor = ArgumentCaptor.forClass(
@@ -381,7 +383,7 @@ class CommandTreeTest {
         final CommandExecutionHandler<TestCommandSender> executionHandler = this.setupFlags();
 
         // Act
-        this.commandManager.executeCommand(new TestCommandSender(), "flags -tf --num 63 --enum potato").join();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "flags -tf --num 63 --enum potato").join();
 
         // Assert
         final ArgumentCaptor<CommandContext<TestCommandSender>> contextArgumentCaptor = ArgumentCaptor.forClass(
@@ -530,8 +532,8 @@ class CommandTreeTest {
         );
 
         // Act
-        this.commandManager.executeCommand(new TestCommandSender(), "float 0.0").join();
-        this.commandManager.executeCommand(new TestCommandSender(), "float 100").join();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "float 0.0").join();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "float 100").join();
 
         // Assert
         final ArgumentCaptor<CommandContext<TestCommandSender>> contextArgumentCaptor = ArgumentCaptor.forClass(
@@ -560,7 +562,7 @@ class CommandTreeTest {
         );
 
         // Act
-        this.commandManager.executeCommand(new TestCommandSender(), "optionals").join();
+        this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "optionals").join();
 
         // Assert
         final ArgumentCaptor<CommandContext<TestCommandSender>> contextArgumentCaptor = ArgumentCaptor.forClass(

--- a/cloud-core/src/test/java/cloud/commandframework/ExecutionBenchmark.java
+++ b/cloud-core/src/test/java/cloud/commandframework/ExecutionBenchmark.java
@@ -69,6 +69,6 @@ public class ExecutionBenchmark {
     @Benchmark
     @Fork(3)
     public void testCommandParsing() {
-        manager.executeCommand(new TestCommandSender(), literalChain).join();
+        manager.commandExecutor().executeCommand(new TestCommandSender(), literalChain).join();
     }
 }

--- a/cloud-core/src/test/java/cloud/commandframework/PermissionTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/PermissionTest.java
@@ -103,10 +103,10 @@ class PermissionTest {
         when(this.permissionFunction.apply("first")).thenReturn(true);
 
         // Act
-        this.manager.executeCommand(new TestCommandSender(), "first").join();
+        this.manager.commandExecutor().executeCommand(new TestCommandSender(), "first").join();
         final CompletionException exception = assertThrows(
                 CompletionException.class,
-                () -> this.manager.executeCommand(new TestCommandSender(), "first 10").join()
+                () -> this.manager.commandExecutor().executeCommand(new TestCommandSender(), "first 10").join()
         );
 
         // Assert
@@ -223,12 +223,12 @@ class PermissionTest {
                 CloudKey.of("boolean"), $ -> condition.get()
         )));
         // First time should succeed
-        manager.executeCommand(new TestCommandSender(), "predicate").join();
+        manager.commandExecutor().executeCommand(new TestCommandSender(), "predicate").join();
         // Now we force it to fail
         condition.set(false);
         assertThrows(
                 CompletionException.class,
-                () -> manager.executeCommand(new TestCommandSender(), "predicate").join()
+                () -> manager.commandExecutor().executeCommand(new TestCommandSender(), "predicate").join()
         );
     }
 

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/DurationParserTest.java
@@ -56,20 +56,20 @@ class DurationParserTest {
 
     @Test
     void single_single_unit() {
-        final CommandResult<?> result1 = manager.executeCommand(new TestCommandSender(), "duration 2d").join();
+        final CommandResult<?> result1 = manager.commandExecutor().executeCommand(new TestCommandSender(), "duration 2d").join();
         assertThat(result1.commandContext().get(DURATION_KEY)).isEqualTo(Duration.ofDays(2));
 
-        final CommandResult<?> result2 = manager.executeCommand(new TestCommandSender(), "duration 999s").join();
+        final CommandResult<?> result2 = manager.commandExecutor().executeCommand(new TestCommandSender(), "duration 999s").join();
         assertThat(result2.commandContext().get(DURATION_KEY)).isEqualTo(Duration.ofSeconds(999));
     }
 
     @Test
     void single_multiple_units() {
-        final CommandResult<?> result1 = manager.executeCommand(new TestCommandSender(), "duration 2d12h7m34s").join();
+        final CommandResult<?> result1 = manager.commandExecutor().executeCommand(new TestCommandSender(), "duration 2d12h7m34s").join();
         assertThat(result1.commandContext().get(DURATION_KEY)).
                 isEqualTo(Duration.ofDays(2).plusHours(12).plusMinutes(7).plusSeconds(34));
 
-        final CommandResult<?> result2 = manager.executeCommand(new TestCommandSender(), "duration 700h75m1d999s").join();
+        final CommandResult<?> result2 = manager.commandExecutor().executeCommand(new TestCommandSender(), "duration 700h75m1d999s").join();
         assertThat(result2.commandContext().get(DURATION_KEY))
                 .isEqualTo(Duration.ofDays(1).plusHours(700).plusMinutes(75).plusSeconds(999));
     }
@@ -78,12 +78,12 @@ class DurationParserTest {
     void invalid_format_failing() {
         Assertions.assertThrows(
                 CompletionException.class,
-                () -> manager.executeCommand(new TestCommandSender(), "duration d").join()
+                () -> manager.commandExecutor().executeCommand(new TestCommandSender(), "duration d").join()
         );
 
         Assertions.assertThrows(
                 CompletionException.class,
-                () -> manager.executeCommand(new TestCommandSender(), "duration 1x").join()
+                () -> manager.commandExecutor().executeCommand(new TestCommandSender(), "duration 1x").join()
         );
     }
 }

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/StringArgumentTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/StringArgumentTest.java
@@ -64,7 +64,7 @@ class StringArgumentTest {
                 .build());
 
         // Act
-        final CommandResult<?> result = this.manager.executeCommand(new TestCommandSender(), "single string").join();
+        final CommandResult<?> result = this.manager.commandExecutor().executeCommand(new TestCommandSender(), "single string").join();
 
         // Assert
         assertThat(result.commandContext().get(MESSAGE1_KEY)).isEqualTo("string");
@@ -79,7 +79,7 @@ class StringArgumentTest {
                 .build());
 
         // Act
-        final CommandResult<?> result = this.manager.executeCommand(new TestCommandSender(),
+        final CommandResult<?> result = this.manager.commandExecutor().executeCommand(new TestCommandSender(),
                 "quoted 'quoted \" string' unquoted").join();
 
         // Assert
@@ -96,7 +96,7 @@ class StringArgumentTest {
                 .build());
 
         // Act
-        final CommandResult<?> result = this.manager.executeCommand(new TestCommandSender(), "quoted quoted unquoted").join();
+        final CommandResult<?> result = this.manager.commandExecutor().executeCommand(new TestCommandSender(), "quoted quoted unquoted").join();
 
         // Assert
         assertThat(result.commandContext().get(MESSAGE1_KEY)).isEqualTo("quoted");
@@ -112,7 +112,7 @@ class StringArgumentTest {
                 .build());
 
         // Act
-        final CommandResult<?> result = this.manager.executeCommand(new TestCommandSender(),
+        final CommandResult<?> result = this.manager.commandExecutor().executeCommand(new TestCommandSender(),
                 "quoted \"quoted \\\" string\" unquoted").join();
 
         // Assert
@@ -131,7 +131,7 @@ class StringArgumentTest {
         // Act & Assert
         Assertions.assertThrows(
                 CompletionException.class,
-                () -> manager.executeCommand(new TestCommandSender(), "'quoted quoted unquoted").join()
+                () -> manager.commandExecutor().executeCommand(new TestCommandSender(), "'quoted quoted unquoted").join()
         );
     }
 
@@ -144,7 +144,7 @@ class StringArgumentTest {
 
         // Act
         final CommandResult<?> result =
-                this.manager.executeCommand(new TestCommandSender(), "greedy greedy string content").join();
+                this.manager.commandExecutor().executeCommand(new TestCommandSender(), "greedy greedy string content").join();
 
         // Assert
         assertThat(result.commandContext().get(MESSAGE1_KEY)).isEqualTo("greedy string content");

--- a/cloud-core/src/test/java/cloud/commandframework/context/ParsingContextTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/context/ParsingContextTest.java
@@ -55,7 +55,7 @@ class ParsingContextTest {
         final String commandInput = "t 1337 roflmao xd";
 
         // Act
-        final CommandResult<TestCommandSender> result = this.commandManager.executeCommand(
+        final CommandResult<TestCommandSender> result = this.commandManager.commandExecutor().executeCommand(
                 new TestCommandSender(),
                 commandInput
         ).get();
@@ -78,7 +78,7 @@ class ParsingContextTest {
         final String commandInput = "t f bar";
 
         // Act
-        final CommandResult<TestCommandSender> result = this.commandManager.executeCommand(
+        final CommandResult<TestCommandSender> result = this.commandManager.commandExecutor().executeCommand(
                 new TestCommandSender(),
                 commandInput
         ).get();

--- a/cloud-core/src/test/java/cloud/commandframework/execution/CommandExecutionCoordinatorTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/execution/CommandExecutionCoordinatorTest.java
@@ -68,7 +68,7 @@ class CommandExecutionCoordinatorTest {
         // Act
         final CompletionException completionException = assertThrows(
                 CompletionException.class,
-                () -> commandManager.executeCommand(new TestCommandSender(), "test 123").join()
+                () -> commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test 123").join()
         );
 
         // Assert
@@ -106,7 +106,7 @@ class CommandExecutionCoordinatorTest {
         // Act
         final CompletionException completionException = assertThrows(
                 CompletionException.class,
-                () -> commandManager.executeCommand(new TestCommandSender(), "test 123").join()
+                () -> commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test 123").join()
         );
 
         // Assert
@@ -145,7 +145,7 @@ class CommandExecutionCoordinatorTest {
         // Act
         final CompletionException completionException = assertThrows(
                 CompletionException.class,
-                () -> commandManager.executeCommand(new TestCommandSender(), "test 123").join()
+                () -> commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test 123").join()
         );
 
         // Assert
@@ -195,7 +195,7 @@ class CommandExecutionCoordinatorTest {
         // Act
         final CompletionException completionException = assertThrows(
                 CompletionException.class,
-                () -> commandManager.executeCommand(new TestCommandSender(), "test 123").join()
+                () -> commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test 123").join()
         );
 
         // Assert

--- a/cloud-core/src/test/java/cloud/commandframework/feature/ArbitraryPositionFlagTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/feature/ArbitraryPositionFlagTest.java
@@ -67,7 +67,7 @@ class ArbitraryPositionFlagTest {
                 "test literal foo bar --flag");
 
         for (String cmd : passing) {
-            CommandResult<TestCommandSender> result = this.commandManager.executeCommand(new TestCommandSender(), cmd).join();
+            CommandResult<TestCommandSender> result = this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), cmd).join();
             assertThat(result.commandContext().flags().isPresent("flag")).isEqualTo(true);
         }
     }
@@ -94,7 +94,7 @@ class ArbitraryPositionFlagTest {
     }
 
     private Executable commandExecutable(String cmd) {
-        return () -> this.commandManager.executeCommand(new TestCommandSender(), cmd).join();
+        return () -> this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), cmd).join();
     }
 
 }

--- a/cloud-core/src/test/java/cloud/commandframework/feature/ChangedCommandSenderTypeTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/feature/ChangedCommandSenderTypeTest.java
@@ -63,7 +63,7 @@ class ChangedCommandSenderTypeTest {
         );
 
         // Assert
-        this.commandManager.executeCommand(new SubType(), "root literal 10").join();
+        this.commandManager.commandExecutor().executeCommand(new SubType(), "root literal 10").join();
     }
 
 

--- a/cloud-core/src/test/java/cloud/commandframework/feature/DefaultValueTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/feature/DefaultValueTest.java
@@ -54,7 +54,7 @@ class DefaultValueTest {
         );
 
         // Act
-        final CommandResult<TestCommandSender> result = this.commandManager.executeCommand(new TestCommandSender(), "test").get();
+        final CommandResult<TestCommandSender> result = this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test").get();
 
         // Assert
         assertThat(result.commandContext().get(key)).isEqualTo(5);
@@ -70,7 +70,7 @@ class DefaultValueTest {
         );
 
         // Act
-        final CommandResult<TestCommandSender> result = this.commandManager.executeCommand(new TestCommandSender(), "test").get();
+        final CommandResult<TestCommandSender> result = this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test").get();
 
         // Assert
         assertThat(result.commandContext().get(key)).isNotNull();
@@ -85,7 +85,7 @@ class DefaultValueTest {
         );
 
         // Act
-        final CommandResult<TestCommandSender> result = this.commandManager.executeCommand(new TestCommandSender(), "test").get();
+        final CommandResult<TestCommandSender> result = this.commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test").get();
 
         // Assert
         assertThat(result.commandContext().get(key)).isEqualTo(5);

--- a/cloud-core/src/test/java/cloud/commandframework/feature/RepeatableFlagTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/feature/RepeatableFlagTest.java
@@ -57,7 +57,7 @@ class RepeatableFlagTest {
         );
 
         // Act
-        final CommandResult<TestCommandSender> result = this.commandManager.executeCommand(
+        final CommandResult<TestCommandSender> result = this.commandManager.commandExecutor().executeCommand(
                 new TestCommandSender(),
                 "test --flag one --flag two --flag three"
         ).join();
@@ -79,7 +79,7 @@ class RepeatableFlagTest {
         );
 
         // Act
-        final CommandResult<TestCommandSender> result = this.commandManager.executeCommand(
+        final CommandResult<TestCommandSender> result = this.commandManager.commandExecutor().executeCommand(
                 new TestCommandSender(),
                 "test --flag -fff"
         ).join();

--- a/cloud-core/src/test/java/cloud/commandframework/issue/Issue281.java
+++ b/cloud-core/src/test/java/cloud/commandframework/issue/Issue281.java
@@ -70,7 +70,7 @@ class Issue281 {
         // Act
         final CompletionException exception = assertThrows(
                 CompletionException.class,
-                () -> commandManager.executeCommand(new TestCommandSender(), "test").join()
+                () -> commandManager.commandExecutor().executeCommand(new TestCommandSender(), "test").join()
         );
 
         // Assert

--- a/cloud-core/src/test/java/cloud/commandframework/issue/Issue321.java
+++ b/cloud-core/src/test/java/cloud/commandframework/issue/Issue321.java
@@ -50,7 +50,7 @@ class Issue321 {
         );
 
         // Act
-        final CommandResult<TestCommandSender> result = commandManager.executeCommand(
+        final CommandResult<TestCommandSender> result = commandManager.commandExecutor().executeCommand(
                 new TestCommandSender(),
                 "command --flag1 one two three --flag2 1 2 3"
         ).join();

--- a/cloud-discord/cloud-javacord/src/main/java/cloud/commandframework/javacord/JavacordCommand.java
+++ b/cloud-discord/cloud-javacord/src/main/java/cloud/commandframework/javacord/JavacordCommand.java
@@ -80,7 +80,7 @@ public class JavacordCommand<C> implements MessageCreateListener {
             return;
         }
 
-        this.manager.executeCommand(sender, finalContent, ctx ->
+        this.manager.commandExecutor().executeCommand(sender, finalContent, ctx ->
                         ctx.store(JavacordCommandManager.JAVACORD_COMMAND_SENDER_KEY, commandSender));
     }
 }

--- a/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/JDACommandListener.java
+++ b/cloud-discord/cloud-jda/src/main/java/cloud/commandframework/jda/JDACommandListener.java
@@ -62,6 +62,6 @@ public class JDACommandListener<C> extends ListenerAdapter {
             return;
         }
 
-        this.commandManager.executeCommand(sender, content.substring(prefix.length()));
+        this.commandManager.commandExecutor().executeCommand(sender, content.substring(prefix.length()));
     }
 }

--- a/cloud-irc/cloud-pircbotx/src/main/java/cloud/commandframework/pircbotx/CloudListenerAdapter.java
+++ b/cloud-irc/cloud-pircbotx/src/main/java/cloud/commandframework/pircbotx/CloudListenerAdapter.java
@@ -42,7 +42,7 @@ final class CloudListenerAdapter<C> extends ListenerAdapter {
             return;
         }
         final C sender = this.manager.getUserMapper().apply(event.getUser());
-        this.manager.executeCommand(
+        this.manager.commandExecutor().executeCommand(
                 sender,
                 message.substring(this.manager.getCommandPrefix().length()),
                 context -> context.store(PircBotXCommandManager.PIRCBOTX_MESSAGE_EVENT_KEY, event)

--- a/cloud-kotlin/cloud-kotlin-coroutines-annotations/src/main/kotlin/cloud/commandframework/kotlin/coroutines/annotations/KotlinAnnotatedMethods.kt
+++ b/cloud-kotlin/cloud-kotlin-coroutines-annotations/src/main/kotlin/cloud/commandframework/kotlin/coroutines/annotations/KotlinAnnotatedMethods.kt
@@ -65,7 +65,7 @@ public fun <C> AnnotationParser<C>.installCoroutineSupport(
     context: CoroutineContext = EmptyCoroutineContext,
     onlyForSuspending: Boolean = false
 ): AnnotationParser<C> {
-    if (manager().commandExecutionCoordinator() is CommandExecutionCoordinator.SimpleCoordinator) {
+    if (manager().commandExecutor().commandExecutionCoordinator() is CommandExecutionCoordinator.SimpleCoordinator) {
         RuntimeException(
             """You are highly advised to not use the simple command execution coordinator together
                             with coroutine support. Consider using the asynchronous command execution coordinator instead."""

--- a/cloud-kotlin/cloud-kotlin-coroutines-annotations/src/test/kotlin/cloud/commandframework/kotlin/coroutines/annotations/KotlinAnnotatedMethodsTest.kt
+++ b/cloud-kotlin/cloud-kotlin-coroutines-annotations/src/test/kotlin/cloud/commandframework/kotlin/coroutines/annotations/KotlinAnnotatedMethodsTest.kt
@@ -70,7 +70,7 @@ class KotlinAnnotatedMethodsTest {
             .installCoroutineSupport()
             .parse(CommandMethods())
 
-        commandManager.executeCommand(TestCommandSender(), "test").await()
+        commandManager.commandExecutor().executeCommand(TestCommandSender(), "test").await()
     }
 
     @Test
@@ -80,7 +80,7 @@ class KotlinAnnotatedMethodsTest {
             .parse(CommandMethods())
 
         assertThrows<CommandExecutionException> {
-            commandManager.executeCommand(TestCommandSender(), "test-exception").await()
+            commandManager.commandExecutor().executeCommand(TestCommandSender(), "test-exception").await()
         }
     }
 
@@ -90,7 +90,7 @@ class KotlinAnnotatedMethodsTest {
             .installCoroutineSupport()
             .parse(CommandMethods())
 
-        val result = commandManager.executeCommand(TestCommandSender(), "with-default").await()
+        val result = commandManager.commandExecutor().executeCommand(TestCommandSender(), "with-default").await()
         assertThat(result.commandContext().get<Int>("the-value")).isEqualTo(5)
     }
 

--- a/cloud-kotlin/cloud-kotlin-coroutines/src/test/kotlin/cloud/commandframework/kotlin/coroutines/SuspendingArgumentParserTest.kt
+++ b/cloud-kotlin/cloud-kotlin-coroutines/src/test/kotlin/cloud/commandframework/kotlin/coroutines/SuspendingArgumentParserTest.kt
@@ -61,7 +61,7 @@ class SuspendingArgumentParserTest {
             }
         }
 
-        manager.executeCommand(TestCommandSender(), "test 123").await()
+        manager.commandExecutor().executeCommand(TestCommandSender(), "test 123").await()
         assertThat(manager.suggestionFactory().suggest(TestCommandSender(), "test ").await()).containsExactly(
             Suggestion.simple("1"),
             Suggestion.simple("2"),

--- a/cloud-kotlin/cloud-kotlin-coroutines/src/test/kotlin/cloud/commandframework/kotlin/coroutines/SuspendingHandlerTest.kt
+++ b/cloud-kotlin/cloud-kotlin-coroutines/src/test/kotlin/cloud/commandframework/kotlin/coroutines/SuspendingHandlerTest.kt
@@ -52,7 +52,7 @@ class SuspendingHandlerTest {
             }
         }
 
-        manager.executeCommand(TestCommandSender(), "suspend").await()
+        manager.commandExecutor().executeCommand(TestCommandSender(), "suspend").await()
     }
 
     suspend fun someSuspendingFunction() {}

--- a/cloud-kotlin/cloud-kotlin-extensions/src/test/kotlin/cloud/commandframework/kotlin/CommandBuildingDSLTest.kt
+++ b/cloud-kotlin/cloud-kotlin-extensions/src/test/kotlin/cloud/commandframework/kotlin/CommandBuildingDSLTest.kt
@@ -90,8 +90,8 @@ class CommandBuildingDSLTest {
             }
         }
 
-        manager.executeCommand(SpecificCommandSender(), "kotlin dsl time")
-        manager.executeCommand(SpecificCommandSender(), "kotlin dsl time bruh_moment")
+        manager.commandExecutor().executeCommand(SpecificCommandSender(), "kotlin dsl time")
+        manager.commandExecutor().executeCommand(SpecificCommandSender(), "kotlin dsl time bruh_moment")
 
         Assertions.assertEquals(
             manager.createHelpHandler()

--- a/cloud-minecraft/cloud-brigadier/src/test/java/cloud/commandframework/brigadier/node/LiteralBrigadierNodeFactoryTest.java
+++ b/cloud-minecraft/cloud-brigadier/src/test/java/cloud/commandframework/brigadier/node/LiteralBrigadierNodeFactoryTest.java
@@ -30,6 +30,7 @@ import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.brigadier.CloudBrigadierManager;
 import cloud.commandframework.brigadier.suggestion.CloudDelegatingSuggestionProvider;
 import cloud.commandframework.brigadier.suggestion.TooltipSuggestion;
+import cloud.commandframework.context.StandardCommandContextFactory;
 import cloud.commandframework.execution.CommandExecutionCoordinator;
 import cloud.commandframework.internal.CommandRegistrationHandler;
 import cloud.commandframework.types.tuples.Pair;
@@ -70,7 +71,7 @@ class LiteralBrigadierNodeFactoryTest {
         this.commandManager = new TestCommandManager();
         final CloudBrigadierManager<Object, Object> cloudBrigadierManager = new CloudBrigadierManager<>(
                 this.commandManager,
-                () -> this.commandManager.commandContextFactory().create(false, new Object()),
+                () -> new StandardCommandContextFactory<>(this.commandManager).create(false, new Object()),
                 this.commandManager.suggestionFactory().mapped(TooltipSuggestion::tooltipSuggestion)
         );
         this.literalBrigadierNodeFactory = cloudBrigadierManager.literalBrigadierNodeFactory();

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommand.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommand.java
@@ -113,7 +113,7 @@ final class BukkitCommand<C> extends org.bukkit.command.Command implements Plugi
             builder.append(" ").append(string);
         }
         final C sender = this.manager.getCommandSenderMapper().apply(commandSender);
-        this.manager.executeCommand(sender, builder.toString());
+        this.manager.commandExecutor().executeCommand(sender, builder.toString());
         return true;
     }
 

--- a/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/BungeeCommand.java
+++ b/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/BungeeCommand.java
@@ -58,7 +58,7 @@ public final class BungeeCommand<C> extends Command implements TabExecutor {
             builder.append(" ").append(string);
         }
         final C sender = this.manager.getCommandSenderMapper().apply(commandSender);
-        this.manager.executeCommand(sender, builder.toString());
+        this.manager.commandExecutor().executeCommand(sender, builder.toString());
     }
 
     @Override

--- a/cloud-minecraft/cloud-cloudburst/src/main/java/cloud/commandframework/cloudburst/CloudburstCommand.java
+++ b/cloud-minecraft/cloud-cloudburst/src/main/java/cloud/commandframework/cloudburst/CloudburstCommand.java
@@ -65,7 +65,7 @@ final class CloudburstCommand<C> extends PluginCommand<Plugin> {
             builder.append(" ").append(string);
         }
         final C sender = this.manager.getCommandSenderMapper().apply(commandSender);
-        this.manager.executeCommand(sender, builder.toString());
+        this.manager.commandExecutor().executeCommand(sender, builder.toString());
         return true;
     }
 }

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/FabricExecutor.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/FabricExecutor.java
@@ -42,7 +42,7 @@ final class FabricExecutor<C, S extends SharedSuggestionProvider> implements Com
         final String input = ctx.getInput().substring(ctx.getLastChild().getNodes().get(0).getRange().getStart());
         final C sender = this.manager.commandSourceMapper().apply(source);
 
-        this.manager.executeCommand(sender, input);
+        this.manager.commandExecutor().executeCommand(sender, input);
         return com.mojang.brigadier.Command.SINGLE_SUCCESS;
     }
 }

--- a/cloud-minecraft/cloud-sponge7/src/main/java/cloud/commandframework/sponge7/CloudCommandCallable.java
+++ b/cloud-minecraft/cloud-sponge7/src/main/java/cloud/commandframework/sponge7/CloudCommandCallable.java
@@ -59,7 +59,7 @@ final class CloudCommandCallable<C> implements CommandCallable {
     public CommandResult process(final @NonNull CommandSource source, final @NonNull String arguments) {
         final C cloudSender = this.manager.getCommandSourceMapper().apply(source);
 
-        this.manager.executeCommand(cloudSender, this.formatCommand(arguments), ctx ->
+        this.manager.commandExecutor().executeCommand(cloudSender, this.formatCommand(arguments), ctx ->
                         ctx.store(SpongeCommandManager.SPONGE_COMMAND_SOURCE_KEY, source));
         return CommandResult.success();
     }

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/VelocityExecutor.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/VelocityExecutor.java
@@ -42,7 +42,7 @@ final class VelocityExecutor<C> implements Command<CommandSource> {
         final String input = commandContext.getInput();
         final C sender = this.manager.commandSenderMapper().apply(
                 source);
-        this.manager.executeCommand(sender, input);
+        this.manager.commandExecutor().executeCommand(sender, input);
         return com.mojang.brigadier.Command.SINGLE_SUCCESS;
     }
 }


### PR DESCRIPTION
This is basically just polluting the CommandManager API. We could skip exposing the getter altogether and require the platform implementations to construct this class separately, but that feels a bit overkill.