### PR TITLE
feat: use captions for the default exception handlers

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -21,6 +21,10 @@ acceptedBreaks:
         \ org.incendo.cloud.permission.Permission, org.incendo.cloud.meta.CommandMeta,\
         \ org.incendo.cloud.description.CommandDescription)"
       justification: "beta release"
+    - code: "java.method.addedToInterface"
+      new: "method T org.incendo.cloud.caption.CaptionFormatter<C, T>::formatCaption(org.incendo.cloud.caption.Caption,\
+        \ C, java.lang.String, java.util.Collection<org.incendo.cloud.caption.CaptionVariable>)"
+      justification: "beta release"
     - code: "java.method.numberOfParametersChanged"
       old: "method void org.incendo.cloud.Command<C>::<init>(java.util.List<org.incendo.cloud.component.CommandComponent<C>>,\
         \ org.incendo.cloud.execution.CommandExecutionHandler<C>, org.incendo.cloud.permission.Permission,\

--- a/cloud-core/src/main/java/org/incendo/cloud/CommandManager.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/CommandManager.java
@@ -28,15 +28,19 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.common.returnsreceiver.qual.This;
+import org.incendo.cloud.caption.Caption;
 import org.incendo.cloud.caption.CaptionFormatter;
 import org.incendo.cloud.caption.CaptionRegistry;
+import org.incendo.cloud.caption.CaptionVariable;
 import org.incendo.cloud.caption.StandardCaptionsProvider;
 import org.incendo.cloud.component.CommandComponent;
 import org.incendo.cloud.context.CommandContext;
@@ -82,6 +86,8 @@ import org.incendo.cloud.suggestion.SuggestionFactory;
 import org.incendo.cloud.suggestion.SuggestionProcessor;
 import org.incendo.cloud.syntax.CommandSyntaxFormatter;
 import org.incendo.cloud.syntax.StandardCommandSyntaxFormatter;
+import org.incendo.cloud.type.tuple.Pair;
+import org.incendo.cloud.type.tuple.Triplet;
 
 /**
  * The manager is responsible for command registration, parsing delegation, etc.
@@ -768,5 +774,23 @@ public abstract class CommandManager<C> implements Stateful<RegistrationState>, 
     public boolean isCommandRegistrationAllowed() {
         return this.settings().get(ManagerSetting.ALLOW_UNSAFE_REGISTRATION)
                 || this.state.get() != RegistrationState.AFTER_REGISTRATION;
+    }
+
+    /**
+     * Registers the default exception handlers.
+     *
+     * @param messageSender consumer that gets invoked when a message should be sent to the command sender
+     * @param logger        consumer that gets invoked when a message should be logged
+     */
+    protected void registerDefaultExceptionHandlers(
+            final @NonNull Consumer<Triplet<CommandContext<C>, Caption, List<@NonNull CaptionVariable>>> messageSender,
+            final @NonNull Consumer<Pair<String, Throwable>> logger
+    ) {
+        final DefaultExceptionHandlers<C> defaultExceptionHandlers = new DefaultExceptionHandlers<>(
+                messageSender,
+                logger,
+                this.exceptionController
+        );
+        defaultExceptionHandlers.register();
     }
 }

--- a/cloud-core/src/main/java/org/incendo/cloud/DefaultExceptionHandlers.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/DefaultExceptionHandlers.java
@@ -1,0 +1,139 @@
+//
+// MIT License
+//
+// Copyright (c) 2024 Incendo
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package org.incendo.cloud;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.incendo.cloud.caption.Caption;
+import org.incendo.cloud.caption.CaptionVariable;
+import org.incendo.cloud.caption.StandardCaptionKeys;
+import org.incendo.cloud.context.CommandContext;
+import org.incendo.cloud.exception.ArgumentParseException;
+import org.incendo.cloud.exception.CommandExecutionException;
+import org.incendo.cloud.exception.InvalidCommandSenderException;
+import org.incendo.cloud.exception.InvalidSyntaxException;
+import org.incendo.cloud.exception.NoPermissionException;
+import org.incendo.cloud.exception.NoSuchCommandException;
+import org.incendo.cloud.exception.handling.ExceptionContext;
+import org.incendo.cloud.exception.handling.ExceptionController;
+import org.incendo.cloud.type.tuple.Pair;
+import org.incendo.cloud.type.tuple.Triplet;
+import org.incendo.cloud.util.TypeUtils;
+
+/**
+ * Opinionated default exception handlers.
+ *
+ * @param <C> command sender type
+ */
+@API(status = API.Status.INTERNAL)
+final class DefaultExceptionHandlers<C> {
+
+    private final Consumer<Triplet<CommandContext<C>, Caption, List<@NonNull CaptionVariable>>> messageSender;
+    private final Consumer<Pair<String, Throwable>> logger;
+    private final ExceptionController<C> exceptionController;
+
+    DefaultExceptionHandlers(
+            final @NonNull Consumer<Triplet<CommandContext<C>, Caption, List<@NonNull CaptionVariable>>> messageSender,
+            final @NonNull Consumer<Pair<String, Throwable>> logger,
+            final @NonNull ExceptionController<C> exceptionController
+    ) {
+        this.messageSender = Objects.requireNonNull(messageSender, "messageSender");
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.exceptionController = Objects.requireNonNull(exceptionController, "exceptionController");
+    }
+
+    /**
+     * Registers the exception handlers.
+     */
+    void register() {
+        this.exceptionController.registerHandler(Throwable.class, context -> {
+            this.sendMessage(context, StandardCaptionKeys.EXCEPTION_UNEXPECTED);
+            this.log("An unhandled exception was thrown during command execution", context.exception());
+        });
+        this.exceptionController.registerHandler(CommandExecutionException.class, context -> {
+            this.sendMessage(context, StandardCaptionKeys.EXCEPTION_UNEXPECTED);
+            this.log("Exception executing command handler", context.exception().getCause());
+        });
+        this.exceptionController.registerHandler(ArgumentParseException.class, context ->
+                this.sendMessage(
+                        context,
+                        StandardCaptionKeys.EXCEPTION_INVALID_ARGUMENT,
+                        CaptionVariable.of("cause", context.exception().getCause().getMessage())
+                )
+        );
+        this.exceptionController.registerHandler(NoSuchCommandException.class, context ->
+                this.sendMessage(
+                        context,
+                        StandardCaptionKeys.EXCEPTION_NO_SUCH_COMMAND,
+                        CaptionVariable.of("command", context.exception().suppliedCommand())
+                )
+        );
+        this.exceptionController.registerHandler(NoPermissionException.class, context ->
+                this.sendMessage(
+                        context,
+                        StandardCaptionKeys.EXCEPTION_NO_PERMISSION,
+                        CaptionVariable.of("permission", context.exception().permissionResult().permission().permissionString())
+                )
+        );
+        this.exceptionController.registerHandler(InvalidCommandSenderException.class, context ->
+                this.sendMessage(
+                        context,
+                        StandardCaptionKeys.EXCEPTION_INVALID_SENDER,
+                        CaptionVariable.of("actual", context.context().sender().getClass().getSimpleName()),
+                        CaptionVariable.of("expected", TypeUtils.simpleName(context.exception().requiredSender()))
+                )
+        );
+        this.exceptionController.registerHandler(InvalidSyntaxException.class, context ->
+                this.sendMessage(
+                        context,
+                        StandardCaptionKeys.EXCEPTION_INVALID_SYNTAX,
+                        CaptionVariable.of("syntax", context.exception().correctSyntax())
+                )
+        );
+    }
+
+    private void sendMessage(
+            final @NonNull ExceptionContext<C, ?> context,
+            final @NonNull Caption caption,
+            final @NonNull CaptionVariable @NonNull... variables
+    ) {
+        this.sendMessage(context.context(), caption, variables);
+    }
+
+    private void sendMessage(
+            final @NonNull CommandContext<C> context,
+            final @NonNull Caption caption,
+            final @NonNull CaptionVariable @NonNull... variables
+    ) {
+        this.messageSender.accept(Triplet.of(context, caption, Arrays.asList(variables)));
+    }
+
+    private void log(final @NonNull String message, final @NonNull Throwable exception) {
+        this.logger.accept(Pair.of(message, exception));
+    }
+}

--- a/cloud-core/src/main/java/org/incendo/cloud/caption/CaptionFormatter.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/caption/CaptionFormatter.java
@@ -23,6 +23,8 @@
 //
 package org.incendo.cloud.caption;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -68,11 +70,29 @@ public interface CaptionFormatter<C, T> {
      * @param variables  the caption variables
      * @return the transformed message
      */
-    @NonNull T formatCaption(
+    default @NonNull T formatCaption(
             @NonNull Caption captionKey,
             @NonNull C recipient,
             @NonNull String caption,
             @NonNull CaptionVariable @NonNull... variables
+    ) {
+        return this.formatCaption(captionKey, recipient, caption, Arrays.asList(variables));
+    }
+
+    /**
+     * Formats the {@code caption}.
+     *
+     * @param captionKey the caption key
+     * @param recipient  the recipient of the message
+     * @param caption    the value of the caption
+     * @param variables  the caption variables
+     * @return the transformed message
+     */
+    @NonNull T formatCaption(
+            @NonNull Caption captionKey,
+            @NonNull C recipient,
+            @NonNull String caption,
+            @NonNull Collection<@NonNull CaptionVariable> variables
     );
 
 
@@ -89,7 +109,7 @@ public interface CaptionFormatter<C, T> {
                 final @NonNull Caption captionKey,
                 final @NonNull C recipient,
                 final @NonNull String caption,
-                final @NonNull CaptionVariable @NonNull... variables
+                final @NonNull Collection<@NonNull CaptionVariable> variables
         ) {
             final Map<String, String> replacements = new HashMap<>();
             for (final CaptionVariable variable : variables) {

--- a/cloud-core/src/main/java/org/incendo/cloud/caption/StandardCaptionKeys.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/caption/StandardCaptionKeys.java
@@ -107,6 +107,28 @@ public final class StandardCaptionKeys {
      */
     public static final Caption ARGUMENT_PARSE_FAILURE_EITHER = of("argument.parse.failure.either");
 
+    public static final Caption EXCEPTION_UNEXPECTED = of("exception.unexpected");
+    /**
+     * Variables: {@code <cause>}
+     */
+    public static final Caption EXCEPTION_INVALID_ARGUMENT = of("exception.invalid_argument");
+    /**
+     * Variables: {@code <command>}
+     */
+    public static final Caption EXCEPTION_NO_SUCH_COMMAND = of("exception.no_such_command");
+    /**
+     * Variables: {@code <permission>}
+     */
+    public static final Caption EXCEPTION_NO_PERMISSION = of("exception.no_permission");
+    /**
+     * Variables: {@code <actual>}, {@code <expected>}
+     */
+    public static final Caption EXCEPTION_INVALID_SENDER = of("exception.invalid_sender");
+    /**
+     * Variables: {@code <syntax>}
+     */
+    public static final Caption EXCEPTION_INVALID_SYNTAX = of("exception.invalid_syntax");
+
     private StandardCaptionKeys() {
     }
 

--- a/cloud-core/src/main/java/org/incendo/cloud/caption/StandardCaptionsProvider.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/caption/StandardCaptionsProvider.java
@@ -103,6 +103,32 @@ public final class StandardCaptionsProvider<C> extends DelegatingCaptionProvider
      */
     public static final String ARGUMENT_PARSE_FAILURE_EITHER = "Could not resolve <primary> or <fallback> from '<input>'";
 
+    /**
+     * Default caption for {@link StandardCaptionKeys#EXCEPTION_UNEXPECTED}
+     */
+    public static final String EXCEPTION_UNEXPECTED = "An internal error occurred while attempting to perform this command.";
+    /**
+     * Default caption for {@link StandardCaptionKeys#EXCEPTION_INVALID_ARGUMENT}
+     */
+    public static final String EXCEPTION_INVALID_ARGUMENT = "Invalid Command Argument: <cause>.";
+    /**
+     * Default caption for {@link StandardCaptionKeys#EXCEPTION_NO_SUCH_COMMAND}
+     */
+    public static final String EXCEPTION_NO_SUCH_COMMAND = "Unknown Command.";
+    /**
+     * Default caption for {@link StandardCaptionKeys#EXCEPTION_NO_PERMISSION}
+     */
+    public static final String EXCEPTION_NO_PERMISSION = "I'm sorry, but you do not have permission to perform this command.";
+    /**
+     * Default caption for {@link StandardCaptionKeys#EXCEPTION_INVALID_SENDER}
+     */
+    public static final String EXCEPTION_INVALID_SENDER =
+            "<actual> is not allowed to execute that command. Must be of type <expected>";
+    /**
+     * Default caption for {@link StandardCaptionKeys#EXCEPTION_INVALID_SYNTAX}
+     */
+    public static final String EXCEPTION_INVALID_SYNTAX = "Invalid Command Syntax. Correct command syntax is: <syntax>.";
+
     private static final CaptionProvider<?> PROVIDER = CaptionProvider.constantProvider()
             .putCaption(
                     StandardCaptionKeys.ARGUMENT_PARSE_FAILURE_BOOLEAN,
@@ -155,8 +181,25 @@ public final class StandardCaptionsProvider<C> extends DelegatingCaptionProvider
             ).putCaption(
                     StandardCaptionKeys.ARGUMENT_PARSE_FAILURE_EITHER,
                     ARGUMENT_PARSE_FAILURE_EITHER
-            )
-            .build();
+            ).putCaption(
+                    StandardCaptionKeys.EXCEPTION_UNEXPECTED,
+                    EXCEPTION_UNEXPECTED
+            ).putCaption(
+                    StandardCaptionKeys.EXCEPTION_INVALID_ARGUMENT,
+                    EXCEPTION_INVALID_ARGUMENT
+            ).putCaption(
+                    StandardCaptionKeys.EXCEPTION_NO_SUCH_COMMAND,
+                    EXCEPTION_NO_SUCH_COMMAND
+            ).putCaption(
+                    StandardCaptionKeys.EXCEPTION_NO_PERMISSION,
+                    EXCEPTION_NO_PERMISSION
+            ).putCaption(
+                    StandardCaptionKeys.EXCEPTION_INVALID_SENDER,
+                    EXCEPTION_INVALID_SENDER
+            ).putCaption(
+                    StandardCaptionKeys.EXCEPTION_INVALID_SYNTAX,
+                    EXCEPTION_INVALID_SYNTAX
+            ).build();
 
     @SuppressWarnings("unchecked")
     @Override

--- a/cloud-core/src/main/java/org/incendo/cloud/context/CommandContext.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/context/CommandContext.java
@@ -24,6 +24,7 @@
 package org.incendo.cloud.context;
 
 import io.leangen.geantyref.TypeToken;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -111,6 +112,20 @@ public class CommandContext<C> implements MutableCloudKeyContainer {
     }
 
     /**
+     * Formats a {@code caption} using the {@link CommandManager#captionFormatter()}.
+     *
+     * @param caption   the caption key
+     * @param variables the variables to use during formatting
+     * @return the formatted caption
+     */
+    public @NonNull String formatCaption(
+            final @NonNull Caption caption,
+            final @NonNull Collection<@NonNull CaptionVariable> variables
+    ) {
+        return this.formatCaption(this.commandManager.captionFormatter(), caption, variables);
+    }
+
+    /**
      * Formats a {@code caption} using the given {@code formatter}.
      *
      * @param <T>       the message type produced by the formatter
@@ -123,6 +138,28 @@ public class CommandContext<C> implements MutableCloudKeyContainer {
             final @NonNull CaptionFormatter<C, T> formatter,
             final @NonNull Caption caption,
             final @NonNull CaptionVariable @NonNull... variables
+    ) {
+        return formatter.formatCaption(
+                caption,
+                this.commandSender,
+                this.captionRegistry.caption(caption, this.commandSender),
+                variables
+        );
+    }
+
+    /**
+     * Formats a {@code caption} using the given {@code formatter}.
+     *
+     * @param <T>       the message type produced by the formatter
+     * @param formatter the formatter
+     * @param caption   the caption key
+     * @param variables the variables to use during formatting
+     * @return the formatted caption
+     */
+    public <T> @NonNull T formatCaption(
+            final @NonNull CaptionFormatter<C, T> formatter,
+            final @NonNull Caption caption,
+            final @NonNull Collection<@NonNull CaptionVariable> variables
     ) {
         return formatter.formatCaption(
                 caption,


### PR DESCRIPTION
This allows for the exception handlers to be translated in the same way as any other caption, without requiring the entire exception handler to be replaced.