### PR TITLE
Allow returning `? extends Suggestion` or `? extends Iterable<? extends Suggestion>>` from suggestion providers

### DIFF
--- a/cloud-annotations/src/test/java/org/incendo/cloud/annotations/feature/MethodSuggestionProviderTest.java
+++ b/cloud-annotations/src/test/java/org/incendo/cloud/annotations/feature/MethodSuggestionProviderTest.java
@@ -77,7 +77,7 @@ class MethodSuggestionProviderTest {
         );
 
         // Act
-        final Iterable<Suggestion> suggestions =
+        final Iterable<? extends Suggestion> suggestions =
                 this.commandManager.parserRegistry()
                         .getSuggestionProvider("suggestions")
                         .orElseThrow(NullPointerException::new)

--- a/cloud-core/src/main/java/org/incendo/cloud/internal/SuggestionContext.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/internal/SuggestionContext.java
@@ -95,7 +95,7 @@ public final class SuggestionContext<C> {
      *
      * @param suggestions the suggestions to add
      */
-    public void addSuggestions(final @NonNull Iterable<@NonNull Suggestion> suggestions) {
+    public void addSuggestions(final @NonNull Iterable<? extends @NonNull Suggestion> suggestions) {
         suggestions.forEach(this::addSuggestion);
     }
 

--- a/cloud-core/src/main/java/org/incendo/cloud/parser/standard/EitherParser.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/parser/standard/EitherParser.java
@@ -153,7 +153,7 @@ public final class EitherParser<C, U, V> implements ArgumentParser.FutureArgumen
 
     @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public @NonNull CompletableFuture<@NonNull Iterable<@NonNull Suggestion>> suggestionsFuture(
+    public @NonNull CompletableFuture<? extends @NonNull Iterable<? extends @NonNull Suggestion>> suggestionsFuture(
             final @NonNull CommandContext<C> context,
             final @NonNull CommandInput input
     ) {

--- a/cloud-core/src/main/java/org/incendo/cloud/suggestion/BlockingSuggestionProvider.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/suggestion/BlockingSuggestionProvider.java
@@ -57,10 +57,10 @@ interface BlockingSuggestionProvider<C> extends SuggestionProvider<C> {
      * @param input   the current input
      * @return the suggestions
      */
-    @NonNull Iterable<@NonNull Suggestion> suggestions(@NonNull CommandContext<C> context, @NonNull CommandInput input);
+    @NonNull Iterable<? extends @NonNull Suggestion> suggestions(@NonNull CommandContext<C> context, @NonNull CommandInput input);
 
     @Override
-    default @NonNull CompletableFuture<@NonNull Iterable<@NonNull Suggestion>> suggestionsFuture(
+    default @NonNull CompletableFuture<? extends @NonNull Iterable<? extends @NonNull Suggestion>> suggestionsFuture(
             final @NonNull CommandContext<C> context,
             final @NonNull CommandInput input
     ) {

--- a/cloud-core/src/main/java/org/incendo/cloud/suggestion/SuggestionProvider.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/suggestion/SuggestionProvider.java
@@ -55,7 +55,7 @@ public interface SuggestionProvider<C> {
      * @param input   the current input
      * @return the suggestions
      */
-    @NonNull CompletableFuture<@NonNull Iterable<@NonNull Suggestion>> suggestionsFuture(
+    @NonNull CompletableFuture<? extends @NonNull Iterable<? extends @NonNull Suggestion>> suggestionsFuture(
             @NonNull CommandContext<C> context,
             @NonNull CommandInput input
     );
@@ -132,7 +132,7 @@ public interface SuggestionProvider<C> {
      * @return suggestion provider
      */
     static <C> @NonNull SuggestionProvider<C> suggesting(
-            final @NonNull Iterable<@NonNull Suggestion> suggestions
+            final @NonNull Iterable<? extends @NonNull Suggestion> suggestions
     ) {
         return blocking((ctx, input) -> suggestions);
     }

--- a/cloud-core/src/test/java/org/incendo/cloud/parser/aggregate/AggregateParserTest.java
+++ b/cloud-core/src/test/java/org/incendo/cloud/parser/aggregate/AggregateParserTest.java
@@ -143,7 +143,7 @@ class AggregateParserTest {
                 .build();
 
         // Act
-        final Iterable<Suggestion> suggestions = parser.suggestionProvider()
+        final Iterable<? extends Suggestion> suggestions = parser.suggestionProvider()
                 .suggestionsFuture(this.commandContext, CommandInput.empty()).join();
 
         // Assert
@@ -172,7 +172,7 @@ class AggregateParserTest {
                 .build();
 
         // Act
-        final Iterable<Suggestion> suggestions = parser.suggestionProvider()
+        final Iterable<? extends Suggestion> suggestions = parser.suggestionProvider()
                 .suggestionsFuture(this.commandContext, CommandInput.of("123 ")).join();
 
         // Assert

--- a/cloud-core/src/test/java/org/incendo/cloud/parser/standard/EitherParserTest.java
+++ b/cloud-core/src/test/java/org/incendo/cloud/parser/standard/EitherParserTest.java
@@ -93,7 +93,7 @@ class EitherParserTest {
     @Test
     void testSuggestions() {
         // Act
-        final Iterable<Suggestion> suggestions = this.parser.suggestionsFuture(this.context, CommandInput.empty()).join();
+        final Iterable<? extends Suggestion> suggestions = this.parser.suggestionsFuture(this.context, CommandInput.empty()).join();
 
         // Assert
         assertThat(suggestions).containsExactly(


### PR DESCRIPTION
Removes the need for casting: 
```java
  @Override
  public Iterable<Suggestion> suggestions(final CommandContext<Commander> commandContext, final CommandInput input) {
    return mods().allMods()
      .map(modDescription -> (Suggestion) tooltipSuggestion(
        modDescription.modId(),
        Component.literal(modDescription.name())
      ))
      .toList();
  }
```
->
```java
  @Override
  public Iterable<? extends Suggestion> suggestions(final CommandContext<Commander> commandContext, final CommandInput input) {
    return mods().allMods()
      .map(modDescription -> tooltipSuggestion(
        modDescription.modId(),
        Component.literal(modDescription.name())
      ))
      .toList();
  }
```