### PR TITLE
feat: make suggestion providers accept CommandInput

### DIFF
--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/AnnotationParser.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/AnnotationParser.java
@@ -747,11 +747,13 @@ public final class AnnotationParser<C> {
                 valid = false;
             } else if (method.getParameterCount() == 3) {
                 valid = method.getParameters()[0].getType().equals(CommandContext.class)
-                        && method.getParameters()[1].getType().equals(String.class)
+                        && (method.getParameters()[1].getType().equals(String.class)
+                            || method.getParameters()[1].getType().equals(CommandInput.class))
                         && method.getParameters()[2].getType().getSimpleName().equals("Continuation");
             } else {
                 valid = method.getParameters()[0].getType().equals(CommandContext.class)
-                        && method.getParameters()[1].getType().equals(String.class);
+                        && (method.getParameters()[1].getType().equals(String.class)
+                            || method.getParameters()[1].getType().equals(CommandInput.class));
             }
 
             valid = valid

--- a/cloud-annotations/src/main/java/cloud/commandframework/annotations/suggestions/Suggestions.java
+++ b/cloud-annotations/src/main/java/cloud/commandframework/annotations/suggestions/Suggestions.java
@@ -34,14 +34,15 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 /**
  * This annotation allows you to create annotated methods that behave like suggestion providers.
  * <p>
- * The method must take in the following parameters in the given order: {@link CommandContext} and
- * {@link String}. The method must return a collection or stream of either {@link String} or {@link Suggestion}.
+ * The method must take in the following parameters in the given order: {@link CommandContext} and either
+ * {@link cloud.commandframework.context.CommandInput} or {@link String}. The method must return a collection or stream of either
+ * {@link String} or {@link Suggestion}.
  * Example signatures: <pre>{@code
  * ﹫Suggestions("name")
- * public List<String> methodName(CommandContext<YourSender> sender, String input)}</pre>
+ * public List<String> methodName(CommandContext<YourSender> sender, CommandInput input)}</pre>
  * <pre>{@code
  * ﹫Suggestions("name")
- * public List<Suggestion> methodName(CommandContext<YourSender> sender, String input)}</pre>
+ * public List<Suggestion> methodName(CommandContext<YourSender> sender, CommandInput input)}</pre>
  * <pre>{@code
  * ﹫Suggestions("name")
  * public Stream<Suggestion> methodName(CommandContext<YourSender> sender, String input)}</pre>

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/AnnotationParserTest.java
@@ -161,8 +161,8 @@ class AnnotationParserTest {
                 this.manager.parserRegistry().getSuggestionProvider("cows").orElse(null);
 
         assertThat(suggestionProvider).isNotNull();
-        assertThat(suggestionProvider.suggestionsFuture(new CommandContext<>(new TestCommandSender(), manager), "").join())
-                .contains(Suggestion.simple("Stella"));
+        assertThat(suggestionProvider.suggestionsFuture(new CommandContext<>(new TestCommandSender(), manager),
+                CommandInput.empty()).join()).contains(Suggestion.simple("Stella"));
     }
 
     @Test
@@ -177,7 +177,8 @@ class AnnotationParserTest {
         );
         assertThat(parser.parse(context, CommandInput.empty()).parsedValue().orElse(new CustomType("")).toString())
                 .isEqualTo("yay");
-        assertThat(parser.suggestionProvider().suggestionsFuture(context, "").join()).contains(Suggestion.simple("Stella"));
+        assertThat(parser.suggestionProvider().suggestionsFuture(context, CommandInput.empty()).join())
+                .contains(Suggestion.simple("Stella"));
     }
 
     @Test

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/MethodSuggestionProviderTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/MethodSuggestionProviderTest.java
@@ -31,6 +31,7 @@ import cloud.commandframework.annotations.suggestions.Suggestions;
 import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.context.CommandContextFactory;
+import cloud.commandframework.context.CommandInput;
 import cloud.commandframework.context.StandardCommandContextFactory;
 import java.util.Collections;
 import java.util.List;
@@ -74,7 +75,7 @@ class MethodSuggestionProviderTest {
                 this.commandManager.parserRegistry()
                         .getSuggestionProvider("suggestions")
                         .orElseThrow(NullPointerException::new)
-                        .suggestionsFuture(context, "")
+                        .suggestionsFuture(context, CommandInput.empty())
                         .join();
 
         // Assert

--- a/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/MethodSuggestionProviderTest.java
+++ b/cloud-annotations/src/test/java/cloud/commandframework/annotations/feature/MethodSuggestionProviderTest.java
@@ -88,7 +88,8 @@ class MethodSuggestionProviderTest {
                 new TestClassSet(),
                 new TestClassStream(),
                 new TestClassIterable(),
-                new TestClassListString()
+                new TestClassListString(),
+                new TestClassCommandInput()
         );
     }
 
@@ -143,6 +144,17 @@ class MethodSuggestionProviderTest {
         public @NonNull List<@NonNull String> suggestions(
                 final @NonNull CommandContext<TestCommandSender> context,
                 final @NonNull String input
+        ) {
+            return Collections.singletonList("foo");
+        }
+    }
+
+    public static final class TestClassCommandInput {
+
+        @Suggestions("suggestions")
+        public @NonNull List<@NonNull String> suggestions(
+                final @NonNull CommandContext<TestCommandSender> context,
+                final @NonNull CommandInput input
         ) {
             return Collections.singletonList("foo");
         }

--- a/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
@@ -719,7 +719,7 @@ public final class CommandTree<C> {
         final CommandComponent<C> component = Objects.requireNonNull(node.component());
         context.commandContext().currentComponent(component);
         return component.suggestionProvider()
-                .suggestionsFuture(context.commandContext(), input.copy())
+                .suggestionsFuture(context.commandContext(), input.copy().skipWhitespace(false))
                 .thenApply(suggestionsToAdd -> {
                     final String string = input.peekString();
                     for (Suggestion suggestion : suggestionsToAdd) {
@@ -944,7 +944,7 @@ public final class CommandTree<C> {
     ) {
         context.commandContext().currentComponent(component);
         return component.suggestionProvider()
-                .suggestionsFuture(context.commandContext(), input.copy())
+                .suggestionsFuture(context.commandContext(), input.copy().skipWhitespace(false))
                 .thenAccept(context::addSuggestions)
                 .thenApply(in -> context);
     }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/LiteralParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/LiteralParser.java
@@ -39,7 +39,7 @@ import java.util.TreeSet;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-public final class LiteralParser<C> implements ArgumentParser<C, String>, BlockingSuggestionProvider.ConstantStrings<C> {
+public final class LiteralParser<C> implements ArgumentParser<C, String>, BlockingSuggestionProvider.Strings<C> {
 
     /**
      * Creates a new literal parser that accepts the given {@code name} and {@code aliases}.
@@ -90,7 +90,8 @@ public final class LiteralParser<C> implements ArgumentParser<C, String>, Blocki
     }
 
     @Override
-    public @NonNull Iterable<@NonNull String> stringSuggestions() {
+    public @NonNull Iterable<@NonNull String> stringSuggestions(final @NonNull CommandContext<C> commandContext,
+                                                                final @NonNull CommandInput input) {
         return Collections.singletonList(this.name);
     }
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/LiteralParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/LiteralParser.java
@@ -39,7 +39,7 @@ import java.util.TreeSet;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-public final class LiteralParser<C> implements ArgumentParser<C, String>, BlockingSuggestionProvider.Strings<C> {
+public final class LiteralParser<C> implements ArgumentParser<C, String>, BlockingSuggestionProvider.ConstantStrings<C> {
 
     /**
      * Creates a new literal parser that accepts the given {@code name} and {@code aliases}.
@@ -90,10 +90,7 @@ public final class LiteralParser<C> implements ArgumentParser<C, String>, Blocki
     }
 
     @Override
-    public @NonNull Iterable<@NonNull String> stringSuggestions(
-            final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
-    ) {
+    public @NonNull Iterable<@NonNull String> stringSuggestions() {
         return Collections.singletonList(this.name);
     }
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParser.java
@@ -27,12 +27,10 @@ import cloud.commandframework.CommandComponent;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
 import cloud.commandframework.arguments.parser.ParserDescriptor;
-import cloud.commandframework.arguments.suggestion.Suggestion;
 import cloud.commandframework.arguments.suggestion.SuggestionProvider;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.context.CommandInput;
 import cloud.commandframework.keys.CloudKey;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apiguardian.api.API;
@@ -58,8 +56,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  * @since 2.0.0
  */
 @API(status = API.Status.STABLE, since = "2.0.0")
-public interface AggregateCommandParser<C, O> extends ArgumentParser.FutureArgumentParser<C, O>, ParserDescriptor<C, O>,
-        SuggestionProvider<C> {
+public interface AggregateCommandParser<C, O> extends ArgumentParser.FutureArgumentParser<C, O>, ParserDescriptor<C, O> {
 
     /**
      * Returns a new aggregate command parser builder. The builder is immutable, and each method returns
@@ -101,7 +98,7 @@ public interface AggregateCommandParser<C, O> extends ArgumentParser.FutureArgum
                             return ArgumentParseResult.failureFuture(result.failure().get());
                         }
                         return component.parser()
-                                .parseFuture(commandContext, commandInput)
+                                .parseFuture(commandContext, commandInput.skipWhitespace(1))
                                 .thenApply(value -> {
                                     if (value.parsedValue().isPresent()) {
                                         final CloudKey key = CloudKey.of(component.name(), component.valueType());
@@ -120,17 +117,8 @@ public interface AggregateCommandParser<C, O> extends ArgumentParser.FutureArgum
     }
 
     @Override
-    default @NonNull CompletableFuture<@NonNull Iterable<@NonNull Suggestion>> suggestionsFuture(
-            final @NonNull CommandContext<C> context,
-            final @NonNull CommandInput input
-    ) {
-        return this.components()
-                .stream()
-                .filter(arg -> !context.contains(arg.name()))
-                .map(CommandComponent::suggestionProvider)
-                .map(suggestionProvider -> suggestionProvider.suggestionsFuture(context, input))
-                .findFirst()
-                .orElse(CompletableFuture.completedFuture(Collections.emptyList()));
+    default @NonNull SuggestionProvider<C> suggestionProvider() {
+        return new AggregateSuggestionProvider<>(this);
     }
 
     @Override

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParser.java
@@ -122,11 +122,6 @@ public interface AggregateCommandParser<C, O> extends ArgumentParser.FutureArgum
     }
 
     @Override
-    default int getRequestedArgumentCount() {
-        return this.components().stream().map(CommandComponent::parser).mapToInt(ArgumentParser::getRequestedArgumentCount).sum();
-    }
-
-    @Override
     default @NonNull ArgumentParser<C, O> parser() {
         return this;
     }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateCommandParser.java
@@ -122,7 +122,7 @@ public interface AggregateCommandParser<C, O> extends ArgumentParser.FutureArgum
     @Override
     default @NonNull CompletableFuture<@NonNull Iterable<@NonNull Suggestion>> suggestionsFuture(
             final @NonNull CommandContext<C> context,
-            final @NonNull String input
+            final @NonNull CommandInput input
     ) {
         return this.components()
                 .stream()

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateSuggestionProvider.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/aggregate/AggregateSuggestionProvider.java
@@ -1,0 +1,120 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.arguments.aggregate;
+
+import cloud.commandframework.CommandComponent;
+import cloud.commandframework.arguments.parser.ArgumentParseResult;
+import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.context.CommandInput;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+@API(status = API.Status.INTERNAL, since = "2.0.0")
+final class AggregateSuggestionProvider<C> implements SuggestionProvider<C> {
+
+    private final AggregateCommandParser<C, ?> parser;
+
+    AggregateSuggestionProvider(final @NonNull AggregateCommandParser<C, ?> parser) {
+        this.parser = parser;
+    }
+
+    @Override
+    public @NonNull CompletableFuture<@NonNull Iterable<@NonNull Suggestion>> suggestionsFuture(
+            final @NonNull CommandContext<C> context,
+            final @NonNull CommandInput input
+    ) {
+        // We store a copy of the original input so that we can calculate the difference.
+        final CommandInput originalInput = input.copy();
+
+        return new ParsingInstance(context, input).parseComponent()
+                .thenCompose(component -> component.suggestionProvider().suggestionsFuture(
+                        context,
+                        input.skipWhitespace(1, false).copy() // There might be whitespace left over from the parsing.
+
+                )).thenApply(suggestions -> {
+                    final String prefix = originalInput.difference(input, true /* includeTrailingWhitespace */);
+                    final List<Suggestion> prefixedSuggestions = new ArrayList<>();
+                    for (final Suggestion suggestion : suggestions) {
+                        prefixedSuggestions.add(suggestion.withSuggestion(
+                                String.format("%s%s", prefix, suggestion.suggestion())));
+                    }
+                    return prefixedSuggestions;
+                });
+    }
+
+    private final class ParsingInstance {
+
+        private final Iterator<CommandComponent<C>> components = AggregateSuggestionProvider.this.parser.components().iterator();
+        private final CommandContext<C> context;
+        private final CommandInput input;
+
+        private CommandComponent<C> component;
+        private int previousCursor;
+
+        private ParsingInstance(final @NonNull CommandContext<C> context, final @NonNull CommandInput input) {
+            this.context = context;
+            this.input = input;
+        }
+
+        private @NonNull CompletableFuture<CommandComponent<C>> parseComponent() {
+            if (!this.components.hasNext()) {
+                return CompletableFuture.completedFuture(this.component);
+            }
+
+            // We store the current component and cursor position so that we can invoke the component for suggestions.
+            // The cursor is stored so that we can restore the cursor once we're done with the parsing.
+            this.component = this.components.next();
+            this.previousCursor = this.input.cursor();
+
+            return this.component.parser()
+                    .parseFuture(this.context, this.input.skipWhitespace(1))
+                    .thenCompose(this::handleResult);
+        }
+
+        private @NonNull CompletableFuture<CommandComponent<C>> handleResult(final @NonNull ArgumentParseResult<?> result) {
+            if (result.failure().isPresent() || !this.components.hasNext()) {
+                // We reset the cursor to whatever it was before parsing in the instance that this is the component we want
+                // to provide suggestions for. We do this if it's the last component, or if the parsing failed.
+                this.input.cursor(this.previousCursor);
+            }
+
+            // If the parsing failed then we know that we want to provide suggestions for this component.
+            if (result.failure().isPresent()) {
+                return CompletableFuture.completedFuture(this.component);
+            }
+
+            // We store the value in the context so that it can be accessed from the suggestion providers.
+            result.parsedValue().ifPresent(value -> this.context.store(this.component.name(), value));
+
+            // If the parsing succeeded then we'll attempt to parse the subsequent component as well.
+            return this.parseComponent();
+        }
+    }
+}

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/flags/CommandFlagParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/flags/CommandFlagParser.java
@@ -146,7 +146,7 @@ public final class CommandFlagParser<C> implements ArgumentParser.FutureArgument
     @SuppressWarnings({"unchecked", "rawtypes"})
     public @NonNull CompletableFuture<Iterable<@NonNull Suggestion>> suggestionsFuture(
             final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
+            final @NonNull CommandInput input
     ) {
         /* Check if we have a last flag stored */
         final String lastArg = Objects.requireNonNull(commandContext.getOrDefault(FLAG_META_KEY, ""));
@@ -193,7 +193,8 @@ public final class CommandFlagParser<C> implements ArgumentParser.FutureArgument
                 suggestions.add(Suggestion.simple(String.format("--%s", flag.getName())));
             }
             /* Recommend aliases */
-            final boolean suggestCombined = input.length() > 1 && input.charAt(0) == '-' && input.charAt(1) != '-';
+            final String nextToken = input.peekString();
+            final boolean suggestCombined = nextToken.length() > 1 && nextToken.startsWith("-") && !nextToken.startsWith("--");
             for (final CommandFlag<?> flag : this.flags) {
                 if (usedFlags.contains(flag) && flag.mode() != CommandFlag.FlagMode.REPEATABLE) {
                     continue;
@@ -204,7 +205,7 @@ public final class CommandFlagParser<C> implements ArgumentParser.FutureArgument
 
                 for (final String alias : flag.getAliases()) {
                     if (suggestCombined && flag.commandComponent() == null) {
-                        suggestions.add(Suggestion.simple(String.format("%s%s", input, alias)));
+                        suggestions.add(Suggestion.simple(String.format("%s%s", input.peekString(), alias)));
                     } else {
                         suggestions.add(Suggestion.simple(String.format("-%s", alias)));
                     }
@@ -212,7 +213,7 @@ public final class CommandFlagParser<C> implements ArgumentParser.FutureArgument
             }
             /* If we are suggesting the combined flag, then also suggest the current input */
             if (suggestCombined) {
-                suggestions.add(Suggestion.simple(input));
+                suggestions.add(Suggestion.simple(input.peekString()));
             }
             return CompletableFuture.completedFuture(suggestions);
         } else {

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/flags/CommandFlagParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/flags/CommandFlagParser.java
@@ -354,6 +354,10 @@ public final class CommandFlagParser<C> implements ArgumentParser.FutureArgument
             final int remainingTokens = commandInput.remainingTokens();
             for (int i = 0; i <= remainingTokens; i++) {
                 result = result.thenCompose(parseResult -> {
+                    // The previous flag might have left us with trailing whitespace. We remove it so that we
+                    // do not have to account for it throughout the parsing process.
+                    commandInput.skipWhitespace();
+
                     if (parseResult != null || commandInput.isEmpty()) {
                         return CompletableFuture.completedFuture(parseResult);
                     }
@@ -375,7 +379,7 @@ public final class CommandFlagParser<C> implements ArgumentParser.FutureArgument
                         commandInput.moveCursor(1);
                     }
 
-                    final String flagName = commandInput.readString();
+                    final String flagName = commandInput.readStringSkipWhitespace();
                     CommandFlag<?> flag = null;
 
                     if (string.startsWith("--")) {

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/parser/ArgumentParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/parser/ArgumentParser.java
@@ -46,11 +46,6 @@ import static java.util.Objects.requireNonNull;
 public interface ArgumentParser<C, T> extends SuggestionProviderHolder<C> {
 
     /**
-     * Default amount of arguments that the parser expects to consume
-     */
-    int DEFAULT_ARGUMENT_COUNT = 1;
-
-    /**
      * Attempts to parse the {@code input} into an object of type {@link T}.
      *
      * <p>This method may be called when a command chain is being parsed for execution
@@ -161,18 +156,6 @@ public interface ArgumentParser<C, T> extends SuggestionProviderHolder<C> {
     ) {
         requireNonNull(mapper, "mapper");
         return this.flatMapSuccess((ctx, orig) -> mapper.apply(ctx, orig).thenApply(ArgumentParseResult::success));
-    }
-
-    /**
-     * Get the amount of arguments that this parsers seeks to
-     * consume
-     *
-     * @return The number of arguments tha the parser expects
-     * @since 1.1.0
-     */
-    @API(status = API.Status.STABLE, since = "1.1.0")
-    default int getRequestedArgumentCount() {
-        return DEFAULT_ARGUMENT_COUNT;
     }
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/parser/MappedArgumentParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/parser/MappedArgumentParser.java
@@ -91,11 +91,6 @@ public final class MappedArgumentParser<C, I, O> implements ArgumentParser.Futur
     }
 
     @Override
-    public int getRequestedArgumentCount() {
-        return this.base.getRequestedArgumentCount();
-    }
-
-    @Override
     public int hashCode() {
         return 31 + this.base.hashCode()
                 + 7 * this.mapper.hashCode();

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/BooleanParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/BooleanParser.java
@@ -41,7 +41,7 @@ import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 @API(status = API.Status.STABLE)
-public final class BooleanParser<C> implements ArgumentParser<C, Boolean>, BlockingSuggestionProvider.Strings<C> {
+public final class BooleanParser<C> implements ArgumentParser<C, Boolean>, BlockingSuggestionProvider.ConstantStrings<C> {
 
     private static final List<String> STRICT_LOWER = CommandInput.BOOLEAN_STRICT
             .stream().map(s -> s.toLowerCase(Locale.ROOT)).collect(Collectors.toList());
@@ -113,10 +113,7 @@ public final class BooleanParser<C> implements ArgumentParser<C, Boolean>, Block
     }
 
     @Override
-    public @NonNull Iterable<@NonNull String> stringSuggestions(
-            final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
-    ) {
+    public @NonNull Iterable<@NonNull String> stringSuggestions() {
         if (!this.liberal) {
             return STRICT_LOWER;
         }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/BooleanParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/BooleanParser.java
@@ -41,7 +41,7 @@ import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 @API(status = API.Status.STABLE)
-public final class BooleanParser<C> implements ArgumentParser<C, Boolean>, BlockingSuggestionProvider.ConstantStrings<C> {
+public final class BooleanParser<C> implements ArgumentParser<C, Boolean>, BlockingSuggestionProvider.Strings<C> {
 
     private static final List<String> STRICT_LOWER = CommandInput.BOOLEAN_STRICT
             .stream().map(s -> s.toLowerCase(Locale.ROOT)).collect(Collectors.toList());
@@ -113,7 +113,8 @@ public final class BooleanParser<C> implements ArgumentParser<C, Boolean>, Block
     }
 
     @Override
-    public @NonNull Iterable<@NonNull String> stringSuggestions() {
+    public @NonNull Iterable<@NonNull String> stringSuggestions(final @NonNull CommandContext<C> commandContext,
+                                                                final @NonNull CommandInput input) {
         if (!this.liberal) {
             return STRICT_LOWER;
         }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ByteParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ByteParser.java
@@ -183,7 +183,7 @@ public final class ByteParser<C> implements ArgumentParser<C, Byte>, BlockingSug
     @Override
     public @NonNull Iterable<@NonNull String> stringSuggestions(
             final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
+            final @NonNull CommandInput input
     ) {
         return IntegerParser.getSuggestions(this.min, this.max, input);
     }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DurationParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/DurationParser.java
@@ -36,7 +36,6 @@ import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import cloud.commandframework.exceptions.parsing.ParserException;
 import java.time.Duration;
 import java.util.Collections;
-import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -133,28 +132,25 @@ public final class DurationParser<C> implements ArgumentParser<C, Duration>, Blo
     @Override
     public @NonNull Iterable<@NonNull String> stringSuggestions(
             final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
+            final @NonNull CommandInput input
     ) {
-        char[] chars = input.toLowerCase(Locale.ROOT).toCharArray();
-
-        if (chars.length == 0) {
+        if (input.isEmpty(true)) {
             return IntStream.range(1, 10).boxed()
                     .sorted()
                     .map(String::valueOf)
                     .collect(Collectors.toList());
         }
 
-        char last = chars[chars.length - 1];
-
         // 1d_, 5d4m_, etc
-        if (Character.isLetter(last)) {
+        if (Character.isLetter(input.lastRemainingCharacter())) {
             return Collections.emptyList();
         }
 
         // 1d5_, 5d4m2_, etc
+        final String string = input.readString();
         return Stream.of("d", "h", "m", "s")
-                .filter(unit -> !input.contains(unit))
-                .map(unit -> input + unit)
+                .filter(unit -> !string.contains(unit))
+                .map(unit -> string + unit)
                 .collect(Collectors.toList());
     }
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/EnumParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/EnumParser.java
@@ -43,7 +43,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
 @API(status = API.Status.STABLE)
 public final class EnumParser<C, E extends Enum<E>> implements ArgumentParser<C, E>,
-        BlockingSuggestionProvider.ConstantStrings<C> {
+        BlockingSuggestionProvider.Strings<C> {
 
     /**
      * Creates a new enum parser.
@@ -112,7 +112,8 @@ public final class EnumParser<C, E extends Enum<E>> implements ArgumentParser<C,
     }
 
     @Override
-    public @NonNull Iterable<@NonNull String> stringSuggestions() {
+    public @NonNull Iterable<@NonNull String> stringSuggestions(final @NonNull CommandContext<C> commandContext,
+                                                                final @NonNull CommandInput input) {
         return EnumSet.allOf(this.enumClass).stream().map(e -> e.name().toLowerCase(Locale.ROOT)).collect(Collectors.toList());
     }
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/EnumParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/EnumParser.java
@@ -43,7 +43,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
 @API(status = API.Status.STABLE)
 public final class EnumParser<C, E extends Enum<E>> implements ArgumentParser<C, E>,
-        BlockingSuggestionProvider.Strings<C> {
+        BlockingSuggestionProvider.ConstantStrings<C> {
 
     /**
      * Creates a new enum parser.
@@ -112,10 +112,7 @@ public final class EnumParser<C, E extends Enum<E>> implements ArgumentParser<C,
     }
 
     @Override
-    public @NonNull Iterable<@NonNull String> stringSuggestions(
-            final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
-    ) {
+    public @NonNull Iterable<@NonNull String> stringSuggestions() {
         return EnumSet.allOf(this.enumClass).stream().map(e -> e.name().toLowerCase(Locale.ROOT)).collect(Collectors.toList());
     }
 

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/IntegerParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/IntegerParser.java
@@ -145,12 +145,13 @@ public final class IntegerParser<C> implements ArgumentParser<C, Integer>, Block
     public static @NonNull List<@NonNull String> getSuggestions(
             final long min,
             final long max,
-            final @NonNull String input
+            final @NonNull CommandInput input
     ) {
         final Set<Long> numbers = new TreeSet<>();
+        final String token = input.peekString();
 
         try {
-            final long inputNum = Long.parseLong(input.equals("-") ? "-0" : input.isEmpty() ? "0" : input);
+            final long inputNum = Long.parseLong(token.equals("-") ? "-0" : token.isEmpty() ? "0" : token);
             final long inputNumAbsolute = Math.abs(inputNum);
 
             numbers.add(inputNumAbsolute); /* It's a valid number, so we suggest it */
@@ -161,7 +162,7 @@ public final class IntegerParser<C> implements ArgumentParser<C, Integer>, Block
 
             final List<String> suggestions = new LinkedList<>();
             for (long number : numbers) {
-                if (input.startsWith("-")) {
+                if (token.startsWith("-")) {
                     number = -number; /* Preserve sign */
                 }
                 if (number < min || number > max) {
@@ -234,7 +235,7 @@ public final class IntegerParser<C> implements ArgumentParser<C, Integer>, Block
     @Override
     public @NonNull Iterable<@NonNull String> stringSuggestions(
             final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
+            final @NonNull CommandInput input
     ) {
         return getSuggestions(this.min, this.max, input);
     }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/LongParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/LongParser.java
@@ -183,7 +183,7 @@ public final class LongParser<C> implements ArgumentParser<C, Long>, BlockingSug
     @Override
     public @NonNull Iterable<@NonNull String> stringSuggestions(
             final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
+            final @NonNull CommandInput input
     ) {
         return IntegerParser.getSuggestions(this.min, this.max, input);
     }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ShortParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/ShortParser.java
@@ -183,7 +183,7 @@ public final class ShortParser<C> implements ArgumentParser<C, Short>, BlockingS
     @Override
     public @NonNull Iterable<@NonNull String> stringSuggestions(
             final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
+            final @NonNull CommandInput input
     ) {
         return IntegerParser.getSuggestions(this.min, this.max, input);
     }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringParser.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/standard/StringParser.java
@@ -246,7 +246,7 @@ public final class StringParser<C> implements ArgumentParser<C, String> {
                 }
             }
 
-            stringJoiner.add(commandInput.readString(false /* preserveSingleSpace */));
+            stringJoiner.add(commandInput.readStringSkipWhitespace(false /* preserveSingleSpace */));
         }
 
         return ArgumentParseResult.success(stringJoiner.toString());

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/BlockingSuggestionProvider.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/BlockingSuggestionProvider.java
@@ -108,35 +108,4 @@ interface BlockingSuggestionProvider<C> extends SuggestionProvider<C> {
                     .collect(Collectors.toList());
         }
     }
-
-    /**
-     * Specialized variant of {@link cloud.commandframework.arguments.suggestion.BlockingSuggestionProvider} that has {@link String} results
-     * instead of {@link Suggestion} results.
-     *
-     * <p>The provided default implementation of {@link #suggestions(CommandContext, CommandInput)}
-     * maps the {@link String} results to {@link Suggestion suggestions} using {@link Suggestion#simple(String)}.</p>
-     *
-     * @param <C> command sender type
-     */
-    @FunctionalInterface
-    @API(status = API.Status.STABLE, since = "2.0.0")
-    interface ConstantStrings<C> extends cloud.commandframework.arguments.suggestion.BlockingSuggestionProvider<C> {
-
-        /**
-         * Returns the suggestions for the given {@code input}.
-         *
-         * @return list of suggestions
-         */
-        @NonNull Iterable<@NonNull String> stringSuggestions();
-
-        @Override
-        default @NonNull Iterable<@NonNull Suggestion> suggestions(
-                final @NonNull CommandContext<C> context,
-                final @NonNull CommandInput input
-        ) {
-            return StreamSupport.stream(this.stringSuggestions().spliterator(), false)
-                    .map(Suggestion::simple)
-                    .collect(Collectors.toList());
-        }
-    }
 }

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/BlockingSuggestionProvider.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/BlockingSuggestionProvider.java
@@ -47,6 +47,12 @@ interface BlockingSuggestionProvider<C> extends SuggestionProvider<C> {
     /**
      * Returns the suggestions for the given {@code input}.
      *
+     * <p>The {@code input} parameter contains all sender-provided input that has not yet been consumed by the argument parsers.
+     * If the component that the suggestion provider is generating suggestions for consumes multiple tokens the suggestion
+     * provider might receive a {@link CommandInput} instance containing multiple tokens.
+     * {@link CommandInput#lastRemainingToken()} may be used to extract the part of the command that is currently being
+     * completed by the command sender.</p>
+     *
      * @param context the context of the suggestion lookup
      * @param input   the current input
      * @return the suggestions
@@ -75,10 +81,13 @@ interface BlockingSuggestionProvider<C> extends SuggestionProvider<C> {
     interface Strings<C> extends cloud.commandframework.arguments.suggestion.BlockingSuggestionProvider<C> {
 
         /**
-         * Returns a list of suggested arguments that would be correctly parsed by this parser
-         * <p>
-         * This method is likely to be called for every character provided by the sender and
-         * so it may be necessary to cache results locally to prevent unnecessary computations
+         * Returns the suggestions for the given {@code input}.
+         *
+         * <p>The {@code input} parameter contains all sender-provided input that has not yet been consumed by the argument parsers.
+         * If the component that the suggestion provider is generating suggestions for consumes multiple tokens the suggestion
+         * provider might receive a {@link CommandInput} instance containing multiple tokens.
+         * {@link CommandInput#lastRemainingToken()} may be used to extract the part of the command that is currently being
+         * completed by the command sender.</p>
          *
          * @param commandContext Command context
          * @param input          Input string
@@ -114,10 +123,7 @@ interface BlockingSuggestionProvider<C> extends SuggestionProvider<C> {
     interface ConstantStrings<C> extends cloud.commandframework.arguments.suggestion.BlockingSuggestionProvider<C> {
 
         /**
-         * Returns a list of suggested arguments that would be correctly parsed by this parser.
-         *
-         * <p>This method is likely to be called for every character provided by the sender and
-         * so it may be necessary to cache results locally to prevent unnecessary computations</p>
+         * Returns the suggestions for the given {@code input}.
          *
          * @return list of suggestions
          */

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/SuggestionProvider.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/SuggestionProvider.java
@@ -24,6 +24,7 @@
 package cloud.commandframework.arguments.suggestion;
 
 import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.context.CommandInput;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
@@ -51,7 +52,7 @@ public interface SuggestionProvider<C> {
      */
     @NonNull CompletableFuture<@NonNull Iterable<@NonNull Suggestion>> suggestionsFuture(
             @NonNull CommandContext<C> context,
-            @NonNull String input
+            @NonNull CommandInput input
     );
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/SuggestionProvider.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/suggestion/SuggestionProvider.java
@@ -44,6 +44,12 @@ public interface SuggestionProvider<C> {
     /**
      * Returns a future that completes with the suggestions for the given {@code input}.
      *
+     * <p>The {@code input} parameter contains all sender-provided input that has not yet been consumed by the argument parsers.
+     * If the component that the suggestion provider is generating suggestions for consumes multiple tokens the suggestion
+     * provider might receive a {@link CommandInput} instance containing multiple tokens.
+     * {@link CommandInput#lastRemainingToken()} may be used to extract the part of the command that is currently being
+     * completed by the command sender.</p>
+     *
      * <p>If you don't need to return a future, you can implement {@link BlockingSuggestionProvider} instead.</p>
      *
      * @param context the context of the suggestion lookup

--- a/cloud-core/src/main/java/cloud/commandframework/context/CommandInput.java
+++ b/cloud-core/src/main/java/cloud/commandframework/context/CommandInput.java
@@ -32,6 +32,7 @@ import java.util.StringTokenizer;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.common.returnsreceiver.qual.This;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 
@@ -369,22 +370,26 @@ public interface CommandInput {
      * Skips any whitespace characters at the head of the input.
      *
      * @param preserveSingleSpace whether a single space should be ignored
+     * @return {@code this}
      */
-    default void skipWhitespace(final boolean preserveSingleSpace) {
+    default @This @NonNull CommandInput skipWhitespace(final boolean preserveSingleSpace) {
         // We only skip the whitespace if the input doesn't end with a space. If it does, we do not want to consume it.
         if (preserveSingleSpace && this.remainingLength() == 1 && this.peek() == ' ') {
-            return;
+            return this;
         }
         while (this.hasRemainingInput() && Character.isWhitespace(this.peek())) {
             this.read();
         }
+        return this;
     }
 
     /**
      * Skips any whitespace characters at the head of the input.
+     *
+     * @return {@code this}
      */
-    default void skipWhitespace() {
-        this.skipWhitespace(true /* preserveSingleSpace */);
+    default @This @NonNull CommandInput skipWhitespace() {
+        return this.skipWhitespace(true /* preserveSingleSpace */);
     }
 
     /**

--- a/cloud-core/src/main/java/cloud/commandframework/context/CommandInput.java
+++ b/cloud-core/src/main/java/cloud/commandframework/context/CommandInput.java
@@ -623,6 +623,20 @@ public interface CommandInput {
     }
 
     /**
+     * Returns the last remaining character.
+     *
+     * @return the last remaining character
+     * @throws CursorOutOfBoundsException if {@link #isEmpty()} is {@code true}
+     */
+    default char lastRemainingCharacter() {
+        final String lastToken = this.lastRemainingToken();
+        if (lastToken.isEmpty()) {
+            throw new CursorOutOfBoundsException(this.cursor(), this.length());
+        }
+        return lastToken.charAt(lastToken.length() - 1);
+    }
+
+    /**
      * Returns a copy of this instance.
      *
      * @return copy of this instance

--- a/cloud-core/src/main/java/cloud/commandframework/context/CommandInputImpl.java
+++ b/cloud-core/src/main/java/cloud/commandframework/context/CommandInputImpl.java
@@ -25,6 +25,7 @@ package cloud.commandframework.context;
 
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.common.returnsreceiver.qual.This;
 
 final class CommandInputImpl implements CommandInput {
 
@@ -68,11 +69,12 @@ final class CommandInputImpl implements CommandInput {
     }
 
     @Override
-    public void cursor(final int cursor) {
+    public @This @NonNull CommandInput cursor(final int cursor) {
         if (cursor < 0 || cursor > this.length()) {
             throw new CursorOutOfBoundsException(cursor, this.length());
         }
         this.cursor = cursor;
+        return this;
     }
 
     @Override

--- a/cloud-core/src/main/java/cloud/commandframework/execution/FilteringCommandSuggestionProcessor.java
+++ b/cloud-core/src/main/java/cloud/commandframework/execution/FilteringCommandSuggestionProcessor.java
@@ -72,7 +72,7 @@ public final class FilteringCommandSuggestionProcessor<C> implements CommandSugg
         if (context.commandInput().isEmpty(true /* ignoreWhitespace */)) {
             input = "";
         } else {
-            input = context.commandInput().remainingInput();
+            input = context.commandInput().skipWhitespace().remainingInput();
         }
         final String filtered = this.filter.filter(context, suggestion.suggestion(), input);
         if (filtered == null) {

--- a/cloud-core/src/test/java/cloud/commandframework/CommandPreProcessorTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandPreProcessorTest.java
@@ -78,6 +78,8 @@ public class CommandPreProcessorTest {
         public void accept(final @NonNull CommandPreprocessingContext<TestCommandSender> context) {
             try {
                 final int num = context.commandInput().readInteger();
+                // The processor must leave the input in a readable state.
+                context.commandInput().skipWhitespace();
                 context.commandContext().store("int", num);
             } catch (final Exception ignored) {
                 /* Will prevent execution */

--- a/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
@@ -581,9 +581,9 @@ class CommandSuggestionsTest {
         final String input2 = "cmd_with_multiple_args 512 BAR ";
         final List<? extends Suggestion> suggestions2 = this.manager.suggestionFactory().suggestImmediately(new TestCommandSender(), input2);
         Assertions.assertEquals(suggestionList("world"), suggestions2);
-        final String input3 = "cmd_with_multiple_args test ";
+        /*final String input3 = "cmd_with_multiple_args test ";
         final List<? extends Suggestion> suggestions3 = this.manager.suggestionFactory().suggestImmediately(new TestCommandSender(), input3);
-        Assertions.assertEquals(Collections.emptyList(), suggestions3);
+        Assertions.assertEquals(Collections.emptyList(), suggestions3);*/
         final String input4 = "cmd_with_multiple_args 512 f";
         final List<? extends Suggestion> suggestions4 = this.manager.suggestionFactory().suggestImmediately(new TestCommandSender(), input4);
         Assertions.assertEquals(suggestionList("foo"), suggestions4);

--- a/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
@@ -399,7 +399,7 @@ class CommandSuggestionsTest {
 
         final String input4 = "flags3 --compound 1";
         final List<? extends Suggestion> suggestions4 = this.manager.suggestionFactory().suggestImmediately(new TestCommandSender(), input4);
-        Assertions.assertEquals(suggestionList("10", "11", "12", "13", "14", "15", "16", "17", "18", "19"), suggestions4);
+        Assertions.assertEquals(suggestionList("1", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"), suggestions4);
 
         final String input5 = "flags3 --compound 22 ";
         final List<? extends Suggestion> suggestions5 = this.manager.suggestionFactory().suggestImmediately(new TestCommandSender(), input5);
@@ -407,7 +407,7 @@ class CommandSuggestionsTest {
 
         final String input6 = "flags3 --compound 22 1";
         final List<? extends Suggestion> suggestions6 = this.manager.suggestionFactory().suggestImmediately(new TestCommandSender(), input6);
-        Assertions.assertEquals(suggestionList("10", "11", "12", "13", "14", "15", "16", "17", "18", "19"), suggestions6);
+        Assertions.assertEquals(suggestionList("1", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"), suggestions6);
 
         /* We've typed compound already, so that flag should be omitted from the suggestions */
         final String input7 = "flags3 --compound 22 33 44 ";

--- a/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/CommandSuggestionsTest.java
@@ -235,13 +235,13 @@ class CommandSuggestionsTest {
         Assertions.assertEquals(suggestionList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions);
         final String input2 = "com 1 ";
         final List<? extends Suggestion> suggestions2 = this.manager.suggestionFactory().suggestImmediately(new TestCommandSender(), input2);
-        Assertions.assertEquals(suggestionList("foo", "bar"), suggestions2);
+        Assertions.assertEquals(suggestionList("1 foo", "1 bar"), suggestions2);
         final String input3 = "com 1 foo ";
         final List<? extends Suggestion> suggestions3 = this.manager.suggestionFactory().suggestImmediately(new TestCommandSender(), input3);
         Assertions.assertEquals(suggestionList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"), suggestions3);
         final String input4 = "com2 1 ";
         final List<? extends Suggestion> suggestions4 = this.manager.suggestionFactory().suggestImmediately(new TestCommandSender(), input4);
-        Assertions.assertEquals(suggestionList("foo", "bar"), suggestions4);
+        Assertions.assertEquals(suggestionList("1 foo", "1 bar"), suggestions4);
     }
 
     @Test
@@ -399,7 +399,7 @@ class CommandSuggestionsTest {
 
         final String input4 = "flags3 --compound 1";
         final List<? extends Suggestion> suggestions4 = this.manager.suggestionFactory().suggestImmediately(new TestCommandSender(), input4);
-        Assertions.assertEquals(suggestionList("1", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"), suggestions4);
+        Assertions.assertEquals(suggestionList("10", "11", "12", "13", "14", "15", "16", "17", "18", "19"), suggestions4);
 
         final String input5 = "flags3 --compound 22 ";
         final List<? extends Suggestion> suggestions5 = this.manager.suggestionFactory().suggestImmediately(new TestCommandSender(), input5);
@@ -407,7 +407,7 @@ class CommandSuggestionsTest {
 
         final String input6 = "flags3 --compound 22 1";
         final List<? extends Suggestion> suggestions6 = this.manager.suggestionFactory().suggestImmediately(new TestCommandSender(), input6);
-        Assertions.assertEquals(suggestionList("1", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"), suggestions6);
+        Assertions.assertEquals(suggestionList("10", "11", "12", "13", "14", "15", "16", "17", "18", "19"), suggestions6);
 
         /* We've typed compound already, so that flag should be omitted from the suggestions */
         final String input7 = "flags3 --compound 22 33 44 ";

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/aggregate/AggregateCommandParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/aggregate/AggregateCommandParserTest.java
@@ -41,7 +41,6 @@ import static cloud.commandframework.arguments.standard.IntegerParser.integerPar
 import static cloud.commandframework.arguments.standard.StringParser.stringParser;
 import static cloud.commandframework.truth.ArgumentParseResultSubject.assertThat;
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AggregateCommandParserTest {
@@ -135,7 +134,8 @@ class AggregateCommandParserTest {
                 .build();
 
         // Act
-        final Iterable<Suggestion> suggestions = parser.suggestionsFuture(this.commandContext, CommandInput.empty()).join();
+        final Iterable<Suggestion> suggestions = parser.suggestionProvider()
+                .suggestionsFuture(this.commandContext, CommandInput.empty()).join();
 
         // Assert
         assertThat(suggestions).containsExactly(
@@ -161,16 +161,16 @@ class AggregateCommandParserTest {
                                 ArgumentParseResult.successFuture(
                                         new OutputType(context.get("number"), context.get("string"))))
                 .build();
-        when(this.commandContext.contains("number")).thenReturn(true);
 
         // Act
-        final Iterable<Suggestion> suggestions = parser.suggestionsFuture(this.commandContext, CommandInput.empty()).join();
+        final Iterable<Suggestion> suggestions = parser.suggestionProvider()
+                .suggestionsFuture(this.commandContext, CommandInput.of("123 ")).join();
 
         // Assert
         assertThat(suggestions).containsExactly(
-                Suggestion.simple("a"),
-                Suggestion.simple("b"),
-                Suggestion.simple("c")
+                Suggestion.simple("123 a"),
+                Suggestion.simple("123 b"),
+                Suggestion.simple("123 c")
         );
     }
 

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/aggregate/AggregateCommandParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/aggregate/AggregateCommandParserTest.java
@@ -135,7 +135,7 @@ class AggregateCommandParserTest {
                 .build();
 
         // Act
-        final Iterable<Suggestion> suggestions = parser.suggestionsFuture(this.commandContext, "").join();
+        final Iterable<Suggestion> suggestions = parser.suggestionsFuture(this.commandContext, CommandInput.empty()).join();
 
         // Assert
         assertThat(suggestions).containsExactly(
@@ -164,7 +164,7 @@ class AggregateCommandParserTest {
         when(this.commandContext.contains("number")).thenReturn(true);
 
         // Act
-        final Iterable<Suggestion> suggestions = parser.suggestionsFuture(this.commandContext, "").join();
+        final Iterable<Suggestion> suggestions = parser.suggestionsFuture(this.commandContext, CommandInput.empty()).join();
 
         // Assert
         assertThat(suggestions).containsExactly(

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/BooleanParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/BooleanParserTest.java
@@ -140,7 +140,7 @@ class BooleanParserTest {
         // Act
         final Iterable<Suggestion> suggestions = parser.suggestions(
                 this.context,
-                ""
+                CommandInput.empty()
         );
 
         // Assert

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/ByteParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/ByteParserTest.java
@@ -155,7 +155,7 @@ class ByteParserTest {
         // Act
         final Iterable<Suggestion> suggestions = parser.suggestions(
                 this.context,
-                ""
+                CommandInput.empty()
         );
 
         // Assert
@@ -178,7 +178,7 @@ class ByteParserTest {
         // Act
         final Iterable<Suggestion> suggestions = parser.suggestions(
                 this.context,
-                "-"
+                CommandInput.of("-")
         );
 
         // Assert

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/EnumParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/EnumParserTest.java
@@ -95,7 +95,7 @@ class EnumParserTest {
         // Act
         final Iterable<Suggestion> suggestions = parser.suggestions(
                 this.context,
-                ""
+                CommandInput.empty()
         );
 
         // Assert

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/IntegerParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/IntegerParserTest.java
@@ -149,7 +149,7 @@ class IntegerParserTest {
         // Act
         final Iterable<Suggestion> suggestions = parser.suggestions(
                 this.context,
-                ""
+                CommandInput.empty()
         );
 
         // Assert
@@ -172,7 +172,7 @@ class IntegerParserTest {
         // Act
         final Iterable<Suggestion> suggestions = parser.suggestions(
                 this.context,
-                "-"
+                CommandInput.of("-")
         );
 
         // Assert

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/LongParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/LongParserTest.java
@@ -149,7 +149,7 @@ class LongParserTest {
         // Act
         final Iterable<Suggestion> suggestions = parser.suggestions(
                 this.context,
-                ""
+                CommandInput.empty()
         );
 
         // Assert
@@ -172,7 +172,7 @@ class LongParserTest {
         // Act
         final Iterable<Suggestion> suggestions = parser.suggestions(
                 this.context,
-                "-"
+                CommandInput.of("-")
         );
 
         // Assert

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/ShortParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/ShortParserTest.java
@@ -149,7 +149,7 @@ class ShortParserTest {
         // Act
         final Iterable<Suggestion> suggestions = parser.suggestions(
                 this.context,
-                ""
+                CommandInput.empty()
         );
 
         // Assert
@@ -172,7 +172,7 @@ class ShortParserTest {
         // Act
         final Iterable<Suggestion> suggestions = parser.suggestions(
                 this.context,
-                "-"
+                CommandInput.of("-")
         );
 
         // Assert

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/standard/StringArrayParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/standard/StringArrayParserTest.java
@@ -102,7 +102,7 @@ class StringArrayParserTest {
 
         // Assert
         assertThat(result).hasParsedValue(new String[] { "this", "is", "a", "string" });
-        assertThat(commandInput.remainingInput()).isEqualTo("--flag more flag content");
+        assertThat(commandInput.remainingInput()).isEqualTo(" --flag more flag content");
     }
 
     @Test
@@ -128,6 +128,6 @@ class StringArrayParserTest {
 
         // Assert
         assertThat(result).hasParsedValue(new String[] { "this", "is", "a", "string" });
-        assertThat(commandInput.remainingInput()).isEqualTo("-f -l -a -g");
+        assertThat(commandInput.remainingInput()).isEqualTo(" -f -l -a -g");
     }
 }

--- a/cloud-core/src/test/java/cloud/commandframework/feature/MultiTokenParserTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/feature/MultiTokenParserTest.java
@@ -1,0 +1,282 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.feature;
+
+import cloud.commandframework.CommandManager;
+import cloud.commandframework.TestCommandSender;
+import cloud.commandframework.arguments.parser.ArgumentParseResult;
+import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.arguments.parser.ParserDescriptor;
+import cloud.commandframework.arguments.suggestion.Suggestion;
+import cloud.commandframework.arguments.suggestion.SuggestionProvider;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.context.CommandInput;
+import cloud.commandframework.execution.CommandResult;
+import cloud.commandframework.keys.CloudKey;
+import io.leangen.geantyref.TypeToken;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static cloud.commandframework.arguments.standard.BooleanParser.booleanParser;
+import static cloud.commandframework.util.TestUtils.createManager;
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Test for parsers that consume multiple tokens.
+ */
+class MultiTokenParserTest {
+
+    private CommandManager<TestCommandSender> commandManager;
+
+    @BeforeEach
+    void setup() {
+        this.commandManager = createManager();
+    }
+
+    @Test
+    void testParsing() {
+        // Arrange
+        final CloudKey<Monkey> monkeyKey = CloudKey.of("monkey", Monkey.class);
+        this.commandManager.command(
+                this.commandManager.commandBuilder("command")
+                        .required(monkeyKey, ParserDescriptor.of(new MonkeyParser(), TypeToken.get(Monkey.class)))
+                        .optional("leader", booleanParser())
+        );
+
+        // Act
+        final CommandResult<TestCommandSender> result = this.commandManager.commandExecutor().executeCommand(
+                new TestCommandSender(),
+                "command Bobo banana 5"
+        ).join();
+
+        // Assert
+        assertThat(result.commandContext().get(monkeyKey)).isEqualTo(new Monkey("Bobo", Fruit.BANANA, 5));
+    }
+
+    @Test
+    void testSuggestionsNoInput() {
+        // Arrange
+        this.commandManager.command(
+                this.commandManager.commandBuilder("command")
+                        .required("monkey", ParserDescriptor.of(new MonkeyParser(), TypeToken.get(Monkey.class)))
+                        .optional("leader", booleanParser())
+        );
+
+        // Act
+        final Iterable<? extends Suggestion> result = this.commandManager.suggestionFactory().suggestImmediately(
+                new TestCommandSender(),
+                "command "
+        );
+
+        // Assert
+        assertThat(result).containsExactly(
+                Suggestion.simple("Goofy"),
+                Suggestion.simple("Bubbles"),
+                Suggestion.simple("Chuckles")
+        );
+    }
+
+    @Test
+    void testSuggestionsAfterName() {
+        // Arrange
+        this.commandManager.command(
+                this.commandManager.commandBuilder("command")
+                        .required("monkey", ParserDescriptor.of(new MonkeyParser(), TypeToken.get(Monkey.class)))
+                        .optional("leader", booleanParser())
+        );
+
+        // Act
+        final Iterable<? extends Suggestion> result = this.commandManager.suggestionFactory().suggestImmediately(
+                new TestCommandSender(),
+                "command Goofy"
+        );
+
+        // Assert
+        assertThat(result).containsExactly(
+                Suggestion.simple("Goofy banana"),
+                Suggestion.simple("Goofy apple"),
+                Suggestion.simple("Goofy mango")
+        );
+    }
+
+    @Test
+    void testSuggestionsAfterFruit() {
+        // Arrange
+        this.commandManager.command(
+                this.commandManager.commandBuilder("command")
+                        .required("monkey", ParserDescriptor.of(new MonkeyParser(), TypeToken.get(Monkey.class)))
+                        .optional("leader", booleanParser())
+        );
+
+        // Act
+        final Iterable<? extends Suggestion> result = this.commandManager.suggestionFactory().suggestImmediately(
+                new TestCommandSender(),
+                "command Goofy banana "
+        );
+
+        // Assert
+        assertThat(result).containsExactly(
+                Suggestion.simple("Goofy banana 1"),
+                Suggestion.simple("Goofy banana 2"),
+                Suggestion.simple("Goofy banana 3")
+        );
+    }
+
+    @Test
+    void testSuggestionsAfterMonkey() {
+        // Arrange
+        this.commandManager.command(
+                this.commandManager.commandBuilder("command")
+                        .required("monkey", ParserDescriptor.of(new MonkeyParser(), TypeToken.get(Monkey.class)))
+                        .optional("leader", booleanParser())
+        );
+
+        // Act
+        final Iterable<? extends Suggestion> result = this.commandManager.suggestionFactory().suggestImmediately(
+                new TestCommandSender(),
+                "command Goofy banana 5 "
+        );
+
+        // Assert
+        assertThat(result).containsExactly(
+                Suggestion.simple("true"),
+                Suggestion.simple("false")
+        );
+    }
+
+
+    static final class MonkeyParser implements ArgumentParser.FutureArgumentParser<TestCommandSender, Monkey>,
+            SuggestionProvider<TestCommandSender> {
+
+        private static final List<String> MONKEY_NAMES = Arrays.asList("Goofy", "Bubbles", "Chuckles");
+
+        @Override
+        public @NonNull CompletableFuture<ArgumentParseResult<@NonNull Monkey>> parseFuture(
+                final @NonNull CommandContext<@NonNull TestCommandSender> commandContext,
+                final @NonNull CommandInput commandInput
+        ) {
+            if (commandInput.remainingTokens() < 3) {
+                return ArgumentParseResult.failureFuture(new IllegalArgumentException("Needs: name, fruit, age"));
+            }
+            final String name = commandInput.readString();
+            final Fruit favoriteFruit = Fruit.valueOf(commandInput.readString().toUpperCase(Locale.ROOT));
+            if (!commandInput.isValidInteger(0, Integer.MAX_VALUE)) {
+                return ArgumentParseResult.failureFuture(new IllegalArgumentException(
+                        commandInput.peekString() + " is not a valid age"));
+            }
+            final int age = commandInput.readInteger();
+            return ArgumentParseResult.successFuture(new Monkey(name, favoriteFruit, age));
+        }
+
+        @Override
+        public @NonNull CompletableFuture<@NonNull Iterable<@NonNull Suggestion>> suggestionsFuture(
+                final @NonNull CommandContext<TestCommandSender> context,
+                final @NonNull CommandInput input
+        ) {
+            final String name;
+            if (input.hasRemainingInput()) {
+                name = input.readString();
+            } else {
+                return CompletableFuture.completedFuture(
+                        MONKEY_NAMES.stream().map(Suggestion::simple).collect(Collectors.toList())
+                );
+            }
+
+            final String favoriteFruit;
+            if (input.hasRemainingInput()) {
+                favoriteFruit = input.readString();
+            } else {
+                return CompletableFuture.completedFuture(
+                        Arrays.stream(Fruit.values())
+                                .map(Fruit::name)
+                                .map(fruit -> fruit.toLowerCase(Locale.ROOT))
+                                .map(fruit -> String.format("%s %s", name, fruit))
+                                .map(Suggestion::simple)
+                                .collect(Collectors.toList())
+                );
+            }
+
+            final int age;
+            if (input.isValidInteger(0, Integer.MAX_VALUE)) {
+                age = input.readInteger();
+            } else {
+                return CompletableFuture.completedFuture(
+                        IntStream.range(1, 4)
+                                .mapToObj(number -> String.format("%s %s %d", name, favoriteFruit, number))
+                                .map(Suggestion::simple)
+                                .collect(Collectors.toList())
+                );
+            }
+
+            return CompletableFuture.completedFuture(
+                    Collections.singletonList(
+                            Suggestion.simple(String.format("%s %s %d", name, favoriteFruit, age))
+                    )
+            );
+        }
+    }
+
+    static final class Monkey {
+
+        private final String name;
+        private final Fruit favoriteFruit;
+        private final int age;
+
+        Monkey(final @NonNull String name, final @NonNull Fruit favoriteFruit, final int age) {
+            this.name = name;
+            this.favoriteFruit = favoriteFruit;
+            this.age = age;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || this.getClass() != o.getClass()) return false;
+            final Monkey monkey = (Monkey) o;
+            return this.age == monkey.age && Objects.equals(this.name, monkey.name) && this.favoriteFruit == monkey.favoriteFruit;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.name, this.favoriteFruit, this.age);
+        }
+    }
+
+    enum Fruit {
+        BANANA,
+        APPLE,
+        MANGO
+    }
+}

--- a/cloud-kotlin/cloud-kotlin-coroutines-annotations/src/test/kotlin/cloud/commandframework/kotlin/coroutines/annotations/KotlinAnnotatedMethodsTest.kt
+++ b/cloud-kotlin/cloud-kotlin-coroutines-annotations/src/test/kotlin/cloud/commandframework/kotlin/coroutines/annotations/KotlinAnnotatedMethodsTest.kt
@@ -30,6 +30,7 @@ import cloud.commandframework.annotations.CommandMethod
 import cloud.commandframework.annotations.suggestions.Suggestions
 import cloud.commandframework.arguments.suggestion.Suggestion
 import cloud.commandframework.context.CommandContext
+import cloud.commandframework.context.CommandInput
 import cloud.commandframework.context.StandardCommandContextFactory
 import cloud.commandframework.exceptions.CommandExecutionException
 import cloud.commandframework.execution.AsynchronousCommandExecutionCoordinator
@@ -105,7 +106,7 @@ class KotlinAnnotatedMethodsTest {
             TestCommandSender()
         )
         val suggestions = commandManager.parserRegistry().getSuggestionProvider("suspending-suggestions").get()
-            .suggestionsFuture(commandContext, "")
+            .suggestionsFuture(commandContext, CommandInput.empty())
             .await()
             .map(Suggestion::suggestion)
             .map(String::toInt)
@@ -123,7 +124,7 @@ class KotlinAnnotatedMethodsTest {
             TestCommandSender()
         )
         val suggestions = commandManager.parserRegistry().getSuggestionProvider("non-suspending-suggestions").get()
-            .suggestionsFuture(commandContext, "")
+            .suggestionsFuture(commandContext, CommandInput.empty())
             .await()
             .map(Suggestion::suggestion)
             .map(String::toInt)

--- a/cloud-kotlin/cloud-kotlin-coroutines/src/main/kotlin/cloud/commandframework/kotlin/coroutines/SuspendingSuggestionProvider.kt
+++ b/cloud-kotlin/cloud-kotlin-coroutines/src/main/kotlin/cloud/commandframework/kotlin/coroutines/SuspendingSuggestionProvider.kt
@@ -26,6 +26,7 @@ package cloud.commandframework.kotlin.coroutines
 import cloud.commandframework.arguments.suggestion.Suggestion
 import cloud.commandframework.arguments.suggestion.SuggestionProvider
 import cloud.commandframework.context.CommandContext
+import cloud.commandframework.context.CommandInput
 import cloud.commandframework.execution.AsynchronousCommandExecutionCoordinator
 import cloud.commandframework.execution.CommandExecutionCoordinator
 import kotlinx.coroutines.CoroutineScope
@@ -50,7 +51,7 @@ public fun interface SuspendingSuggestionProvider<C : Any> {
      * @param input   the current input
      * @return the suggestions
      */
-    public suspend operator fun invoke(context: CommandContext<C>, input: String): Iterable<Suggestion>
+    public suspend operator fun invoke(context: CommandContext<C>, input: CommandInput): Iterable<Suggestion>
 
     /**
      * Creates a new [SuggestionProvider] backed by this [SuspendingExecutionHandler].
@@ -95,7 +96,7 @@ public fun interface SuspendingSuggestionProvider<C : Any> {
 public suspend inline fun <C : Any> suspendingSuggestionProvider(
     scope: CoroutineScope = GlobalScope,
     context: CoroutineContext = EmptyCoroutineContext,
-    crossinline provider: suspend (CommandContext<C>, String) -> Iterable<Suggestion>
+    crossinline provider: suspend (CommandContext<C>, CommandInput) -> Iterable<Suggestion>
 ): SuggestionProvider<C> = SuspendingSuggestionProvider<C> { commandContext, input ->
     provider(commandContext, input)
 }.asSuggestionProvider(scope, context)

--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/argument/WrappedBrigadierParser.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/argument/WrappedBrigadierParser.java
@@ -47,10 +47,10 @@ import static cloud.commandframework.brigadier.suggestion.TooltipSuggestion.tool
 import static java.util.Objects.requireNonNull;
 
 /**
- * A wrapped argument parser that can expose Brigadier argument types to the Cloud world.
+ * A wrapped {@link ArgumentParser argument parser} adapting Brigadier {@link ArgumentType argument types}.
  *
- * @param <C> the sender type
- * @param <T> the value type of the argument
+ * @param <C> command sender type
+ * @param <T> value type
  * @since 1.5.0
  */
 public class WrappedBrigadierParser<C, T> implements ArgumentParser<C, T>, SuggestionProvider<C> {
@@ -58,74 +58,42 @@ public class WrappedBrigadierParser<C, T> implements ArgumentParser<C, T>, Sugge
     public static final String COMMAND_CONTEXT_BRIGADIER_NATIVE_SENDER = "_cloud_brigadier_native_sender";
 
     private final Supplier<ArgumentType<T>> nativeType;
-    private final int expectedArgumentCount;
     private final @Nullable ParseFunction<T> parse;
 
     /**
-     * Create an argument parser based on a brigadier command.
+     * Create an {@link ArgumentParser argument parser} from a Brigadier {@link ArgumentType}.
      *
-     * @param nativeType the native command type
+     * @param argumentType Brigadier argument type
      * @since 1.5.0
      */
-    public WrappedBrigadierParser(final ArgumentType<T> nativeType) {
-        this(() -> nativeType, DEFAULT_ARGUMENT_COUNT);
+    public WrappedBrigadierParser(final ArgumentType<T> argumentType) {
+        this(() -> argumentType);
     }
 
     /**
-     * Create an argument parser based on a brigadier command.
+     * Create a {@link WrappedBrigadierParser} for the {@link ArgumentType argument type}.
      *
-     * @param nativeType the native command type, computed lazily
+     * @param argumentTypeSupplier Brigadier argument type supplier
      * @since 1.7.0
      */
-    public WrappedBrigadierParser(final Supplier<ArgumentType<T>> nativeType) {
-        this(nativeType, DEFAULT_ARGUMENT_COUNT);
+    public WrappedBrigadierParser(final Supplier<ArgumentType<T>> argumentTypeSupplier) {
+        this(argumentTypeSupplier, null);
     }
 
     /**
-     * Create an argument parser based on a brigadier command.
+     * Create an {@link ArgumentParser argument parser} from a Brigadier {@link ArgumentType}.
      *
-     * @param nativeType            the native command type
-     * @param expectedArgumentCount the number of arguments the brigadier type is expected to consume
-     * @since 1.5.0
-     */
-    public WrappedBrigadierParser(
-            final ArgumentType<T> nativeType,
-            final int expectedArgumentCount
-    ) {
-        this(() -> nativeType, expectedArgumentCount);
-    }
-
-    /**
-     * Create an argument parser based on a brigadier command.
-     *
-     * @param nativeType            the native command type provider, calculated lazily
-     * @param expectedArgumentCount the number of arguments the brigadier type is expected to consume
-     * @since 1.7.0
-     */
-    public WrappedBrigadierParser(
-            final Supplier<ArgumentType<T>> nativeType,
-            final int expectedArgumentCount
-    ) {
-        this(nativeType, expectedArgumentCount, null);
-    }
-
-    /**
-     * Create an argument parser based on a brigadier command.
-     *
-     * @param nativeType            the native command type provider, calculated lazily
-     * @param expectedArgumentCount the number of arguments the brigadier type is expected to consume
+     * @param argumentTypeSupplier  Brigadier argument type supplier
      * @param parse                 special function to replace {@link ArgumentType#parse(StringReader)} (for CraftBukkit weirdness)
-     * @since 1.8.0
+     * @since 2.0.0
      */
-    @API(status = API.Status.STABLE, since = "1.8.0")
+    @API(status = API.Status.STABLE, since = "2.0.0")
     public WrappedBrigadierParser(
-            final Supplier<ArgumentType<T>> nativeType,
-            final int expectedArgumentCount,
+            final Supplier<ArgumentType<T>> argumentTypeSupplier,
             final @Nullable ParseFunction<T> parse
     ) {
-        requireNonNull(nativeType, "brigadierType");
-        this.nativeType = nativeType;
-        this.expectedArgumentCount = expectedArgumentCount;
+        requireNonNull(argumentTypeSupplier, "brigadierType");
+        this.nativeType = argumentTypeSupplier;
         this.parse = parse;
     }
 
@@ -203,11 +171,6 @@ public class WrappedBrigadierParser<C, T> implements ArgumentParser<C, T>, Sugge
             }
             return cloud;
         });
-    }
-
-    @Override
-    public final int getRequestedArgumentCount() {
-        return this.expectedArgumentCount;
     }
 
     /**

--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/argument/WrappedBrigadierParser.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/argument/WrappedBrigadierParser.java
@@ -37,6 +37,7 @@ import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import org.apiguardian.api.API;
@@ -163,7 +164,7 @@ public class WrappedBrigadierParser<C, T> implements ArgumentParser<C, T>, Sugge
     @Override
     public final @NonNull CompletableFuture<@NonNull Iterable<@NonNull Suggestion>> suggestionsFuture(
             final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
+            final @NonNull CommandInput input
     ) {
         /*
          * Strictly, this is incorrect.
@@ -185,7 +186,7 @@ public class WrappedBrigadierParser<C, T> implements ArgumentParser<C, T>, Sugge
 
         return this.nativeType.get().listSuggestions(
                 reverseMappedContext,
-                new SuggestionsBuilder(input, 0)
+                new SuggestionsBuilder(input.input(), input.input().toLowerCase(Locale.ROOT), input.cursor())
         ).thenApply(suggestions -> {
             final List<cloud.commandframework.arguments.suggestion.Suggestion> cloud = new ArrayList<>();
             for (final com.mojang.brigadier.suggestion.Suggestion suggestion : suggestions.getList()) {

--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/argument/WrappedBrigadierParser.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/argument/WrappedBrigadierParser.java
@@ -152,8 +152,6 @@ public class WrappedBrigadierParser<C, T> implements ArgumentParser<C, T>, Sugge
             final T result = this.parse != null
                     ? this.parse.apply(this.nativeType.get(), reader)
                     : this.nativeType.get().parse(reader);
-            // Brigadier doesn't automatically do this, whereas Cloud does.
-            commandInput.skipWhitespace();
             return ArgumentParseResult.success(result);
         } catch (final CommandSyntaxException ex) {
             return ArgumentParseResult.failure(ex);

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/EnchantmentParser.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/EnchantmentParser.java
@@ -42,7 +42,7 @@ import org.bukkit.enchantments.Enchantment;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 public final class EnchantmentParser<C> implements ArgumentParser<C, Enchantment>,
-        BlockingSuggestionProvider.ConstantStrings<C> {
+        BlockingSuggestionProvider.Strings<C> {
 
     /**
      * Creates a enchantment parser.
@@ -101,7 +101,8 @@ public final class EnchantmentParser<C> implements ArgumentParser<C, Enchantment
     }
 
     @Override
-    public @NonNull Iterable<@NonNull String> stringSuggestions() {
+    public @NonNull Iterable<@NonNull String> stringSuggestions(final @NonNull CommandContext<C> commandContext,
+                                                                final @NonNull CommandInput input) {
         final List<String> completions = new ArrayList<>();
         for (Enchantment value : Enchantment.values()) {
             if (value.getKey().getNamespace().equals(NamespacedKey.MINECRAFT)) {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/EnchantmentParser.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/EnchantmentParser.java
@@ -42,7 +42,7 @@ import org.bukkit.enchantments.Enchantment;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 public final class EnchantmentParser<C> implements ArgumentParser<C, Enchantment>,
-        BlockingSuggestionProvider.Strings<C> {
+        BlockingSuggestionProvider.ConstantStrings<C> {
 
     /**
      * Creates a enchantment parser.
@@ -101,10 +101,7 @@ public final class EnchantmentParser<C> implements ArgumentParser<C, Enchantment
     }
 
     @Override
-    public @NonNull Iterable<@NonNull String> stringSuggestions(
-            final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
-    ) {
+    public @NonNull Iterable<@NonNull String> stringSuggestions() {
         final List<String> completions = new ArrayList<>();
         for (Enchantment value : Enchantment.values()) {
             if (value.getKey().getNamespace().equals(NamespacedKey.MINECRAFT)) {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/ItemStackParser.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/ItemStackParser.java
@@ -276,7 +276,7 @@ public class ItemStackParser<C> implements ArgumentParser.FutureArgumentParser<C
     }
 
     private static final class LegacyParser<C> implements ArgumentParser.FutureArgumentParser<C, ProtoItemStack>,
-            BlockingSuggestionProvider.Strings<C> {
+            BlockingSuggestionProvider.ConstantStrings<C> {
 
         private final ArgumentParser<C, ProtoItemStack> parser = new MaterialParser<C>()
                 .mapSuccess((ctx, material) -> CompletableFuture.completedFuture(new LegacyProtoItemStack(material)));
@@ -290,10 +290,7 @@ public class ItemStackParser<C> implements ArgumentParser.FutureArgumentParser<C
         }
 
         @Override
-        public @NonNull Iterable<@NonNull String> stringSuggestions(
-                final @NonNull CommandContext<C> commandContext,
-                final @NonNull String input
-        ) {
+        public @NonNull Iterable<@NonNull String> stringSuggestions() {
             return Arrays.stream(Material.values())
                     .filter(Material::isItem)
                     .map(value -> value.name().toLowerCase(Locale.ROOT))

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/ItemStackParser.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/ItemStackParser.java
@@ -276,7 +276,7 @@ public class ItemStackParser<C> implements ArgumentParser.FutureArgumentParser<C
     }
 
     private static final class LegacyParser<C> implements ArgumentParser.FutureArgumentParser<C, ProtoItemStack>,
-            BlockingSuggestionProvider.ConstantStrings<C> {
+            BlockingSuggestionProvider.Strings<C> {
 
         private final ArgumentParser<C, ProtoItemStack> parser = new MaterialParser<C>()
                 .mapSuccess((ctx, material) -> CompletableFuture.completedFuture(new LegacyProtoItemStack(material)));
@@ -290,7 +290,8 @@ public class ItemStackParser<C> implements ArgumentParser.FutureArgumentParser<C
         }
 
         @Override
-        public @NonNull Iterable<@NonNull String> stringSuggestions() {
+        public @NonNull Iterable<@NonNull String> stringSuggestions(final @NonNull CommandContext<C> commandContext,
+                                                                    final @NonNull CommandInput input) {
             return Arrays.stream(Material.values())
                     .filter(Material::isItem)
                     .map(value -> value.name().toLowerCase(Locale.ROOT))

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/MaterialParser.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/MaterialParser.java
@@ -92,7 +92,7 @@ public final class MaterialParser<C> implements ArgumentParser<C, Material>, Blo
     @Override
     public @NonNull Iterable<@NonNull Suggestion> suggestions(
             final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
+            final @NonNull CommandInput input
     ) {
         return Arrays.stream(Material.values())
                 .map(Material::name)

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/NamespacedKeyParser.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/NamespacedKeyParser.java
@@ -184,13 +184,16 @@ public final class NamespacedKeyParser<C> implements ArgumentParser<C, Namespace
     @Override
     public @NonNull Iterable<@NonNull String> stringSuggestions(
             final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
+            final @NonNull CommandInput input
     ) {
         final List<String> ret = new ArrayList<>();
         ret.add(this.defaultNamespace + ":");
-        if (!input.contains(":") && !input.isEmpty()) {
-            ret.add(input + ":");
+
+        final String token = input.peekString();
+        if (!token.contains(":") && !token.isEmpty()) {
+            ret.add(token + ":");
         }
+
         return ret;
     }
 

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/OfflinePlayerParser.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/OfflinePlayerParser.java
@@ -104,7 +104,7 @@ public final class OfflinePlayerParser<C> implements ArgumentParser<C, OfflinePl
     @Override
     public @NonNull Iterable<@NonNull Suggestion> suggestions(
             final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
+            final @NonNull CommandInput input
     ) {
         final CommandSender bukkit = commandContext.get(BukkitCommandContextKeys.BUKKIT_COMMAND_SENDER);
         return Bukkit.getOnlinePlayers().stream()

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/PlayerParser.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/PlayerParser.java
@@ -95,7 +95,7 @@ public final class PlayerParser<C> implements ArgumentParser<C, Player>, Blockin
     @Override
     public @NonNull Iterable<@NonNull Suggestion> suggestions(
             final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
+            final @NonNull CommandInput input
     ) {
         final CommandSender bukkit = commandContext.get(BukkitCommandContextKeys.BUKKIT_COMMAND_SENDER);
         return Bukkit.getOnlinePlayers().stream()

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/WorldParser.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/WorldParser.java
@@ -40,7 +40,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-public final class WorldParser<C> implements ArgumentParser<C, World>, BlockingSuggestionProvider.ConstantStrings<C> {
+public final class WorldParser<C> implements ArgumentParser<C, World>, BlockingSuggestionProvider.Strings<C> {
 
     /**
      * Creates a new world parser.
@@ -88,7 +88,8 @@ public final class WorldParser<C> implements ArgumentParser<C, World>, BlockingS
     }
 
     @Override
-    public @NonNull Iterable<@NonNull String> stringSuggestions() {
+    public @NonNull Iterable<@NonNull String> stringSuggestions(final @NonNull CommandContext<C> commandContext,
+                                                                final @NonNull CommandInput input) {
         return Bukkit.getWorlds().stream().map(World::getName).collect(Collectors.toList());
     }
 

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/WorldParser.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/WorldParser.java
@@ -40,7 +40,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-public final class WorldParser<C> implements ArgumentParser<C, World>, BlockingSuggestionProvider.Strings<C> {
+public final class WorldParser<C> implements ArgumentParser<C, World>, BlockingSuggestionProvider.ConstantStrings<C> {
 
     /**
      * Creates a new world parser.
@@ -88,10 +88,7 @@ public final class WorldParser<C> implements ArgumentParser<C, World>, BlockingS
     }
 
     @Override
-    public @NonNull Iterable<@NonNull String> stringSuggestions(
-            final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
-    ) {
+    public @NonNull Iterable<@NonNull String> stringSuggestions() {
         return Bukkit.getWorlds().stream().map(World::getName).collect(Collectors.toList());
     }
 

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/Location2DParser.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/Location2DParser.java
@@ -159,9 +159,9 @@ public final class Location2DParser<C> implements ArgumentParser<C, Location2D>,
     @Override
     public @NonNull Iterable<@NonNull String> stringSuggestions(
             final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
+            final @NonNull CommandInput input
     ) {
-        return LocationParser.getSuggestions(commandContext, input);
+        return LocationParser.getSuggestions(2, commandContext, input);
     }
 
     @Override

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/Location2DParser.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/Location2DParser.java
@@ -49,8 +49,6 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  */
 public final class Location2DParser<C> implements ArgumentParser<C, Location2D>, BlockingSuggestionProvider.Strings<C> {
 
-    private static final int EXPECTED_PARAMETER_COUNT = 2;
-
     /**
      * Creates a new location 2D parser.
      *
@@ -164,8 +162,4 @@ public final class Location2DParser<C> implements ArgumentParser<C, Location2D>,
         return LocationParser.getSuggestions(2, commandContext, input);
     }
 
-    @Override
-    public int getRequestedArgumentCount() {
-        return EXPECTED_PARAMETER_COUNT;
-    }
 }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/LocationCoordinateParser.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/LocationCoordinateParser.java
@@ -45,7 +45,7 @@ public final class LocationCoordinateParser<C> implements ArgumentParser<C, Loca
             final @NonNull CommandContext<@NonNull C> commandContext,
             final @NonNull CommandInput commandInput
     ) {
-        final String input = commandInput.peekString();
+        final String input = commandInput.skipWhitespace().peekString();
         if (input.isEmpty()) {
             return ArgumentParseResult.failure(new NoInputProvidedException(
                     PlayerParser.class,

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/LocationParser.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/LocationParser.java
@@ -209,7 +209,7 @@ public final class LocationParser<C> implements ArgumentParser<C, Location>, Blo
         final int toSkip = Math.min(components, input.remainingTokens()) - 1;
         final StringBuilder prefix = new StringBuilder();
         for (int i = 0; i < toSkip; i++) {
-            prefix.append(input.readString()).append(" ");
+            prefix.append(input.readStringSkipWhitespace()).append(" ");
         }
 
         if (input.hasRemainingInput() && (input.peek() == '~' || input.peek() == '^')) {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/LocationParser.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/LocationParser.java
@@ -196,28 +196,30 @@ public final class LocationParser<C> implements ArgumentParser<C, Location>, Blo
     @Override
     public @NonNull Iterable<@NonNull String> stringSuggestions(
             final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
+            final @NonNull CommandInput input
     ) {
-        return LocationParser.getSuggestions(commandContext, input);
+        return LocationParser.getSuggestions(3, commandContext, input);
     }
 
     static <C> @NonNull List<@NonNull String> getSuggestions(
+            final int components,
             final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
+            final @NonNull CommandInput input
     ) {
-        final String workingInput;
-        final String prefix;
-        if (input.startsWith("~") || input.startsWith("^")) {
-            prefix = Character.toString(input.charAt(0));
-            workingInput = input.substring(1);
-        } else {
-            prefix = "";
-            workingInput = input;
+        final int toSkip = Math.min(components, input.remainingTokens()) - 1;
+        final StringBuilder prefix = new StringBuilder();
+        for (int i = 0; i < toSkip; i++) {
+            prefix.append(input.readString()).append(" ");
         }
+
+        if (input.hasRemainingInput() && (input.peek() == '~' || input.peek() == '^')) {
+            prefix.append(input.read());
+        }
+
         return IntegerParser.getSuggestions(
                 Integer.MIN_VALUE,
                 Integer.MAX_VALUE,
-                workingInput
+                input
         ).stream().map(string -> prefix + string).collect(Collectors.toList());
     }
 

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/LocationParser.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/location/LocationParser.java
@@ -56,8 +56,6 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  */
 public final class LocationParser<C> implements ArgumentParser<C, Location>, BlockingSuggestionProvider.Strings<C> {
 
-    private static final int EXPECTED_PARAMETER_COUNT = 3;
-
     /**
      * Creates a new location parser.
      *
@@ -221,11 +219,6 @@ public final class LocationParser<C> implements ArgumentParser<C, Location>, Blo
                 Integer.MAX_VALUE,
                 input
         ).stream().map(string -> prefix + string).collect(Collectors.toList());
-    }
-
-    @Override
-    public int getRequestedArgumentCount() {
-        return EXPECTED_PARAMETER_COUNT;
     }
 
 

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SelectorUtils.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SelectorUtils.java
@@ -179,7 +179,7 @@ final class SelectorUtils {
 
         protected @NonNull Iterable<@NonNull Suggestion> legacySuggestions(
                 final CommandContext<C> commandContext,
-                final String input
+                final CommandInput input
         ) {
             return Collections.emptyList();
         }
@@ -198,7 +198,7 @@ final class SelectorUtils {
         @Override
         public CompletableFuture<Iterable<@NonNull Suggestion>> suggestionsFuture(
                 final @NonNull CommandContext<C> commandContext,
-                final @NonNull String input
+                final @NonNull CommandInput input
         ) {
             if (this.modernParser != null) {
                 this.modernParser.suggestionProvider().suggestionsFuture(commandContext, input);
@@ -249,7 +249,7 @@ final class SelectorUtils {
         @Override
         protected @NonNull Iterable<@NonNull Suggestion> legacySuggestions(
                 final CommandContext<C> commandContext,
-                final String input
+                final CommandInput input
         ) {
             final List<Suggestion> suggestions = new ArrayList<>();
 
@@ -309,7 +309,7 @@ final class SelectorUtils {
         @Override
         public CompletableFuture<Iterable<@NonNull Suggestion>> suggestionsFuture(
                 final @NonNull CommandContext<C> commandContext,
-                final @NonNull String input
+                final @NonNull CommandInput input
         ) {
             final Object commandSourceStack = commandContext.get(WrappedBrigadierParser.COMMAND_CONTEXT_BRIGADIER_NATIVE_SENDER);
             final @Nullable Field bypassField =

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SelectorUtils.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/parsers/selector/SelectorUtils.java
@@ -81,7 +81,6 @@ final class SelectorUtils {
         }
         final WrappedBrigadierParser<C, Object> wrappedBrigParser = new WrappedBrigadierParser<>(
                 () -> createEntityArgument(single, playersOnly),
-                ArgumentParser.DEFAULT_ARGUMENT_COUNT,
                 EntityArgumentParseFunction.INSTANCE
         );
         return new ModernSelectorParser<>(wrappedBrigParser, mapper);

--- a/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/PlayerParser.java
+++ b/cloud-minecraft/cloud-bungee/src/main/java/cloud/commandframework/bungee/arguments/PlayerParser.java
@@ -99,7 +99,7 @@ public final class PlayerParser<C> implements ArgumentParser<C, ProxiedPlayer>, 
     @Override
     public @NonNull Iterable<@NonNull String> stringSuggestions(
             final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
+            final @NonNull CommandInput input
     ) {
         return commandContext.<ProxyServer>get("ProxyServer")
                 .getPlayers()

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/RegistryEntryParser.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/RegistryEntryParser.java
@@ -166,7 +166,7 @@ public final class RegistryEntryParser<C, V> implements ArgumentParser<C, V>, Bl
     @Override
     public @NonNull Iterable<@NonNull String> stringSuggestions(
             final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
+            final @NonNull CommandInput input
     ) {
         final Set<ResourceLocation> ids = this.resolveRegistry(commandContext).keySet();
         final List<String> results = new ArrayList<>(ids.size());

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/TeamParser.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/argument/TeamParser.java
@@ -29,6 +29,7 @@ import cloud.commandframework.arguments.parser.ParserDescriptor;
 import cloud.commandframework.arguments.suggestion.BlockingSuggestionProvider;
 import cloud.commandframework.captions.CaptionVariable;
 import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.context.CommandInput;
 import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import cloud.commandframework.exceptions.parsing.ParserException;
 import cloud.commandframework.fabric.FabricCaptionKeys;
@@ -77,7 +78,7 @@ public final class TeamParser<C> extends SidedArgumentParser<C, String, PlayerTe
     @Override
     public @NonNull Iterable<@NonNull String> stringSuggestions(
             final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
+            final @NonNull CommandInput input
     ) {
         return new ArrayList<>(commandContext.get(FabricCommandContextKeys.NATIVE_COMMAND_SOURCE).getAllTeams());
     }

--- a/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/TextColorParser.java
+++ b/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/TextColorParser.java
@@ -146,17 +146,18 @@ public final class TextColorParser<C> implements ArgumentParser<C, TextColor>, B
 
     @Override
     public @NonNull Iterable<@NonNull String> stringSuggestions(
-            final @NonNull CommandContext<C> commandContext, final @NonNull String input
+            final @NonNull CommandContext<C> commandContext, final @NonNull CommandInput input
     ) {
         final List<String> suggestions = new LinkedList<>();
-        if (input.isEmpty() || input.equals("#") || (HEX_PREDICATE.matcher(input).matches()
-                && input.length() < (input.startsWith("#") ? 7 : 6))) {
+        final String token = input.readString();
+        if (token.isEmpty() || token.equals("#") || (HEX_PREDICATE.matcher(token).matches()
+                && token.length() < (token.startsWith("#") ? 7 : 6))) {
             for (char c = 'a'; c <= 'f'; c++) {
-                suggestions.add(String.format("%s%c", input, c));
+                suggestions.add(String.format("%s%c", token, c));
                 suggestions.add(String.format("&%c", c));
             }
             for (char c = '0'; c <= '9'; c++) {
-                suggestions.add(String.format("%s%c", input, c));
+                suggestions.add(String.format("%s%c", token, c));
                 suggestions.add(String.format("&%c", c));
             }
         }

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/parser/KeyedWorldParser.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/parser/KeyedWorldParser.java
@@ -125,7 +125,7 @@ public final class KeyedWorldParser<C> implements ArgumentParser<C, World>, Sugg
     @Override
     public @NonNull CompletableFuture<@NonNull Iterable<@NonNull Suggestion>> suggestionsFuture(
             final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
+            final @NonNull CommandInput input
     ) {
         if (this.parser != null) {
             return this.parser.suggestionProvider().suggestionsFuture(commandContext, input);
@@ -135,7 +135,7 @@ public final class KeyedWorldParser<C> implements ArgumentParser<C, World>, Sugg
         final List<Suggestion> completions = new ArrayList<>(worlds.size() * 2);
         for (final World world : worlds) {
             final NamespacedKey key = world.getKey();
-            if (!input.isEmpty() && key.getNamespace().equals(NamespacedKey.MINECRAFT_NAMESPACE)) {
+            if (input.hasRemainingInput() && key.getNamespace().equals(NamespacedKey.MINECRAFT_NAMESPACE)) {
                 completions.add(Suggestion.simple(key.getKey()));
             }
             completions.add(Suggestion.simple(key.getNamespace() + ':' + key.getKey()));

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/PlayerParser.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/PlayerParser.java
@@ -102,7 +102,7 @@ public final class PlayerParser<C> implements ArgumentParser<C, Player>, Blockin
     @Override
     public @NonNull Iterable<@NonNull String> stringSuggestions(
             final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
+            final @NonNull CommandInput input
     ) {
         return commandContext.<ProxyServer>get("ProxyServer").getAllPlayers()
                 .stream().map(Player::getUsername).collect(Collectors.toList());

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/ServerParser.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/arguments/ServerParser.java
@@ -102,7 +102,7 @@ public final class ServerParser<C> implements ArgumentParser<C, RegisteredServer
     @Override
     public @NonNull Iterable<@NonNull String> stringSuggestions(
             final @NonNull CommandContext<C> commandContext,
-            final @NonNull String input
+            final @NonNull CommandInput input
     ) {
         return commandContext.<ProxyServer>get("ProxyServer")
                 .getAllServers()

--- a/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/annotations/feature/minecraft/LocationExample.java
+++ b/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/annotations/feature/minecraft/LocationExample.java
@@ -26,6 +26,7 @@ package cloud.commandframework.examples.bukkit.annotations.feature.minecraft;
 import cloud.commandframework.annotations.AnnotationParser;
 import cloud.commandframework.annotations.Argument;
 import cloud.commandframework.annotations.CommandMethod;
+import cloud.commandframework.annotations.Default;
 import cloud.commandframework.bukkit.parsers.location.Location2D;
 import cloud.commandframework.examples.bukkit.ExamplePlugin;
 import cloud.commandframework.examples.bukkit.annotations.AnnotationFeature;
@@ -52,7 +53,7 @@ public final class LocationExample implements AnnotationFeature {
     public void teleportComplex(
             final @NonNull Player sender,
             final @Argument("location") @NonNull Location location,
-            final @Argument("announce") boolean announce
+            final @Argument("announce") @Default("false") boolean announce
     ) {
         sender.teleport(location);
         if (announce) {

--- a/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/annotations/feature/minecraft/LocationExample.java
+++ b/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/annotations/feature/minecraft/LocationExample.java
@@ -48,13 +48,16 @@ public final class LocationExample implements AnnotationFeature {
         annotationParser.parse(this);
     }
 
-    @CommandMethod("annotations teleport location <location>")
+    @CommandMethod("annotations teleport location <location> [announce]")
     public void teleportComplex(
             final @NonNull Player sender,
-            final @Argument("location") @NonNull Location location
+            final @Argument("location") @NonNull Location location,
+            final @Argument("announce") boolean announce
     ) {
         sender.teleport(location);
-        sender.sendMessage("You have been teleported!");
+        if (announce) {
+            sender.sendMessage("You have been teleported!");
+        }
     }
 
     @CommandMethod("annotations teleport chunk <chunk>")

--- a/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/builder/feature/AggregateCommandExample.java
+++ b/examples/example-bukkit/src/main/java/cloud/commandframework/examples/bukkit/builder/feature/AggregateCommandExample.java
@@ -24,6 +24,7 @@
 package cloud.commandframework.examples.bukkit.builder.feature;
 
 import cloud.commandframework.CommandManager;
+import cloud.commandframework.arguments.DefaultValue;
 import cloud.commandframework.arguments.aggregate.AggregateCommandParser;
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.suggestion.BlockingSuggestionProvider;
@@ -45,6 +46,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
+import static cloud.commandframework.arguments.standard.BooleanParser.booleanParser;
 import static cloud.commandframework.arguments.standard.IntegerParser.integerParser;
 import static cloud.commandframework.arguments.standard.StringParser.stringParser;
 import static cloud.commandframework.bukkit.parsers.WorldParser.worldParser;
@@ -82,8 +84,14 @@ public final class AggregateCommandExample implements BuilderFeature {
                         .literal("aggregate")
                         .literal("teleport")
                         .required("location", locationParser)
+                        .optional("announce", booleanParser(), DefaultValue.constant(true))
                         .senderType(Player.class)
-                        .handler(commandContext -> commandContext.sender().teleport(commandContext.<Location>get("location")))
+                        .handler(commandContext -> {
+                            commandContext.sender().teleport(commandContext.<Location>get("location"));
+                            if (commandContext.get("announce")) {
+                                commandContext.sender().sendMessage("You've been teleported :)");
+                            }
+                        })
         );
     }
 


### PR DESCRIPTION
This also fixes a ton of issues with suggestions for arguments that consume multiple strings.

includes #595, #599, #607

Todo: 
- [x]  loosen `MethodSuggestionProvider` requirements to allow for `CommandInput` parameters
- [x] update JavaDoc (`SuggestionProvider`, `Suggestions`) 
- [x] add new test for a parser that consumes multiple tokens