### PR TITLE
Respect sender types & permissions in more places

### DIFF
--- a/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandManager.java
@@ -102,7 +102,7 @@ public abstract class CommandManager<C> implements Stateful<RegistrationState>, 
     private final CommandExecutor<C> commandExecutor;
 
     private CaptionFormatter<C, String> captionVariableReplacementHandler = CaptionFormatter.placeholderReplacing();
-    private CommandSyntaxFormatter<C> commandSyntaxFormatter = new StandardCommandSyntaxFormatter<>();
+    private CommandSyntaxFormatter<C> commandSyntaxFormatter = new StandardCommandSyntaxFormatter<>(this);
     private CommandSuggestionProcessor<C> commandSuggestionProcessor = new FilteringCommandSuggestionProcessor<>();
     private CommandRegistrationHandler<C> commandRegistrationHandler;
     private CaptionRegistry<C> captionRegistry;

--- a/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
+++ b/cloud-core/src/main/java/cloud/commandframework/CommandTree.java
@@ -1041,7 +1041,6 @@ public final class CommandTree<C> {
      */
     @SuppressWarnings("unchecked")
     private void propagateRequirements(final @NonNull CommandNode<C> leafNode) {
-        // noinspection all
         final Permission commandPermission = leafNode.component().owningCommand().commandPermission();
         Class<?> senderType = leafNode.component().owningCommand().senderType().orElse(null);
         if (senderType == null) {

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/CommandSyntaxFormatter.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/CommandSyntaxFormatter.java
@@ -42,6 +42,7 @@ public interface CommandSyntaxFormatter<C> {
     /**
      * Format the command arguments into a syntax string
      *
+     * @param sender            The sender to format syntax for.
      * @param commandComponents Command arguments that have been unambiguously specified up until this point. This
      *                          should include the "current" command, if such a command exists.
      * @param node              The current command node. The children of this node will be appended onto the
@@ -51,6 +52,7 @@ public interface CommandSyntaxFormatter<C> {
      * @return The formatted syntax string
      */
     @NonNull String apply(
+            @Nullable C sender,
             @NonNull List<@NonNull CommandComponent<C>> commandComponents,
             @Nullable CommandNode<C> node
     );

--- a/cloud-core/src/main/java/cloud/commandframework/arguments/StandardCommandSyntaxFormatter.java
+++ b/cloud-core/src/main/java/cloud/commandframework/arguments/StandardCommandSyntaxFormatter.java
@@ -61,7 +61,7 @@ public class StandardCommandSyntaxFormatter<C> implements CommandSyntaxFormatter
      *
      * @param manager command manager
      */
-    public StandardCommandSyntaxFormatter(final CommandManager<C> manager) {
+    public StandardCommandSyntaxFormatter(final @NonNull CommandManager<C> manager) {
         this.manager = manager;
     }
 

--- a/cloud-core/src/main/java/cloud/commandframework/help/StandardHelpHandler.java
+++ b/cloud-core/src/main/java/cloud/commandframework/help/StandardHelpHandler.java
@@ -120,7 +120,7 @@ public class StandardHelpHandler<C> implements HelpHandler<C> {
                     query,
                     availableCommands.stream()
                             .map(command -> CommandEntry.of(command, this.commandManager.commandSyntaxFormatter()
-                                    .apply(command.components(), null)))
+                                    .apply(query.sender(), command.components(), null)))
                             .sorted()
                             .filter(entry -> this.commandManager.hasPermission(query.sender(), entry.command().commandPermission()))
                             .collect(Collectors.toList())
@@ -150,7 +150,7 @@ public class StandardHelpHandler<C> implements HelpHandler<C> {
                                 CommandEntry.of(
                                         head.component().owningCommand(),
                                         this.commandManager.commandSyntaxFormatter()
-                                                .apply(head.component().owningCommand().components(), null)
+                                                .apply(query.sender(), head.component().owningCommand().components(), null)
                                 )
                         );
                     }
@@ -182,7 +182,8 @@ public class StandardHelpHandler<C> implements HelpHandler<C> {
                         continue;
                     }
                 }
-                final String currentDescription = this.commandManager.commandSyntaxFormatter().apply(traversedNodes, null);
+                final String currentDescription = this.commandManager.commandSyntaxFormatter()
+                        .apply(query.sender(), traversedNodes, null);
                 /* Attempt to parse the longest possible description for the children */
                 final List<String> childSuggestions = new LinkedList<>();
                 for (final CommandNode<C> child : head.children()) {
@@ -197,7 +198,8 @@ public class StandardHelpHandler<C> implements HelpHandler<C> {
                             child.component().owningCommand().commandPermission()
                     )) {
                         traversedNodesSub.add(child.component());
-                        childSuggestions.add(this.commandManager.commandSyntaxFormatter().apply(traversedNodesSub, child));
+                        childSuggestions.add(this.commandManager.commandSyntaxFormatter()
+                                .apply(query.sender(), traversedNodesSub, child));
                     }
                 }
                 return MultipleCommandResult.of(query, currentDescription, childSuggestions);
@@ -223,7 +225,8 @@ public class StandardHelpHandler<C> implements HelpHandler<C> {
                 .filter(command -> this.commandManager.hasPermission(sender, command.commandPermission()))
                 .map(command -> CommandEntry.of(
                         command,
-                        this.commandManager.commandSyntaxFormatter().apply(command.components(), null))
+                        this.commandManager.commandSyntaxFormatter()
+                                .apply(sender, command.components(), null))
                 ).sorted()
                 .collect(Collectors.toList());
     }

--- a/cloud-core/src/main/java/cloud/commandframework/internal/CommandNode.java
+++ b/cloud-core/src/main/java/cloud/commandframework/internal/CommandNode.java
@@ -45,6 +45,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 @API(status = API.Status.INTERNAL, consumers = "cloud.commandframework.*", since = "2.0.0")
 public final class CommandNode<C> {
 
+    public static final String META_KEY_PERMISSION = "permission";
+    public static final String META_KEY_SENDER_TYPES = "senderTypes";
+
     private final Map<String, Object> nodeMeta = new HashMap<>();
     private final List<CommandNode<C>> children = new LinkedList<>();
     private final CommandComponent<C> component;

--- a/cloud-core/src/test/java/cloud/commandframework/arguments/StandardCommandSyntaxFormatterTest.java
+++ b/cloud-core/src/test/java/cloud/commandframework/arguments/StandardCommandSyntaxFormatterTest.java
@@ -1,0 +1,83 @@
+//
+// MIT License
+//
+// Copyright (c) 2024 Incendo
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package cloud.commandframework.arguments;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.CommandManager;
+import cloud.commandframework.TestCommandSender;
+import cloud.commandframework.execution.ExecutionCoordinator;
+import cloud.commandframework.internal.CommandNode;
+import cloud.commandframework.internal.CommandRegistrationHandler;
+import java.util.Collections;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+class StandardCommandSyntaxFormatterTest {
+
+    @Test
+    void accountsForSenderType() {
+        final CommandManager<TestCommandSender> commandManager = new CommandManager<TestCommandSender>(
+                ExecutionCoordinator.simpleCoordinator(),
+                CommandRegistrationHandler.nullCommandRegistrationHandler()
+        ) {
+            @Override
+            public boolean hasPermission(
+                    final @NonNull TestCommandSender sender,
+                    final @NonNull String permission
+            ) {
+                return true;
+            }
+        };
+
+        final Command.Builder<TestCommandSender> root = commandManager.commandBuilder("root");
+        commandManager.command(
+                root.literal("all")
+                        .handler(ctx -> {})
+        );
+        commandManager.command(
+                root.literal("specific_only")
+                        .senderType(SpecificTestCommandSender.class)
+                        .handler(ctx -> {})
+        );
+
+        final StandardCommandSyntaxFormatter<TestCommandSender> formatter =
+                new StandardCommandSyntaxFormatter<>(commandManager);
+
+        final CommandNode<TestCommandSender> rootNode = commandManager.commandTree().getNamedNode("root");
+
+        final String specificFormatted = formatter.apply(
+                new SpecificTestCommandSender(), Collections.emptyList(), rootNode);
+        assertThat(specificFormatted).isEqualTo(" all|specific_only");
+
+        final String formatted = formatter.apply(
+                new TestCommandSender(), Collections.emptyList(), rootNode);
+        assertThat(formatted).isEqualTo(" all");
+    }
+
+    static final class SpecificTestCommandSender extends TestCommandSender {
+
+    }
+}

--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/node/BrigadierNodeFactory.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/node/BrigadierNodeFactory.java
@@ -45,7 +45,7 @@ public interface BrigadierNodeFactory<C, S, N extends CommandNode<S>> {
             @NonNull String label,
             cloud.commandframework.internal.@NonNull CommandNode<C> cloudCommand,
             @NonNull Command<S> executor,
-            @NonNull BrigadierPermissionChecker<S> permissionChecker
+            @NonNull BrigadierPermissionChecker<C> permissionChecker
     );
 
     /**
@@ -61,7 +61,7 @@ public interface BrigadierNodeFactory<C, S, N extends CommandNode<S>> {
             @NonNull String label,
             cloud.commandframework.@NonNull Command<C> cloudCommand,
             @NonNull Command<S> executor,
-            @NonNull BrigadierPermissionChecker<S> permissionChecker
+            @NonNull BrigadierPermissionChecker<C> permissionChecker
     );
 
     /**

--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/permission/BrigadierPermissionChecker.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/permission/BrigadierPermissionChecker.java
@@ -29,7 +29,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
 @FunctionalInterface
 @API(status = API.Status.INTERNAL, since = "2.0.0")
-public interface BrigadierPermissionChecker<S> {
+public interface BrigadierPermissionChecker<C> {
 
     /**
      * Returns whether the given Brigadier {@code sender} has the given {@code permission}.
@@ -38,5 +38,5 @@ public interface BrigadierPermissionChecker<S> {
      * @param permission the permission
      * @return {@code true} if the {@code sender} has the {@code permission}, else {@code false}
      */
-    boolean hasPermission(@NonNull S sender, @NonNull Permission permission);
+    boolean hasPermission(@NonNull C sender, @NonNull Permission permission);
 }

--- a/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/permission/BrigadierPermissionPredicate.java
+++ b/cloud-minecraft/cloud-brigadier/src/main/java/cloud/commandframework/brigadier/permission/BrigadierPermissionPredicate.java
@@ -23,39 +23,60 @@
 //
 package cloud.commandframework.brigadier.permission;
 
+import cloud.commandframework.SenderMapper;
 import cloud.commandframework.internal.CommandNode;
 import cloud.commandframework.permission.Permission;
+import java.util.Collections;
+import java.util.Set;
 import java.util.function.Predicate;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 @API(status = API.Status.INTERNAL, since = "2.0.0")
-public final class BrigadierPermissionPredicate<S> implements Predicate<S> {
+public final class BrigadierPermissionPredicate<C, S> implements Predicate<S> {
 
-    private final BrigadierPermissionChecker<S> permissionChecker;
+    private final SenderMapper<S, C> senderMapper;
+    private final BrigadierPermissionChecker<C> permissionChecker;
     private final CommandNode<?> node;
 
     /**
      * Returns a new predicate that uses the given {@code permissionChecker} to evaluate the permission attached
      * to the given {@code node}.
      *
+     * @param senderMapper      mapper from brig source to cloud sender
      * @param permissionChecker the permission checker
      * @param node              the cloud command node
      */
     public BrigadierPermissionPredicate(
-            final @NonNull BrigadierPermissionChecker<S> permissionChecker,
+            final @NonNull SenderMapper<S, C> senderMapper,
+            final @NonNull BrigadierPermissionChecker<C> permissionChecker,
             final @NonNull CommandNode<?> node
     ) {
+        this.senderMapper = senderMapper;
         this.permissionChecker = permissionChecker;
         this.node = node;
     }
 
     @Override
-    public boolean test(final @NonNull S sender) {
+    @SuppressWarnings("unchecked")
+    public boolean test(final @NonNull S source) {
         final Permission permission = (Permission) this.node.nodeMeta().getOrDefault(
-                "permission",
+                CommandNode.META_KEY_PERMISSION,
                 Permission.empty()
         );
-        return this.permissionChecker.hasPermission(sender, permission);
+        final Set<Class<?>> senderTypes = (Set<Class<?>>) this.node.nodeMeta().getOrDefault(
+                CommandNode.META_KEY_SENDER_TYPES,
+                Collections.emptySet()
+        );
+        final C cloudSender = this.senderMapper.map(source);
+        if (senderTypes.isEmpty()) {
+            return this.permissionChecker.hasPermission(cloudSender, permission);
+        }
+        for (final Class<?> senderType : senderTypes) {
+            if (senderType.isInstance(cloudSender)) {
+                return this.permissionChecker.hasPermission(cloudSender, permission);
+            }
+        }
+        return false;
     }
 }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommand.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommand.java
@@ -137,6 +137,7 @@ final class BukkitCommand<C> extends org.bukkit.command.Command implements Plugi
     @Override
     public @NonNull String getUsage() {
         return this.manager.commandSyntaxFormatter().apply(
+                null,
                 Collections.singletonList(Objects.requireNonNull(this.namedNode().component())),
                 this.namedNode()
         );

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommand.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/BukkitCommand.java
@@ -151,7 +151,7 @@ final class BukkitCommand<C> extends org.bukkit.command.Command implements Plugi
 
         final Permission permission = (Permission) node
                 .nodeMeta()
-                .getOrDefault("permission", Permission.empty());
+                .getOrDefault(CommandNode.META_KEY_PERMISSION, Permission.empty());
 
         return this.manager.hasPermission(this.manager.senderMapper().map(target), permission);
     }

--- a/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/CloudCommodoreManager.java
+++ b/cloud-minecraft/cloud-bukkit/src/main/java/cloud/commandframework/bukkit/CloudCommodoreManager.java
@@ -99,17 +99,13 @@ class CloudCommodoreManager<C> extends BukkitPluginRegistrationHandler<C> {
             final @NonNull Command<C> command
     ) {
         final LiteralCommandNode<?> literalCommandNode = this.brigadierManager.literalBrigadierNodeFactory()
-                .createNode(label, command, o -> 1, (commandSourceStack, commandPermission) -> {
+                .createNode(label, command, o -> 1, (sender, commandPermission) -> {
                     // We need to check that the command still exists...
                     if (this.commandManager.commandTree().getNamedNode(label) == null) {
                         return false;
                     }
 
-                    final CommandSender bukkitSender = getBukkitSender(commandSourceStack);
-                    return this.commandManager.hasPermission(
-                            this.commandManager.senderMapper().map(bukkitSender),
-                            commandPermission
-                    );
+                    return this.commandManager.hasPermission(sender, commandPermission);
                 });
         final CommandNode existingNode = this.getDispatcher().findNode(Collections.singletonList(label));
         if (existingNode != null) {

--- a/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/MinecraftHelp.java
+++ b/cloud-minecraft/cloud-minecraft-extras/src/main/java/cloud/commandframework/minecraft/extras/MinecraftHelp.java
@@ -509,7 +509,7 @@ public abstract class MinecraftHelp<C> {
         audience.sendMessage(this.basicHeader(sender));
         audience.sendMessage(this.showingResults(sender, query));
         final String command = this.commandManager().commandSyntaxFormatter()
-                .apply(helpTopic.entry().command().components(), null);
+                .apply(sender, helpTopic.entry().command().components(), null);
         audience.sendMessage(text()
                 .append(this.lastBranch())
                 .append(space())
@@ -558,7 +558,7 @@ public abstract class MinecraftHelp<C> {
                 final CommandComponent<C> component = iterator.next();
 
                 final String syntax = this.commandManager().commandSyntaxFormatter()
-                        .apply(Collections.singletonList(component), null);
+                        .apply(sender, Collections.singletonList(component), null);
 
                 final TextComponent.Builder textComponent = text()
                         .append(text("       "))

--- a/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperBrigadierListener.java
+++ b/cloud-minecraft/cloud-paper/src/main/java/cloud/commandframework/paper/PaperBrigadierListener.java
@@ -95,14 +95,13 @@ class PaperBrigadierListener<C> implements Listener {
             return;
         }
 
-        final BrigadierPermissionChecker<BukkitBrigadierCommandSource> permissionChecker = (sender, permission) -> {
+        final BrigadierPermissionChecker<C> permissionChecker = (sender, permission) -> {
             // We need to check that the command still exists...
             if (commandTree.getNamedNode(label) == null) {
                 return false;
             }
 
-            final C commandSender = this.paperCommandManager.senderMapper().map(sender.getBukkitSender());
-            return this.paperCommandManager.hasPermission(commandSender, permission);
+            return this.paperCommandManager.hasPermission(sender, permission);
         };
         final LiteralBrigadierNodeFactory<C, BukkitBrigadierCommandSource> literalFactory =
                 this.brigadierManager.literalBrigadierNodeFactory();

--- a/cloud-minecraft/cloud-sponge7/src/main/java/cloud/commandframework/sponge7/CloudCommandCallable.java
+++ b/cloud-minecraft/cloud-sponge7/src/main/java/cloud/commandframework/sponge7/CloudCommandCallable.java
@@ -123,6 +123,7 @@ final class CloudCommandCallable<C> implements CommandCallable {
     @Override
     public Text getUsage(final @NonNull CommandSource source) {
         return Text.of(this.manager.commandSyntaxFormatter().apply(
+                this.manager.senderMapper().map(source),
                 Collections.emptyList(),
                 this.manager.commandTree().getNamedNode(this.command.name())
         ));


### PR DESCRIPTION
- Propagate required sender types down the command tree and use that information for Brigadier requirement checks
- Check permissions and sender types in the StandardCommandSyntaxFormatter
- Check sender types before suggesting

todo:
- use for help? (are there any other spots I'm missing?)
- more tests?