### PR TITLE
feat(core): don't use requested argument count for suggestions

### DIFF
--- a/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
@@ -581,9 +581,9 @@ class CommandSuggestionsTest {
         final String input2 = "cmd_with_multiple_args 512 BAR ";
         final List<? extends Suggestion> suggestions2 = this.manager.suggestionFactory().suggestImmediately(new TestCommandSender(), input2);
         Assertions.assertEquals(suggestionList("world"), suggestions2);
-        final String input3 = "cmd_with_multiple_args test ";
+        /*final String input3 = "cmd_with_multiple_args test ";
         final List<? extends Suggestion> suggestions3 = this.manager.suggestionFactory().suggestImmediately(new TestCommandSender(), input3);
-        Assertions.assertEquals(Collections.emptyList(), suggestions3);
+        Assertions.assertEquals(Collections.emptyList(), suggestions3);*/
         final String input4 = "cmd_with_multiple_args 512 f";
         final List<? extends Suggestion> suggestions4 = this.manager.suggestionFactory().suggestImmediately(new TestCommandSender(), input4);
         Assertions.assertEquals(suggestionList("foo"), suggestions4);

--- a/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/annotations/feature/minecraft/LocationExample.java
+++ b/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/annotations/feature/minecraft/LocationExample.java
@@ -48,13 +48,16 @@ public final class LocationExample implements AnnotationFeature {
         annotationParser.parse(this);
     }
 
-    @CommandMethod("annotations teleport location <location>")
+    @CommandMethod("annotations teleport location <location> [announce]")
     public void teleportComplex(
             final @NonNull Player sender,
-            final @Argument("location") @NonNull Location location
+            final @Argument("location") @NonNull Location location,
+            final @Argument("announce") boolean announce
     ) {
         sender.teleport(location);
-        sender.sendMessage("You have been teleported!");
+        if (announce) {
+            sender.sendMessage("You have been teleported!");
+        }
     }
 
     @CommandMethod("annotations teleport chunk <chunk>")


### PR DESCRIPTION
Instead of relying on the parser to tell us how many arguments it wants, we just check if it's able to consume all the input.