### PR TITLE
fix(brigadier): don't force executors by default

### DIFF
--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/BrigadierSetting.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/BrigadierSetting.java
@@ -1,0 +1,41 @@
+//
+// MIT License
+//
+// Copyright (c) 2022 Alexander Söderberg & Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.brigadier;
+
+import cloud.commandframework.setting.Setting;
+import org.apiguardian.api.API;
+
+/**
+ * Configurable options that determine how {@link CloudBrigadierManager} behaves.
+ *
+ * @since 2.0.0
+ */
+@API(status = API.Status.STABLE, since = "2.0.0")
+public enum BrigadierSetting implements Setting {
+    /**
+     * Makes each constructed {@link com.mojang.brigadier.tree.CommandNode} executable, which allows Cloud to
+     * display errors for partially completed command input.
+     */
+    FORCE_EXECUTABLE
+}

--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/CloudBrigadierManager.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/CloudBrigadierManager.java
@@ -45,6 +45,7 @@ import cloud.commandframework.brigadier.argument.WrappedBrigadierParser;
 import cloud.commandframework.brigadier.node.LiteralBrigadierNodeFactory;
 import cloud.commandframework.brigadier.suggestion.TooltipSuggestion;
 import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.setting.Configurable;
 import com.mojang.brigadier.arguments.BoolArgumentType;
 import com.mojang.brigadier.arguments.DoubleArgumentType;
 import com.mojang.brigadier.arguments.FloatArgumentType;
@@ -80,6 +81,7 @@ public final class CloudBrigadierManager<C, S> {
     private final BrigadierMappings<C, S> brigadierMappings = BrigadierMappings.create();
     private final LiteralBrigadierNodeFactory<C, S> literalBrigadierNodeFactory;
     private final Map<@NonNull Class<?>, @NonNull ArgumentTypeFactory<?>> defaultArgumentTypeSuppliers;
+    private final Configurable<BrigadierSetting> settings = Configurable.enumConfigurable(BrigadierSetting.class);
     private Function<S, C> brigadierCommandSenderMapper;
     private Function<C, S> backwardsBrigadierCommandSenderMapper;
 
@@ -199,6 +201,17 @@ public final class CloudBrigadierManager<C, S> {
         /* Map wrapped parsers to their native types */
         this.registerMapping(new TypeToken<WrappedBrigadierParser<C, ?>>() {
         }, builder -> builder.to(WrappedBrigadierParser::getNativeArgument));
+    }
+
+    /**
+     * Returns a {@link Configurable} instance that can be used to modify the settings for this instance.
+     *
+     * @return settings instance
+     * @since 2.0.0
+     */
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    public @NonNull Configurable<BrigadierSetting> settings() {
+        return this.settings;
     }
 
     /**

--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/node/BrigadierNodeFactory.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/node/BrigadierNodeFactory.java
@@ -58,7 +58,6 @@ public interface BrigadierNodeFactory<C, S, N extends CommandNode<S>> {
      * @param label             the command label
      * @param cloudCommand      the cloud command
      * @param permissionChecker function that determines whether a sender has access to the command
-     * @param forceRegister     whether to force-register an executor at every node
      * @param executor          the Brigadier command execution handler
      * @return the created command node
      */
@@ -66,7 +65,6 @@ public interface BrigadierNodeFactory<C, S, N extends CommandNode<S>> {
             @NonNull String label,
             cloud.commandframework.@NonNull Command<C> cloudCommand,
             @NonNull BrigadierPermissionChecker<S> permissionChecker,
-            boolean forceRegister,
             @NonNull Command<S> executor
     );
 }

--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/node/LiteralBrigadierNodeFactory.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/node/LiteralBrigadierNodeFactory.java
@@ -29,6 +29,7 @@ import cloud.commandframework.arguments.aggregate.AggregateCommandParser;
 import cloud.commandframework.arguments.parser.ArgumentParser;
 import cloud.commandframework.arguments.parser.MappedArgumentParser;
 import cloud.commandframework.arguments.suggestion.SuggestionFactory;
+import cloud.commandframework.brigadier.BrigadierSetting;
 import cloud.commandframework.brigadier.CloudBrigadierManager;
 import cloud.commandframework.brigadier.argument.ArgumentTypeFactory;
 import cloud.commandframework.brigadier.argument.BrigadierMapping;
@@ -39,6 +40,7 @@ import cloud.commandframework.brigadier.suggestion.CloudDelegatingSuggestionProv
 import cloud.commandframework.brigadier.suggestion.SuggestionsType;
 import cloud.commandframework.brigadier.suggestion.TooltipSuggestion;
 import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.internal.CommandNode;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
@@ -50,6 +52,7 @@ import com.mojang.brigadier.tree.LiteralCommandNode;
 import io.leangen.geantyref.GenericTypeReflector;
 import io.leangen.geantyref.TypeToken;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.apiguardian.api.API;
@@ -97,13 +100,10 @@ public final class LiteralBrigadierNodeFactory<C, S> implements BrigadierNodeFac
     ) {
         final LiteralArgumentBuilder<S> literalArgumentBuilder = LiteralArgumentBuilder.<S>literal(root.getLiteral())
                 .requires(new BrigadierPermissionPredicate<>(permissionChecker, cloudCommand));
-        if (cloudCommand.component() != null && cloudCommand.component().owningCommand() != null) {
-            literalArgumentBuilder.executes(executor);
-        }
+        this.updateExecutes(literalArgumentBuilder, cloudCommand, executor);
         final LiteralCommandNode<S> constructedRoot = literalArgumentBuilder.build();
         for (final cloud.commandframework.internal.CommandNode<C> child : cloudCommand.children()) {
             constructedRoot.addChild(this.constructCommandNode(
-                    true,
                     child,
                     permissionChecker,
                     executor,
@@ -118,7 +118,6 @@ public final class LiteralBrigadierNodeFactory<C, S> implements BrigadierNodeFac
             final @NonNull String label,
             final cloud.commandframework.@NonNull Command<C> cloudCommand,
             final @NonNull BrigadierPermissionChecker<S> permissionChecker,
-            final boolean forceRegister,
             final @NonNull Command<S> executor
     ) {
         final cloud.commandframework.internal.CommandNode<C> node = this.commandManager
@@ -133,21 +132,17 @@ public final class LiteralBrigadierNodeFactory<C, S> implements BrigadierNodeFac
         final LiteralArgumentBuilder<S> literalArgumentBuilder = LiteralArgumentBuilder
                 .<S>literal(label)
                 .requires(new BrigadierPermissionPredicate<>(permissionChecker, node));
-        if (forceRegister || (node.component() != null && node.component().owningCommand() != null)) {
-            literalArgumentBuilder.executes(executor);
-        }
-        literalArgumentBuilder.executes(executor);
+
+        this.updateExecutes(literalArgumentBuilder, node, executor);
+
         final LiteralCommandNode<S> constructedRoot = literalArgumentBuilder.build();
         for (final cloud.commandframework.internal.CommandNode<C> child : node.children()) {
-            constructedRoot.addChild(this.constructCommandNode(forceRegister, child,
-                    permissionChecker, executor, provider
-            ).build());
+            constructedRoot.addChild(this.constructCommandNode(child, permissionChecker, executor, provider).build());
         }
         return constructedRoot;
     }
 
     private @NonNull ArgumentBuilder<S, ?> constructCommandNode(
-            final boolean forceExecutor,
             final cloud.commandframework.internal.@NonNull CommandNode<C> root,
             final @NonNull BrigadierPermissionChecker<S> permissionChecker,
             final com.mojang.brigadier.@NonNull Command<S> executor,
@@ -157,7 +152,6 @@ public final class LiteralBrigadierNodeFactory<C, S> implements BrigadierNodeFac
             final AggregateCommandParser<C, ?> aggregateParser = (AggregateCommandParser<C, ?>) root.component().parser();
             return this.constructAggregateNode(
                     aggregateParser,
-                    forceExecutor,
                     root,
                     permissionChecker,
                     executor,
@@ -167,18 +161,13 @@ public final class LiteralBrigadierNodeFactory<C, S> implements BrigadierNodeFac
 
         final ArgumentBuilder<S, ?> argumentBuilder;
         if (root.component().type() == CommandComponent.ComponentType.LITERAL) {
-            argumentBuilder = this.createLiteralArgumentBuilder(root.component(), root, permissionChecker, executor);
+            argumentBuilder = this.createLiteralArgumentBuilder(root.component(), root, permissionChecker);
         } else {
             argumentBuilder = this.createVariableArgumentBuilder(root.component(), root, permissionChecker);
         }
-        if (forceExecutor || root.isLeaf() || root.component().optional()) {
-            argumentBuilder.executes(executor);
-        }
-        if (root.children().stream().noneMatch(node -> node.component().required())) {
-            argumentBuilder.executes(executor);
-        }
+        this.updateExecutes(argumentBuilder, root, executor);
         for (final cloud.commandframework.internal.CommandNode<C> node : root.children()) {
-            argumentBuilder.then(this.constructCommandNode(forceExecutor, node, permissionChecker, executor, suggestionProvider));
+            argumentBuilder.then(this.constructCommandNode(node, permissionChecker, executor, suggestionProvider));
         }
         return argumentBuilder;
     }
@@ -186,12 +175,10 @@ public final class LiteralBrigadierNodeFactory<C, S> implements BrigadierNodeFac
     private @NonNull ArgumentBuilder<S, ?> createLiteralArgumentBuilder(
             final @NonNull CommandComponent<C> component,
             final cloud.commandframework.internal.@NonNull CommandNode<C> root,
-            final @NonNull BrigadierPermissionChecker<S> permissionChecker,
-            final com.mojang.brigadier.@NonNull Command<S> executor
+            final @NonNull BrigadierPermissionChecker<S> permissionChecker
     ) {
         return LiteralArgumentBuilder.<S>literal(component.name())
-                .requires(new BrigadierPermissionPredicate<>(permissionChecker, root))
-                .executes(executor);
+                .requires(new BrigadierPermissionPredicate<>(permissionChecker, root));
     }
 
     private @NonNull ArgumentBuilder<S, ?> createVariableArgumentBuilder(
@@ -219,7 +206,6 @@ public final class LiteralBrigadierNodeFactory<C, S> implements BrigadierNodeFac
 
     private @NonNull ArgumentBuilder<S, ?> constructAggregateNode(
             final @NonNull AggregateCommandParser<C, ?> aggregateParser,
-            final boolean forceExecutor,
             final cloud.commandframework.internal.@NonNull CommandNode<C> root,
             final @NonNull BrigadierPermissionChecker<S> permissionChecker,
             final com.mojang.brigadier.@NonNull Command<S> executor,
@@ -245,7 +231,7 @@ public final class LiteralBrigadierNodeFactory<C, S> implements BrigadierNodeFac
                     .requires(new BrigadierPermissionPredicate<>(permissionChecker, root));
             argumentBuilders[i] = fragmentBuilder;
 
-            if (forceExecutor || ((i == components.size() - 1) && (root.isLeaf() || !root.component().required()))) {
+            if (this.cloudBrigadierManager.settings().get(BrigadierSetting.FORCE_EXECUTABLE)) {
                 fragmentBuilder.executes(executor);
             }
 
@@ -255,9 +241,11 @@ public final class LiteralBrigadierNodeFactory<C, S> implements BrigadierNodeFac
             }
         }
 
+        this.updateExecutes(argumentBuilders[components.size() - 1], root, executor);
+
         for (final cloud.commandframework.internal.CommandNode<C> node : root.children()) {
             argumentBuilders[components.size() - 1]
-                    .then(this.constructCommandNode(forceExecutor, node, permissionChecker, executor, suggestionProvider));
+                    .then(this.constructCommandNode(node, permissionChecker, executor, suggestionProvider));
         }
 
         return argumentBuilders[0];
@@ -320,5 +308,33 @@ public final class LiteralBrigadierNodeFactory<C, S> implements BrigadierNodeFac
                 .argumentType(StringArgumentType.word())
                 .suggestionsType(SuggestionsType.CLOUD_SUGGESTIONS)
                 .build();
+    }
+
+    /**
+     * Invokes {@link ArgumentBuilder#executes(Command)} on the given {@code builder} if any of the given conditions are met:
+     * <ul>
+     *     <li>the node is a leaf node</li>
+     *     <li>the node is optional</li>
+     *     <li>the node has an associated owning command</li>
+     *     <li>any of the children of the node is optional</li>
+     * </ul>
+     *
+     * @param builder  brigadier node builder
+     * @param node     cloud node
+     * @param executor brigadier executor
+     */
+    private void updateExecutes(
+            final @NonNull ArgumentBuilder<S, ?> builder,
+            final @NonNull CommandNode<C> node,
+            final @NonNull Command<S> executor
+    ) {
+        if (this.cloudBrigadierManager.settings().get(BrigadierSetting.FORCE_EXECUTABLE)
+                || node.isLeaf()
+                || node.component().optional()
+                || node.component().owningCommand() != null
+                || node.children().stream().map(CommandNode::component)
+                    .filter(Objects::nonNull).anyMatch(CommandComponent::optional)) {
+            builder.executes(executor);
+        }
     }
 }

--- a/cloud-minecraft/cloud-brigadier/src/test/java/cloud/commandframework/brigadier/node/LiteralBrigadierNodeFactoryTest.java
+++ b/cloud-minecraft/cloud-brigadier/src/test/java/cloud/commandframework/brigadier/node/LiteralBrigadierNodeFactoryTest.java
@@ -35,6 +35,7 @@ import cloud.commandframework.context.StandardCommandContextFactory;
 import cloud.commandframework.execution.CommandExecutionCoordinator;
 import cloud.commandframework.internal.CommandRegistrationHandler;
 import cloud.commandframework.types.tuples.Pair;
+import com.mojang.brigadier.arguments.BoolArgumentType;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
@@ -52,6 +53,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static cloud.commandframework.arguments.standard.BooleanParser.booleanParser;
 import static cloud.commandframework.arguments.standard.IntegerParser.integerParser;
 import static cloud.commandframework.arguments.standard.StringParser.greedyStringParser;
 import static com.google.common.truth.Truth.assertThat;
@@ -98,7 +100,6 @@ class LiteralBrigadierNodeFactoryTest {
                 "command",
                 command,
                 (source, permission) -> true,
-                false /* forceRegister */,
                 brigadierCommand
         );
 
@@ -107,12 +108,12 @@ class LiteralBrigadierNodeFactoryTest {
         assertThat(commandNode.getLiteral()).isEqualTo("command");
         assertThat(commandNode.isValidInput("command")).isTrue();
         assertThat(commandNode.getChildren()).hasSize(1);
-        assertThat(commandNode.getCommand()).isEqualTo(brigadierCommand);
+        assertThat(commandNode.getCommand()).isNull();
 
         assertThat(commandNode.getChild("literal")).isNotNull();
         assertThat(commandNode.getChild("literal")).isInstanceOf(LiteralCommandNode.class);
         assertThat(commandNode.getChild("literal").getChildren()).hasSize(1);
-        assertThat(commandNode.getCommand()).isEqualTo(brigadierCommand);
+        assertThat(commandNode.getCommand()).isNull();
 
         assertThat(commandNode.getChild("literal").getChild("integer")).isNotNull();
         assertThat(commandNode.getChild("literal").getChild("integer")).isInstanceOf(ArgumentCommandNode.class);
@@ -122,7 +123,7 @@ class LiteralBrigadierNodeFactoryTest {
         assertThat(integerArgument.getType()).isInstanceOf(IntegerArgumentType.class);
         assertThat(integerArgument.getType()).isEqualTo(IntegerArgumentType.integer(0, 10));
         assertThat(integerArgument.getChildren()).hasSize(1);
-        assertThat(integerArgument.getCommand()).isEqualTo(brigadierCommand);
+        assertThat(integerArgument.getCommand()).isEqualTo(brigadierCommand); // Following is optional.
 
         assertThat(integerArgument.getChild("string")).isNotNull();
         assertThat(integerArgument.getChild("string")).isInstanceOf(ArgumentCommandNode.class);
@@ -164,6 +165,7 @@ class LiteralBrigadierNodeFactoryTest {
                                         )
                                 ).build()
                 )
+                .required("boolean", booleanParser())
                 .build();
         this.commandManager.command(command);
         final com.mojang.brigadier.Command<Object> brigadierCommand = ctx -> 0;
@@ -173,7 +175,6 @@ class LiteralBrigadierNodeFactoryTest {
                 "command",
                 command,
                 (source, permission) -> true,
-                false /* forceRegister */,
                 brigadierCommand
         );
 
@@ -182,12 +183,12 @@ class LiteralBrigadierNodeFactoryTest {
         assertThat(commandNode.getLiteral()).isEqualTo("command");
         assertThat(commandNode.isValidInput("command")).isTrue();
         assertThat(commandNode.getChildren()).hasSize(1);
-        assertThat(commandNode.getCommand()).isEqualTo(brigadierCommand);
+        assertThat(commandNode.getCommand()).isNull();
 
         assertThat(commandNode.getChild("literal")).isNotNull();
         assertThat(commandNode.getChild("literal")).isInstanceOf(LiteralCommandNode.class);
         assertThat(commandNode.getChild("literal").getChildren()).hasSize(1);
-        assertThat(commandNode.getCommand()).isEqualTo(brigadierCommand);
+        assertThat(commandNode.getCommand()).isNull();
 
         assertThat(commandNode.getChild("literal").getChild("integer")).isNotNull();
         assertThat(commandNode.getChild("literal").getChild("integer")).isInstanceOf(ArgumentCommandNode.class);
@@ -207,8 +208,8 @@ class LiteralBrigadierNodeFactoryTest {
         assertThat(stringArgument.getType()).isInstanceOf(StringArgumentType.class);
         assertThat(((StringArgumentType) stringArgument.getType()).getType())
                 .isEqualTo(StringArgumentType.StringType.GREEDY_PHRASE);
-        assertThat(stringArgument.getChildren()).isEmpty();
-        assertThat(stringArgument.getCommand()).isEqualTo(brigadierCommand);
+        assertThat(stringArgument.getChildren()).hasSize(0);
+        assertThat(stringArgument.getCommand()).isNull();
     }
 
 

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/CloudCommodoreManager.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/CloudCommodoreManager.java
@@ -111,7 +111,7 @@ class CloudCommodoreManager<C> extends BukkitPluginRegistrationHandler<C> {
                             this.commandManager.getCommandSenderMapper().apply(bukkitSender),
                             commandPermission
                     );
-                }, false, o -> 1);
+                }, o -> 1);
         final CommandNode existingNode = this.getDispatcher().findNode(Collections.singletonList(label));
         if (existingNode != null) {
             this.mergeChildren(existingNode, literalCommandNode);

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/FabricCommandRegistrationHandler.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/FabricCommandRegistrationHandler.java
@@ -171,7 +171,6 @@ abstract class FabricCommandRegistrationHandler<C, S extends SharedSuggestionPro
                                     this.commandManager().commandSourceMapper().apply(src),
                                     perm
                             ),
-                            true,
                             new FabricExecutor<>(this.commandManager())
                     );
 
@@ -240,7 +239,6 @@ abstract class FabricCommandRegistrationHandler<C, S extends SharedSuggestionPro
                         component.name(),
                         command,
                         permission,
-                        true /* forceRegister */,
                         executor
             );
 

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/VelocityPluginRegistrationHandler.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/VelocityPluginRegistrationHandler.java
@@ -70,7 +70,6 @@ final class VelocityPluginRegistrationHandler<C> implements CommandRegistrationH
                                 this.manager.commandSenderMapper().apply(c),
                                 p
                         ),
-                        true,
                         new VelocityExecutor<>(this.manager)
                 )
         );


### PR DESCRIPTION
This no longer marks everything as executable, at the cost of us being able to capture invalid input.
