### PR TITLE
feat(brigadier): add missing generic to BrigadierManagerHolder, switc…

### DIFF
--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/BrigadierManagerHolder.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/BrigadierManagerHolder.java
@@ -23,26 +23,52 @@
 //
 package cloud.commandframework.brigadier;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.apiguardian.api.API;
 
 /**
- * This interface is implemented by command managers capable of registering commands to Brigadier.
+ * Interface implemented by {@link cloud.commandframework.CommandManager command managers} that are capable of registering
+ * commands to Brigadier using {@link CloudBrigadierManager}.
  *
- * @param <C> Command sender type
+ * @param <C> cloud command sender type
+ * @param <S> brigadier command source type
  * @since 1.2.0
  */
-public interface BrigadierManagerHolder<C> {
+@API(status = API.Status.STABLE, since = "2.0.0")
+public interface BrigadierManagerHolder<C, S> {
 
     /**
-     * Get the Brigadier manager instance used by this manager. This method being present
-     * in a command manager means the manager has the capability to register commands
-     * to Brigadier, but does not necessarily mean that this capability is being used.
-     * <p>
-     * In the case that Brigadier isn't used, this method should always return {@code null}.
+     * Returns whether the {@link CloudBrigadierManager} is present and active.
      *
-     * @return The Brigadier manager instance, if commands are being registered to Brigadier.
-     *         Else, {@code null}
+     * @return if the {@link CloudBrigadierManager brigadier manager} is  present and active
+     * @since 2.0.0
+     */
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    boolean hasBrigadierManager();
+
+    /**
+     * Get the {@link CloudBrigadierManager} used by this {@link cloud.commandframework.CommandManager command manager}.
+     *
+     * <p>Generally, {@link #hasBrigadierManager()} should be checked before calling this method. However, some command managers
+     * will always use Brigadier and in those cases the check can be skipped (this will be in the relevant manager's
+     * documentation).</p>
+     *
+     * @return the {@link CloudBrigadierManager}
+     * @throws BrigadierManagerNotPresent when {@link #hasBrigadierManager()} is false
      * @since 1.2.0
      */
-    @Nullable CloudBrigadierManager<C, ?> brigadierManager();
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    CloudBrigadierManager<C, ? extends S> brigadierManager();
+
+    /**
+     * Exception thrown when {@link #brigadierManager()} is called and {@link #hasBrigadierManager()}
+     * is {@code false}.
+     *
+     * @since 2.0.0
+     */
+    @API(status = API.Status.STABLE, since = "2.0.0")
+    final class BrigadierManagerNotPresent extends RuntimeException {
+        public BrigadierManagerNotPresent(final String message) {
+            super(message);
+        }
+    }
 }

--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/BrigadierManagerHolder.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/BrigadierManagerHolder.java
@@ -65,8 +65,15 @@ public interface BrigadierManagerHolder<C, S> {
      *
      * @since 2.0.0
      */
+    @SuppressWarnings("serial")
     @API(status = API.Status.STABLE, since = "2.0.0")
     final class BrigadierManagerNotPresent extends RuntimeException {
+
+        /**
+         * Creates a new {@link BrigadierManagerNotPresent} exception.
+         *
+         * @param message detail message
+         */
         public BrigadierManagerNotPresent(final String message) {
             super(message);
         }

--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/BrigadierManagerHolder.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/BrigadierManagerHolder.java
@@ -24,6 +24,7 @@
 package cloud.commandframework.brigadier;
 
 import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * Interface implemented by {@link cloud.commandframework.CommandManager command managers} that are capable of registering
@@ -57,7 +58,7 @@ public interface BrigadierManagerHolder<C, S> {
      * @since 1.2.0
      */
     @API(status = API.Status.STABLE, since = "2.0.0")
-    CloudBrigadierManager<C, ? extends S> brigadierManager();
+    @NonNull CloudBrigadierManager<C, ? extends S> brigadierManager();
 
     /**
      * Exception thrown when {@link #brigadierManager()} is called and {@link #hasBrigadierManager()}

--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/CloudBrigadierManager.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/CloudBrigadierManager.java
@@ -71,8 +71,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * <a href="https://github.com/aikar/commands/blob/master/brigadier/src/main/java/co.aikar.commands/ACFBrigadierManager.java">
  * ACFBrigadiermanager</a> in the ACF project, which was originally written by MiniDigger and licensed under the MIT license.
  *
- * @param <C> Command sender type
- * @param <S> Brigadier sender type
+ * @param <C> cloud command sender type
+ * @param <S> brigadier command source type
  */
 @SuppressWarnings({"unchecked", "unused"})
 public final class CloudBrigadierManager<C, S> {

--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/argument/BrigadierMappings.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/argument/BrigadierMappings.java
@@ -34,8 +34,8 @@ public interface BrigadierMappings<C, S> {
     /**
      * Returns a new instance of the default implementation.
      *
-     * @param <C> the Cloud command sender type
-     * @param <S> the Brigadier command sender type
+     * @param <C> cloud command sender type
+     * @param <S> brigadier command source type
      * @return the mapping instance
      */
     static <C, S> @NonNull BrigadierMappings<C, S> create() {

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandManager.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandManager.java
@@ -73,6 +73,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.logging.Level;
+import org.apiguardian.api.API;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -90,8 +91,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * @param <C> Command sender type
  */
-@SuppressWarnings("unchecked")
-public class BukkitCommandManager<C> extends CommandManager<C> implements BrigadierManagerHolder<C> {
+public class BukkitCommandManager<C> extends CommandManager<C> implements BrigadierManagerHolder<C, Object> {
 
     private static final String MESSAGE_INTERNAL_ERROR = ChatColor.RED
             + "An internal error occurred while attempting to perform this command.";
@@ -124,7 +124,6 @@ public class BukkitCommandManager<C> extends CommandManager<C> implements Brigad
      * @param backwardsCommandSenderMapper Function that maps the command sender type to {@link CommandSender}
      * @throws Exception If the construction of the manager fails
      */
-    @SuppressWarnings("unchecked")
     public BukkitCommandManager(
             final @NonNull Plugin owningPlugin,
             final @NonNull Function<@NonNull CommandTree<@NonNull C>,
@@ -345,17 +344,19 @@ public class BukkitCommandManager<C> extends CommandManager<C> implements Brigad
         }
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @since 1.2.0
-     */
+    @Override
+    public boolean hasBrigadierManager() {
+        return this.commandRegistrationHandler() instanceof CloudCommodoreManager;
+    }
+
+    @API(status = API.Status.STABLE, since = "2.0.0")
     @Override
     public @Nullable CloudBrigadierManager<C, ?> brigadierManager() {
         if (this.commandRegistrationHandler() instanceof CloudCommodoreManager) {
             return ((CloudCommodoreManager<C>) this.commandRegistrationHandler()).brigadierManager();
         }
-        return null;
+        throw new BrigadierManagerHolder.BrigadierManagerNotPresent("The CloudBrigadierManager is either not supported in the " +
+                "current environment, or it is not enabled.");
     }
 
     /**

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandManager.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandManager.java
@@ -344,19 +344,32 @@ public class BukkitCommandManager<C> extends CommandManager<C> implements Brigad
         }
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@inheritDoc}
+     * @since 2.0.0
+     */
     @Override
     public boolean hasBrigadierManager() {
         return this.commandRegistrationHandler() instanceof CloudCommodoreManager;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@inheritDoc}
+     * @throws BrigadierManagerNotPresent when {@link #hasBrigadierManager()} is false
+     * @since 1.2.0
+     */
     @API(status = API.Status.STABLE, since = "2.0.0")
     @Override
     public @Nullable CloudBrigadierManager<C, ?> brigadierManager() {
         if (this.commandRegistrationHandler() instanceof CloudCommodoreManager) {
             return ((CloudCommodoreManager<C>) this.commandRegistrationHandler()).brigadierManager();
         }
-        throw new BrigadierManagerHolder.BrigadierManagerNotPresent("The CloudBrigadierManager is either not supported in the " +
-                "current environment, or it is not enabled.");
+        throw new BrigadierManagerHolder.BrigadierManagerNotPresent("The CloudBrigadierManager is either not supported in the "
+                + "current environment, or it is not enabled.");
     }
 
     /**

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandManager.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandManager.java
@@ -365,7 +365,7 @@ public class BukkitCommandManager<C> extends CommandManager<C> implements Brigad
      */
     @API(status = API.Status.STABLE, since = "2.0.0")
     @Override
-    public @Nullable CloudBrigadierManager<C, ?> brigadierManager() {
+    public @NonNull CloudBrigadierManager<C, ?> brigadierManager() {
         if (this.commandRegistrationHandler() instanceof CloudCommodoreManager) {
             return ((CloudCommodoreManager<C>) this.commandRegistrationHandler()).brigadierManager();
         }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandManager.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandManager.java
@@ -350,6 +350,7 @@ public class BukkitCommandManager<C> extends CommandManager<C> implements Brigad
      * @return {@inheritDoc}
      * @since 2.0.0
      */
+    @API(status = API.Status.STABLE, since = "2.0.0")
     @Override
     public boolean hasBrigadierManager() {
         return this.commandRegistrationHandler() instanceof CloudCommodoreManager;

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandManager.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommandManager.java
@@ -84,7 +84,6 @@ import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Command manager for the Bukkit platform

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/CloudCommodoreManager.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/CloudCommodoreManager.java
@@ -91,7 +91,7 @@ class CloudCommodoreManager<C> extends BukkitPluginRegistrationHandler<C> {
         this.unregisterWithCommodore(label);
     }
 
-    protected @NonNull CloudBrigadierManager brigadierManager() {
+    protected @NonNull CloudBrigadierManager<C, Object> brigadierManager() {
         return this.brigadierManager;
     }
 

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/FabricCommandManager.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/FabricCommandManager.java
@@ -102,6 +102,7 @@ import net.minecraft.world.scores.PlayerTeam;
 import net.minecraft.world.scores.criteria.ObjectiveCriteria;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -119,7 +120,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  * @since 1.5.0
  */
 public abstract class FabricCommandManager<C, S extends SharedSuggestionProvider> extends CommandManager<C> implements
-        BrigadierManagerHolder<C> {
+        BrigadierManagerHolder<C, S> {
 
     private static final Logger LOGGER = LogManager.getLogger();
     private static final int MOD_PUBLIC_STATIC_FINAL = Modifier.PUBLIC | Modifier.STATIC | Modifier.FINAL;
@@ -364,6 +365,27 @@ public abstract class FabricCommandManager<C, S extends SharedSuggestionProvider
         return this.backwardsCommandSourceMapper;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This will always return true for {@link FabricCommandManager}s.</p>
+     *
+     * @return {@code true}
+     * @since 2.0.0
+     */
+    @Override
+    public boolean hasBrigadierManager() {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>{@link FabricCommandManager}s always use Brigadier for registration, so the aforementioned check is not needed.</p>
+     *
+     * @return {@inheritDoc}
+     */
+    @API(status = API.Status.STABLE, since = "2.0.0")
     @Override
     public final @NonNull CloudBrigadierManager<C, S> brigadierManager() {
         return this.brigadierManager;

--- a/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/FabricCommandManager.java
+++ b/cloud-minecraft/cloud-fabric/src/main/java/cloud/commandframework/fabric/FabricCommandManager.java
@@ -373,8 +373,9 @@ public abstract class FabricCommandManager<C, S extends SharedSuggestionProvider
      * @return {@code true}
      * @since 2.0.0
      */
+    @API(status = API.Status.STABLE, since = "2.0.0")
     @Override
-    public boolean hasBrigadierManager() {
+    public final boolean hasBrigadierManager() {
         return true;
     }
 

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperCommandManager.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperCommandManager.java
@@ -39,7 +39,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.Plugin;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Paper command manager that extends {@link BukkitCommandManager}

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperCommandManager.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperCommandManager.java
@@ -34,6 +34,7 @@ import cloud.commandframework.paper.suggestions.SuggestionListenerFactory;
 import cloud.commandframework.state.RegistrationState;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
+import org.apiguardian.api.API;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.Plugin;
@@ -142,11 +143,12 @@ public class PaperCommandManager<C> extends BukkitCommandManager<C> {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @since 1.2.0
-     */
+    @Override
+    public boolean hasBrigadierManager() {
+        return this.paperBrigadierListener != null || super.hasBrigadierManager();
+    }
+
+    @API(status = API.Status.STABLE, since = "2.0.0")
     @Override
     public @Nullable CloudBrigadierManager<C, ?> brigadierManager() {
         if (this.paperBrigadierListener != null) {

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperCommandManager.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperCommandManager.java
@@ -164,7 +164,7 @@ public class PaperCommandManager<C> extends BukkitCommandManager<C> {
      */
     @API(status = API.Status.STABLE, since = "2.0.0")
     @Override
-    public @Nullable CloudBrigadierManager<C, ?> brigadierManager() {
+    public @NonNull CloudBrigadierManager<C, ?> brigadierManager() {
         if (this.paperBrigadierListener != null) {
             return this.paperBrigadierListener.brigadierManager();
         }

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperCommandManager.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperCommandManager.java
@@ -149,6 +149,7 @@ public class PaperCommandManager<C> extends BukkitCommandManager<C> {
      * @return {@inheritDoc}
      * @since 2.0.0
      */
+    @API(status = API.Status.STABLE, since = "2.0.0")
     @Override
     public boolean hasBrigadierManager() {
         return this.paperBrigadierListener != null || super.hasBrigadierManager();

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperCommandManager.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperCommandManager.java
@@ -143,11 +143,24 @@ public class PaperCommandManager<C> extends BukkitCommandManager<C> {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@inheritDoc}
+     * @since 2.0.0
+     */
     @Override
     public boolean hasBrigadierManager() {
         return this.paperBrigadierListener != null || super.hasBrigadierManager();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@inheritDoc}
+     * @throws BrigadierManagerNotPresent when {@link #hasBrigadierManager()} is false
+     * @since 1.2.0
+     */
     @API(status = API.Status.STABLE, since = "2.0.0")
     @Override
     public @Nullable CloudBrigadierManager<C, ?> brigadierManager() {

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/VelocityCommandManager.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/VelocityCommandManager.java
@@ -172,8 +172,9 @@ public class VelocityCommandManager<C> extends CommandManager<C> implements Brig
      * @return {@code true}
      * @since 2.0.0
      */
+    @API(status = API.Status.STABLE, since = "2.0.0")
     @Override
-    public boolean hasBrigadierManager() {
+    public final boolean hasBrigadierManager() {
         return true;
     }
 
@@ -187,7 +188,7 @@ public class VelocityCommandManager<C> extends CommandManager<C> implements Brig
      */
     @API(status = API.Status.STABLE, since = "2.0.0")
     @Override
-    public @NonNull CloudBrigadierManager<C, CommandSource> brigadierManager() {
+    public final @NonNull CloudBrigadierManager<C, CommandSource> brigadierManager() {
         return ((VelocityPluginRegistrationHandler<C>) this.commandRegistrationHandler()).brigadierManager();
     }
 

--- a/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/VelocityCommandManager.java
+++ b/cloud-minecraft/cloud-velocity/src/main/java/cloud/commandframework/velocity/VelocityCommandManager.java
@@ -56,6 +56,7 @@ import java.util.function.Function;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -72,7 +73,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  * @param <C> Command sender type
  */
 @Singleton
-public class VelocityCommandManager<C> extends CommandManager<C> implements BrigadierManagerHolder<C> {
+public class VelocityCommandManager<C> extends CommandManager<C> implements BrigadierManagerHolder<C, CommandSource> {
 
     private static final String MESSAGE_INTERNAL_ERROR = "An internal error occurred while attempting to perform this command.";
     private static final String MESSAGE_NO_PERMS =
@@ -165,13 +166,26 @@ public class VelocityCommandManager<C> extends CommandManager<C> implements Brig
 
     /**
      * {@inheritDoc}
-     * <p>
-     * In the case of the {@link VelocityCommandManager}, Brigadier is always used for command registration,
-     * and therefore this method will never return {@code null}.
      *
+     * <p>This will always return true for {@link VelocityCommandManager}s.</p>
+     *
+     * @return {@code true}
+     * @since 2.0.0
+     */
+    @Override
+    public boolean hasBrigadierManager() {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>{@link VelocityCommandManager}s always use Brigadier for registration, so the aforementioned check is not needed.</p>
+     *
+     * @return {@inheritDoc}
      * @since 1.2.0
      */
-    @SuppressWarnings("unchecked")
+    @API(status = API.Status.STABLE, since = "2.0.0")
     @Override
     public @NonNull CloudBrigadierManager<C, CommandSource> brigadierManager() {
         return ((VelocityPluginRegistrationHandler<C>) this.commandRegistrationHandler()).brigadierManager();


### PR DESCRIPTION
…h #brigadierManager nullability for a boolean method and exception

Checking for null is fine when working with generic code, but when working directly with a PaperCommandManager for example, it becomes annoying as we must have already checked capabilities and registered brigadier before calling #brigadierManager.