### PR TITLE
chore(core): make `ParserRegistry` easier to use

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/arguments/parser/ParserRegistry.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/parser/ParserRegistry.java
@@ -28,81 +28,114 @@ import io.leangen.geantyref.TypeToken;
 import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.Optional;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.common.returnsreceiver.qual.This;
 
 /**
- * Registry of {@link ArgumentParser} that allows these arguments to be
- * referenced by a {@link Class} (or really, a {@link TypeToken})
- * or a {@link String} key
+ * Registry that allows {@link ArgumentParser parsers} to be referenced by the type of the values they produce, or by their names.
  *
- * @param <C> Command sender type
+ * @param <C> command sender type
  */
 @API(status = API.Status.STABLE)
 public interface ParserRegistry<C> {
 
     /**
-     * Register a parser supplier
+     * Registers the given {@code supplier} as the default parser supplier for the given {@code type}.
      *
-     * @param type     The type that is parsed by the parser
-     * @param supplier The function that generates the parser. The map supplied my contain parameters used
-     *                 to configure the parser, many of which are documented in {@link StandardParameters}
-     * @param <T>      Generic type specifying what is produced by the parser
+     * @param type     type that is parsed by the parser
+     * @param supplier function that generates the parser
+     * @param <T>      generic type specifying what is produced by the parser
+     * @return {@code this}
      */
-    <T> void registerParserSupplier(
+    <T> @This ParserRegistry<C> registerParserSupplier(
             @NonNull TypeToken<T> type,
             @NonNull Function<@NonNull ParserParameters, @NonNull ArgumentParser<C, ?>> supplier
     );
 
     /**
-     * Register a named parser supplier
+     * Registers the parser described by the given {@code descriptor}.
      *
-     * @param name     Parser name
-     * @param supplier The function that generates the parser. The map supplied my contain parameters used
-     *                 to configure the parser, many of which are documented in {@link StandardParameters}
+     * <p>This does not allow for customization of the parser using parser parameters. If the parser has options then it is
+     * recommended to use {@link #registerParserSupplier(TypeToken, Function)} instead.</p>
+     *
+     * @param descriptor parser descriptor
+     * @param <T>        type produced by the parser
+     * @return {@code this}
+     * @since 2.0.0
      */
-    void registerNamedParserSupplier(
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    default <T> @This ParserRegistry<C> registerParser(final @NonNull ParserDescriptor<C, T> descriptor) {
+        return this.registerParserSupplier(descriptor.valueType(), parameters -> descriptor.parser());
+    }
+
+    /**
+     * Registers a named parser supplier.
+     *
+     * <p>The named parser will only be created if referenced by name using {@link #createParser(String, ParserParameters)}.
+     * Only unnamed parsers may be referenced by their value types.</p>
+     *
+     * @param name     parser name
+     * @param supplier the function that generates the parser
+     * @return {@code this}
+     */
+    @This ParserRegistry<C> registerNamedParserSupplier(
             @NonNull String name,
             @NonNull Function<@NonNull ParserParameters, @NonNull ArgumentParser<C, ?>> supplier
     );
 
     /**
-     * Register a mapper that maps annotation instances to a map of parameter-object pairs
+     * Registers a named parser supplier.
      *
-     * @param annotation Annotation class
-     * @param mapper     Mapper that maps the pair (annotation, type to be parsed) to a map of
-     *                   {@link ParserParameter parameter}-{@link Object object} pairs
-     * @param <A>        Annotation type
-     * @param <T>        Type of the object that the parser is retrieved for
+     * <p>This does not allow for customization of the parser using parser parameters. If the parser has options then it is
+     * recommended to use {@link #registerNamedParserSupplier(String, Function)} instead.</p>
+     *
+     * @param name       parser name
+     * @param descriptor parser descriptor
+     * @return {@code this}
      */
-    <A extends Annotation, T> void registerAnnotationMapper(
+    default @This ParserRegistry<C> registerNamedParser(
+            @NonNull String name,
+            @NonNull ParserDescriptor<C, ?> descriptor
+    ) {
+        return this.registerNamedParserSupplier(name, parameters -> descriptor.parser());
+    }
+
+    /**
+     * Registers a mapper that maps annotation instances to a map of parameter-object pairs.
+     *
+     * @param annotation annotation class
+     * @param mapper     mapper that maps the pair (annotation, type to be parsed) to a map of
+     *                   {@link ParserParameter parameter}-{@link Object object} pairs
+     * @param <A>        annotation type
+     * @return {@code this}
+     */
+    <A extends Annotation> @This ParserRegistry<C> registerAnnotationMapper(
             @NonNull Class<A> annotation,
-            @NonNull BiFunction<@NonNull A, @NonNull TypeToken<?>,
-                    @NonNull ParserParameters> mapper
+            @NonNull AnnotationMapper<A> mapper
     );
 
     /**
-     * Parse annotations into {@link ParserParameters}
+     * Parses the given {@code annotations} into {@link ParserParameters}.
      *
-     * @param parsingType The type that is produced by the parser that is requesting the parsing parameters
-     * @param annotations The annotations to be parsed
-     * @return Parsed parameters
+     * @param parsingType the type that is produced by the parser that is requesting the parsing parameters
+     * @param annotations annotations to be parsed
+     * @return the parsed parameters
      */
     @NonNull ParserParameters parseAnnotations(
             @NonNull TypeToken<?> parsingType,
-            @NonNull Collection<? extends Annotation> annotations
+            @NonNull Collection<@NonNull ? extends Annotation> annotations
     );
 
     /**
-     * Attempt to create a {@link ArgumentParser} for a specified type, using
-     * an instance of {@link ParserParameter} to configure the parser settings
+     * Attempts to create an instance of the default {@link ArgumentParser} for the given {@code type} using an instance of
+     * {@link ParserParameter} to configure the parser settings.
      *
-     * @param type             Type that should be produced by the parser
-     * @param parserParameters Parser parameters
-     * @param <T>              Generic type
-     * @return Parser, if one can be created
+     * @param type             type of values produced by the parser
+     * @param parserParameters parser parameters
+     * @param <T>              type of values produced by the parser
+     * @return the parser, if one could be created
      */
     <T> @NonNull Optional<ArgumentParser<C, T>> createParser(
             @NonNull TypeToken<T> type,
@@ -110,13 +143,13 @@ public interface ParserRegistry<C> {
     );
 
     /**
-     * Attempt to create a {@link ArgumentParser} for a specified type, using
-     * an instance of {@link ParserParameter} to configure the parser settings
+     * Attempts to create an instance of the parser {@link ArgumentParser} with the given {@code name} using an instance of
+     * {@link ParserParameter} to configure the parser settings.
      *
-     * @param name             Parser
-     * @param parserParameters Parser parameters
-     * @param <T>              Generic type
-     * @return Parser, if one can be created
+     * @param name             name of the parser
+     * @param parserParameters parser parameters
+     * @param <T>              type of values produced by the parser
+     * @return the parser, if one could be created
      */
     <T> @NonNull Optional<ArgumentParser<C, T>> createParser(
             @NonNull String name,
@@ -124,30 +157,40 @@ public interface ParserRegistry<C> {
     );
 
     /**
-     * Register a new named suggestion provider
+     * Registers a new named suggestion providers.
      *
-     * @param name               Name of the suggestion provider. The name is case independent.
-     * @param suggestionProvider The suggestion provider
+     * @param name               name of the suggestion provider. The name is case independent.
+     * @param suggestionProvider the suggestion provider
      * @see #getSuggestionProvider(String) Get a suggestion provider
-     * @since 1.1.0
+     * @since 2.0.0
      */
     @API(status = API.Status.STABLE, since = "2.0.0")
-    void registerSuggestionProvider(
-            @NonNull String name,
-            @NonNull SuggestionProvider<C> suggestionProvider
-    );
+    void registerSuggestionProvider(@NonNull String name, @NonNull SuggestionProvider<C> suggestionProvider);
 
     /**
-     * Get a named suggestion provider, if a suggestion provider with the given name exists in the registry
+     * Returns a named suggestion provider, if it exists.
      *
-     * @param name Suggestion provider name. The name is case independent.
-     * @return Optional that either contains the suggestion provider, or is empty if no
+     * @param name case-independent suggestion provider name
+     * @return optional that either contains the suggestion provider, or is empty if no
      *         suggestion provider is registered with the given name
      * @see #registerSuggestionProvider(String, SuggestionProvider) Register a suggestion provider
      * @since 2.0.0
      */
     @API(status = API.Status.STABLE, since = "2.0.0")
-    @NonNull Optional<SuggestionProvider<C>> getSuggestionProvider(
-            @NonNull String name
-    );
+    @NonNull Optional<SuggestionProvider<C>> getSuggestionProvider(@NonNull String name);
+
+
+    @FunctionalInterface
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    interface AnnotationMapper<A extends Annotation> {
+
+        /**
+         * Returns the {@link ParserParameters parser parameters} that correspond to the given {@code annotation}.
+         *
+         * @param annotation annotation instance
+         * @param parsedType type produced by the parser that is being constructed
+         * @return the parameters
+         */
+        @NonNull ParserParameters mapAnnotation(@NonNull A annotation, @NonNull TypeToken<?> parsedType);
+    }
 }

--- a/cloud-irc/cloud-pircbotx/src/main/java/cloud/commandframework/pircbotx/PircBotXCommandManager.java
+++ b/cloud-irc/cloud-pircbotx/src/main/java/cloud/commandframework/pircbotx/PircBotXCommandManager.java
@@ -39,7 +39,6 @@ import cloud.commandframework.execution.ExecutionCoordinator;
 import cloud.commandframework.internal.CommandRegistrationHandler;
 import cloud.commandframework.keys.CloudKey;
 import cloud.commandframework.pircbotx.arguments.UserParser;
-import io.leangen.geantyref.TypeToken;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.apiguardian.api.API;
@@ -134,10 +133,7 @@ public class PircBotXCommandManager<C> extends CommandManager<C> {
             );
         }
         this.registerCommandPreProcessor(context -> context.commandContext().store(PIRCBOTX_META_KEY, pircBotX));
-        this.parserRegistry().registerParserSupplier(
-                TypeToken.get(User.class),
-                parameters -> new UserParser<>()
-        );
+        this.parserRegistry().registerParser(UserParser.userParser());
 
         // No "native" command system means that we can delete commands just fine.
         this.registerCapability(CloudCapability.StandardCapabilities.ROOT_COMMAND_DELETION);

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandManager.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandManager.java
@@ -38,9 +38,6 @@ import cloud.commandframework.bukkit.annotation.specifier.DefaultNamespace;
 import cloud.commandframework.bukkit.annotation.specifier.RequireExplicitNamespace;
 import cloud.commandframework.bukkit.data.MultipleEntitySelector;
 import cloud.commandframework.bukkit.data.MultiplePlayerSelector;
-import cloud.commandframework.bukkit.data.ProtoItemStack;
-import cloud.commandframework.bukkit.data.SingleEntitySelector;
-import cloud.commandframework.bukkit.data.SinglePlayerSelector;
 import cloud.commandframework.bukkit.internal.CraftBukkitReflection;
 import cloud.commandframework.bukkit.parsers.BlockPredicateParser;
 import cloud.commandframework.bukkit.parsers.EnchantmentParser;
@@ -51,7 +48,6 @@ import cloud.commandframework.bukkit.parsers.NamespacedKeyParser;
 import cloud.commandframework.bukkit.parsers.OfflinePlayerParser;
 import cloud.commandframework.bukkit.parsers.PlayerParser;
 import cloud.commandframework.bukkit.parsers.WorldParser;
-import cloud.commandframework.bukkit.parsers.location.Location2D;
 import cloud.commandframework.bukkit.parsers.location.Location2DParser;
 import cloud.commandframework.bukkit.parsers.location.LocationParser;
 import cloud.commandframework.bukkit.parsers.selector.MultipleEntitySelectorParser;
@@ -73,13 +69,7 @@ import java.util.concurrent.Executor;
 import java.util.logging.Level;
 import org.apiguardian.api.API;
 import org.bukkit.ChatColor;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.OfflinePlayer;
-import org.bukkit.World;
 import org.bukkit.command.CommandSender;
-import org.bukkit.enchantments.Enchantment;
-import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -144,28 +134,19 @@ public class BukkitCommandManager<C> extends CommandManager<C>
         this.registerCommandPreProcessor(new BukkitCommandPreprocessor<>(this));
 
         /* Register Bukkit Parsers */
-        this.parserRegistry().registerParserSupplier(TypeToken.get(World.class), parserParameters ->
-                new WorldParser<>());
-        this.parserRegistry().registerParserSupplier(TypeToken.get(Material.class), parserParameters ->
-                new MaterialParser<>());
-        this.parserRegistry().registerParserSupplier(TypeToken.get(Player.class), parserParameters ->
-                new PlayerParser<>());
-        this.parserRegistry().registerParserSupplier(TypeToken.get(OfflinePlayer.class), parserParameters ->
-                new OfflinePlayerParser<>());
-        this.parserRegistry().registerParserSupplier(TypeToken.get(Enchantment.class), parserParameters ->
-                new EnchantmentParser<>());
-        this.parserRegistry().registerParserSupplier(TypeToken.get(Location.class), parserParameters ->
-                new LocationParser<>());
-        this.parserRegistry().registerParserSupplier(TypeToken.get(Location2D.class), parserParameters ->
-                new Location2DParser<>());
-        this.parserRegistry().registerParserSupplier(TypeToken.get(ProtoItemStack.class), parserParameters ->
-                new ItemStackParser<>());
+        this.parserRegistry()
+                .registerParser(WorldParser.worldParser())
+                .registerParser(MaterialParser.materialParser())
+                .registerParser(PlayerParser.playerParser())
+                .registerParser(OfflinePlayerParser.offlinePlayerParser())
+                .registerParser(EnchantmentParser.enchantmentParser())
+                .registerParser(LocationParser.locationParser())
+                .registerParser(Location2DParser.location2DParser())
+                .registerParser(ItemStackParser.itemStackParser())
+                .registerParser(SingleEntitySelectorParser.singleEntitySelectorParser())
+                .registerParser(SinglePlayerSelectorParser.singlePlayerSelectorParser());
 
         /* Register Entity Selector Parsers */
-        this.parserRegistry().registerParserSupplier(TypeToken.get(SingleEntitySelector.class), parserParameters ->
-                new SingleEntitySelectorParser<>());
-        this.parserRegistry().registerParserSupplier(TypeToken.get(SinglePlayerSelector.class), parserParameters ->
-                new SinglePlayerSelectorParser<>());
         this.parserRegistry().registerAnnotationMapper(
                 AllowEmptySelection.class,
                 (annotation, type) -> ParserParameters.single(

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/BlockPredicateParser.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/BlockPredicateParser.java
@@ -38,7 +38,6 @@ import cloud.commandframework.bukkit.internal.RegistryReflection;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.context.CommandInput;
 import com.mojang.brigadier.arguments.ArgumentType;
-import io.leangen.geantyref.TypeToken;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.Objects;
@@ -234,8 +233,7 @@ public final class BlockPredicateParser<C> implements ArgumentParser.FutureArgum
      */
     @SuppressWarnings("unused")
     private static <C> void registerParserSupplier(final @NonNull BukkitCommandManager<C> commandManager) {
-        commandManager.parserRegistry()
-                .registerParserSupplier(TypeToken.get(BlockPredicate.class), params -> new BlockPredicateParser<>());
+        commandManager.parserRegistry().registerParser(BlockPredicateParser.blockPredicateParser());
     }
 
 

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/ItemStackPredicateParser.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/ItemStackPredicateParser.java
@@ -38,7 +38,6 @@ import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.context.CommandInput;
 import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.context.StringRange;
-import io.leangen.geantyref.TypeToken;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.Collections;
@@ -182,10 +181,7 @@ public final class ItemStackPredicateParser<C> implements ArgumentParser.FutureA
      */
     @SuppressWarnings("unused")
     private static <C> void registerParserSupplier(final @NonNull BukkitCommandManager<C> commandManager) {
-        commandManager.parserRegistry().registerParserSupplier(
-                TypeToken.get(ItemStackPredicate.class),
-                params -> new ItemStackPredicateParser<>()
-        );
+        commandManager.parserRegistry().registerParser(ItemStackPredicateParser.itemStackPredicateParser());
     }
 
     @Override

--- a/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/BungeeCommandManager.java
+++ b/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/BungeeCommandManager.java
@@ -36,13 +36,10 @@ import cloud.commandframework.exceptions.InvalidSyntaxException;
 import cloud.commandframework.exceptions.NoPermissionException;
 import cloud.commandframework.exceptions.NoSuchCommandException;
 import cloud.commandframework.execution.ExecutionCoordinator;
-import io.leangen.geantyref.TypeToken;
 import java.util.logging.Level;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.chat.ComponentBuilder;
-import net.md_5.bungee.api.config.ServerInfo;
-import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Plugin;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -89,10 +86,9 @@ public class BungeeCommandManager<C> extends CommandManager<C> implements Sender
         this.registerCommandPreProcessor(new BungeeCommandPreprocessor<>(this));
 
         /* Register Bungee Parsers */
-        this.parserRegistry().registerParserSupplier(TypeToken.get(ProxiedPlayer.class), parserParameters ->
-                new PlayerParser<>());
-        this.parserRegistry().registerParserSupplier(TypeToken.get(ServerInfo.class), parserParameters ->
-                new ServerParser<>());
+        this.parserRegistry()
+                .registerParser(PlayerParser.playerParser())
+                .registerParser(ServerParser.serverParser());
 
         /* Register default captions */
         if (this.captionRegistry() instanceof FactoryDelegatingCaptionRegistry) {

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/VelocityCommandManager.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/VelocityCommandManager.java
@@ -48,10 +48,7 @@ import com.google.inject.Singleton;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.event.player.ServerPreConnectEvent;
 import com.velocitypowered.api.plugin.PluginContainer;
-import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
-import com.velocitypowered.api.proxy.server.RegisteredServer;
-import io.leangen.geantyref.TypeToken;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -122,10 +119,9 @@ public class VelocityCommandManager<C> extends CommandManager<C>
         this.registerCommandPreProcessor(new VelocityCommandPreprocessor<>(this));
 
         /* Register Velocity Parsers */
-        this.parserRegistry().registerParserSupplier(TypeToken.get(Player.class), parserParameters ->
-                new PlayerParser<>());
-        this.parserRegistry().registerParserSupplier(TypeToken.get(RegisteredServer.class), parserParameters ->
-                new ServerParser<>());
+        this.parserRegistry()
+                .registerParser(PlayerParser.playerParser())
+                .registerParser(ServerParser.serverParser());
 
         /* Register default captions */
         if (this.captionRegistry() instanceof FactoryDelegatingCaptionRegistry) {


### PR DESCRIPTION
It now allows for chained registration calls.

You may also register a `ParserDescriptor` for parsers without configurable options, which also means that we don't have to create a new parser instance every time the parser is requested. The parsers are stateless according to their contracts.