### PR TITLE
Rename Suggestion.simple(String) to Suggestion.suggestion(String)

### DIFF
--- a/cloud-annotations/src/main/java/org/incendo/cloud/annotations/assembler/ArgumentAssemblerImpl.java
+++ b/cloud-annotations/src/main/java/org/incendo/cloud/annotations/assembler/ArgumentAssemblerImpl.java
@@ -153,7 +153,7 @@ public final class ArgumentAssemblerImpl<C> implements ArgumentAssembler<C> {
         if (completions != null) {
             final List<Suggestion> suggestions = Arrays.stream(
                     completions.value().replace(" ", "").split(",")
-            ).map(Suggestion::simple).collect(Collectors.toList());
+            ).map(Suggestion::suggestion).collect(Collectors.toList());
             componentBuilder.suggestionProvider(SuggestionProvider.suggesting(suggestions));
         } else if (descriptor.suggestions() != null) {
             final String suggestionProviderName = this.annotationParser.processString(descriptor.suggestions());

--- a/cloud-annotations/src/main/java/org/incendo/cloud/annotations/suggestion/MethodSuggestionProvider.java
+++ b/cloud-annotations/src/main/java/org/incendo/cloud/annotations/suggestion/MethodSuggestionProvider.java
@@ -138,7 +138,7 @@ public final class MethodSuggestionProvider<C> extends AnnotatedMethodHandler<C>
         if (suggestion instanceof Suggestion) {
             return (List<Suggestion>) suggestions;
         } else if (suggestion instanceof String) {
-            return suggestions.stream().map(Object::toString).map(Suggestion::simple).collect(Collectors.toList());
+            return suggestions.stream().map(Object::toString).map(Suggestion::suggestion).collect(Collectors.toList());
         } else {
             throw new IllegalArgumentException(
                     String.format("Cannot handle suggestions of type: %s",

--- a/cloud-annotations/src/test/java/org/incendo/cloud/annotations/AnnotationParserTest.java
+++ b/cloud-annotations/src/test/java/org/incendo/cloud/annotations/AnnotationParserTest.java
@@ -61,7 +61,7 @@ class AnnotationParserTest {
 
     private static final List<Suggestion> NAMED_SUGGESTIONS = Arrays.asList("Dancing-Queen", "Gimme!-Gimme!-Gimme!",
             "Waterloo"
-    ).stream().map(Suggestion::simple).collect(Collectors.toList());
+    ).stream().map(Suggestion::suggestion).collect(Collectors.toList());
 
     private CommandManager<TestCommandSender> manager;
     private AnnotationParser<TestCommandSender> annotationParser;
@@ -161,7 +161,7 @@ class AnnotationParserTest {
 
         assertThat(suggestionProvider).isNotNull();
         assertThat(suggestionProvider.suggestionsFuture(new CommandContext<>(new TestCommandSender(), manager),
-                CommandInput.empty()).join()).contains(Suggestion.simple("Stella"));
+                CommandInput.empty()).join()).contains(Suggestion.suggestion("Stella"));
     }
 
     @Test
@@ -177,7 +177,7 @@ class AnnotationParserTest {
         assertThat(parser.parse(context, CommandInput.empty()).parsedValue().orElse(new CustomType("")).toString())
                 .isEqualTo("yay");
         assertThat(parser.suggestionProvider().suggestionsFuture(context, CommandInput.empty()).join())
-                .contains(Suggestion.simple("Stella"));
+                .contains(Suggestion.suggestion("Stella"));
     }
 
     @Test

--- a/cloud-annotations/src/test/java/org/incendo/cloud/annotations/feature/MethodSuggestionProviderTest.java
+++ b/cloud-annotations/src/test/java/org/incendo/cloud/annotations/feature/MethodSuggestionProviderTest.java
@@ -85,7 +85,7 @@ class MethodSuggestionProviderTest {
                         .join();
 
         // Assert
-        assertThat(suggestions).containsExactly(Suggestion.simple("foo"));
+        assertThat(suggestions).containsExactly(Suggestion.suggestion("foo"));
     }
 
     static @NonNull Stream<@NonNull Object> testSuggestionsSource() {
@@ -108,7 +108,7 @@ class MethodSuggestionProviderTest {
                 final @NonNull CommandContext<TestCommandSender> context,
                 final @NonNull String input
         ) {
-            return Collections.singletonList(Suggestion.simple("foo"));
+            return Collections.singletonList(Suggestion.suggestion("foo"));
         }
     }
 
@@ -119,7 +119,7 @@ class MethodSuggestionProviderTest {
                 final @NonNull CommandContext<TestCommandSender> context,
                 final @NonNull String input
         ) {
-            return Collections.singleton(Suggestion.simple("foo"));
+            return Collections.singleton(Suggestion.suggestion("foo"));
         }
     }
 
@@ -130,7 +130,7 @@ class MethodSuggestionProviderTest {
                 final @NonNull CommandContext<TestCommandSender> context,
                 final @NonNull String input
         ) {
-            return Stream.of(Suggestion.simple("foo"));
+            return Stream.of(Suggestion.suggestion("foo"));
         }
     }
 
@@ -141,7 +141,7 @@ class MethodSuggestionProviderTest {
                 final @NonNull CommandContext<TestCommandSender> context,
                 final @NonNull String input
         ) {
-            return Collections.singleton(Suggestion.simple("foo"));
+            return Collections.singleton(Suggestion.suggestion("foo"));
         }
     }
 

--- a/cloud-core/src/main/java/org/incendo/cloud/parser/flag/CommandFlagParser.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/parser/flag/CommandFlagParser.java
@@ -196,7 +196,7 @@ public final class CommandFlagParser<C> implements ArgumentParser.FutureArgument
                     continue;
                 }
 
-                suggestions.add(Suggestion.simple(String.format("--%s", flag.name())));
+                suggestions.add(Suggestion.suggestion(String.format("--%s", flag.name())));
             }
             /* Recommend aliases */
             final boolean suggestCombined = nextToken.length() > 1 && nextToken.startsWith("-") && !nextToken.startsWith("--");
@@ -213,15 +213,15 @@ public final class CommandFlagParser<C> implements ArgumentParser.FutureArgument
                         continue;
                     }
                     if (suggestCombined && flag.commandComponent() == null) {
-                        suggestions.add(Suggestion.simple(String.format("%s%s", input.peekString(), alias)));
+                        suggestions.add(Suggestion.suggestion(String.format("%s%s", input.peekString(), alias)));
                     } else {
-                        suggestions.add(Suggestion.simple(String.format("-%s", alias)));
+                        suggestions.add(Suggestion.suggestion(String.format("-%s", alias)));
                     }
                 }
             }
             /* If we are suggesting the combined flag, then also suggest the current input */
             if (suggestCombined) {
-                suggestions.add(Suggestion.simple(input.peekString()));
+                suggestions.add(Suggestion.suggestion(input.peekString()));
             }
             return CompletableFuture.completedFuture(suggestions);
         } else {

--- a/cloud-core/src/main/java/org/incendo/cloud/suggestion/BlockingSuggestionProvider.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/suggestion/BlockingSuggestionProvider.java
@@ -72,7 +72,7 @@ interface BlockingSuggestionProvider<C> extends SuggestionProvider<C> {
      * instead of {@link Suggestion} results.
      *
      * <p>The provided default implementation of {@link #suggestions(CommandContext, CommandInput)}
-     * maps the {@link String} results to {@link Suggestion suggestions} using {@link Suggestion#simple(String)}.</p>
+     * maps the {@link String} results to {@link Suggestion suggestions} using {@link Suggestion#suggestion(String)}.</p>
      *
      * @param <C> command sender type
      */
@@ -104,7 +104,7 @@ interface BlockingSuggestionProvider<C> extends SuggestionProvider<C> {
                 final @NonNull CommandInput input
         ) {
             return StreamSupport.stream(this.stringSuggestions(context, input).spliterator(), false)
-                    .map(Suggestion::simple)
+                    .map(Suggestion::suggestion)
                     .collect(Collectors.toList());
         }
     }

--- a/cloud-core/src/main/java/org/incendo/cloud/suggestion/DelegatingSuggestionFactory.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/suggestion/DelegatingSuggestionFactory.java
@@ -74,7 +74,7 @@ public final class DelegatingSuggestionFactory<C, S extends Suggestion> implemen
         this.contextFactory = contextFactory;
         this.executionCoordinator = executionCoordinator;
         this.mapper = mapper;
-        this.singleEmptySuggestion = Collections.singletonList(mapper.map(Suggestion.simple("")));
+        this.singleEmptySuggestion = Collections.singletonList(mapper.map(Suggestion.suggestion("")));
     }
 
     @Override

--- a/cloud-core/src/main/java/org/incendo/cloud/suggestion/Suggestion.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/suggestion/Suggestion.java
@@ -35,7 +35,7 @@ public interface Suggestion {
      * @param suggestion the suggestion string
      * @return the created suggestion
      */
-    static @NonNull Suggestion simple(final @NonNull String suggestion) {
+    static @NonNull Suggestion suggestion(final @NonNull String suggestion) {
         return new SimpleSuggestion(suggestion);
     }
 

--- a/cloud-core/src/test/java/org/incendo/cloud/CommandDeletionTest.java
+++ b/cloud-core/src/test/java/org/incendo/cloud/CommandDeletionTest.java
@@ -163,7 +163,7 @@ class CommandDeletionTest {
         assertThat(completionException).hasCauseThat().isInstanceOf(NoSuchCommandException.class);
 
         assertThat(this.commandManager.suggestionFactory().suggestImmediately(new TestCommandSender(), "").list())
-                .contains(Suggestion.simple("test"));
+                .contains(Suggestion.suggestion("test"));
         assertThat(this.commandManager.commandTree().rootNodes()).hasSize(1);
     }
 }

--- a/cloud-core/src/test/java/org/incendo/cloud/CommandSuggestionsTest.java
+++ b/cloud-core/src/test/java/org/incendo/cloud/CommandSuggestionsTest.java
@@ -161,7 +161,7 @@ class CommandSuggestionsTest {
         final List<? extends Suggestion> suggestions = this.manager.suggestionFactory().suggestImmediately(new TestCommandSender(), input).list();
 
         // Assert
-        assertThat(suggestions).containsExactly(Suggestion.simple("one"));
+        assertThat(suggestions).containsExactly(Suggestion.suggestion("one"));
     }
 
     @Test

--- a/cloud-core/src/test/java/org/incendo/cloud/CommandTreeTest.java
+++ b/cloud-core/src/test/java/org/incendo/cloud/CommandTreeTest.java
@@ -171,7 +171,7 @@ class CommandTreeTest {
         ).join().list();
 
         // Assert
-        assertThat(results).containsExactly(Suggestion.simple("a"), Suggestion.simple("b"));
+        assertThat(results).containsExactly(Suggestion.suggestion("a"), Suggestion.suggestion("b"));
     }
 
     @Test

--- a/cloud-core/src/test/java/org/incendo/cloud/execution/SuggestionProcessorTest.java
+++ b/cloud-core/src/test/java/org/incendo/cloud/execution/SuggestionProcessorTest.java
@@ -65,7 +65,7 @@ class SuggestionProcessorTest {
         ).list();
 
         // Assert
-        assertThat(suggestions).containsExactly(Suggestion.simple("test-suggestion"));
+        assertThat(suggestions).containsExactly(Suggestion.suggestion("test-suggestion"));
     }
 
     @Test

--- a/cloud-core/src/test/java/org/incendo/cloud/feature/MultiTokenParserTest.java
+++ b/cloud-core/src/test/java/org/incendo/cloud/feature/MultiTokenParserTest.java
@@ -100,9 +100,9 @@ class MultiTokenParserTest {
 
         // Assert
         assertThat(result).containsExactly(
-                Suggestion.simple("Goofy"),
-                Suggestion.simple("Bubbles"),
-                Suggestion.simple("Chuckles")
+                Suggestion.suggestion("Goofy"),
+                Suggestion.suggestion("Bubbles"),
+                Suggestion.suggestion("Chuckles")
         );
     }
 
@@ -123,9 +123,9 @@ class MultiTokenParserTest {
 
         // Assert
         assertThat(result).containsExactly(
-                Suggestion.simple("Goofy banana"),
-                Suggestion.simple("Goofy apple"),
-                Suggestion.simple("Goofy mango")
+                Suggestion.suggestion("Goofy banana"),
+                Suggestion.suggestion("Goofy apple"),
+                Suggestion.suggestion("Goofy mango")
         );
     }
 
@@ -146,9 +146,9 @@ class MultiTokenParserTest {
 
         // Assert
         assertThat(result).containsExactly(
-                Suggestion.simple("Goofy banana 1"),
-                Suggestion.simple("Goofy banana 2"),
-                Suggestion.simple("Goofy banana 3")
+                Suggestion.suggestion("Goofy banana 1"),
+                Suggestion.suggestion("Goofy banana 2"),
+                Suggestion.suggestion("Goofy banana 3")
         );
     }
 
@@ -169,8 +169,8 @@ class MultiTokenParserTest {
 
         // Assert
         assertThat(result).containsExactly(
-                Suggestion.simple("true"),
-                Suggestion.simple("false")
+                Suggestion.suggestion("true"),
+                Suggestion.suggestion("false")
         );
     }
 
@@ -208,7 +208,7 @@ class MultiTokenParserTest {
                 name = input.readString();
             } else {
                 return CompletableFuture.completedFuture(
-                        MONKEY_NAMES.stream().map(Suggestion::simple).collect(Collectors.toList())
+                        MONKEY_NAMES.stream().map(Suggestion::suggestion).collect(Collectors.toList())
                 );
             }
 
@@ -221,7 +221,7 @@ class MultiTokenParserTest {
                                 .map(Fruit::name)
                                 .map(fruit -> fruit.toLowerCase(Locale.ROOT))
                                 .map(fruit -> String.format("%s %s", name, fruit))
-                                .map(Suggestion::simple)
+                                .map(Suggestion::suggestion)
                                 .collect(Collectors.toList())
                 );
             }
@@ -233,14 +233,14 @@ class MultiTokenParserTest {
                 return CompletableFuture.completedFuture(
                         IntStream.range(1, 4)
                                 .mapToObj(number -> String.format("%s %s %d", name, favoriteFruit, number))
-                                .map(Suggestion::simple)
+                                .map(Suggestion::suggestion)
                                 .collect(Collectors.toList())
                 );
             }
 
             return CompletableFuture.completedFuture(
                     Collections.singletonList(
-                            Suggestion.simple(String.format("%s %s %d", name, favoriteFruit, age))
+                            Suggestion.suggestion(String.format("%s %s %d", name, favoriteFruit, age))
                     )
             );
         }

--- a/cloud-core/src/test/java/org/incendo/cloud/feature/RepeatableFlagTest.java
+++ b/cloud-core/src/test/java/org/incendo/cloud/feature/RepeatableFlagTest.java
@@ -107,6 +107,6 @@ class RepeatableFlagTest {
         ).list();
 
         // Assert
-        assertThat(suggestions).containsExactly(Suggestion.simple("--flag"));
+        assertThat(suggestions).containsExactly(Suggestion.suggestion("--flag"));
     }
 }

--- a/cloud-core/src/test/java/org/incendo/cloud/parser/aggregate/AggregateParserTest.java
+++ b/cloud-core/src/test/java/org/incendo/cloud/parser/aggregate/AggregateParserTest.java
@@ -131,9 +131,9 @@ class AggregateParserTest {
         // Arrange
         final AggregateParser<TestCommandSender, OutputType> parser = AggregateParser.<TestCommandSender>builder()
                 .withComponent("number", integerParser(), SuggestionProvider.blocking((ctx, in) -> Arrays.asList(
-                        Suggestion.simple("1"),
-                        Suggestion.simple("2"),
-                        Suggestion.simple("3")
+                        Suggestion.suggestion("1"),
+                        Suggestion.suggestion("2"),
+                        Suggestion.suggestion("3")
                 ))).withComponent("string", stringParser())
                 .withMapper(
                         OutputType.class,
@@ -148,9 +148,9 @@ class AggregateParserTest {
 
         // Assert
         assertThat(suggestions).containsExactly(
-                Suggestion.simple("1"),
-                Suggestion.simple("2"),
-                Suggestion.simple("3")
+                Suggestion.suggestion("1"),
+                Suggestion.suggestion("2"),
+                Suggestion.suggestion("3")
         );
     }
 
@@ -160,9 +160,9 @@ class AggregateParserTest {
         final AggregateParser<TestCommandSender, OutputType> parser = AggregateParser.<TestCommandSender>builder()
                 .withComponent("number", integerParser())
                 .withComponent("string", stringParser(), SuggestionProvider.blocking((ctx, in) -> Arrays.asList(
-                        Suggestion.simple("a"),
-                        Suggestion.simple("b"),
-                        Suggestion.simple("c")
+                        Suggestion.suggestion("a"),
+                        Suggestion.suggestion("b"),
+                        Suggestion.suggestion("c")
                 )))
                 .withMapper(
                         OutputType.class,
@@ -177,9 +177,9 @@ class AggregateParserTest {
 
         // Assert
         assertThat(suggestions).containsExactly(
-                Suggestion.simple("123 a"),
-                Suggestion.simple("123 b"),
-                Suggestion.simple("123 c")
+                Suggestion.suggestion("123 a"),
+                Suggestion.suggestion("123 b"),
+                Suggestion.suggestion("123 c")
         );
     }
 

--- a/cloud-core/src/test/java/org/incendo/cloud/parser/standard/ArgumentTestHelper.java
+++ b/cloud-core/src/test/java/org/incendo/cloud/parser/standard/ArgumentTestHelper.java
@@ -42,6 +42,6 @@ public final class ArgumentTestHelper {
     public static @NonNull List<@NonNull Suggestion> suggestionList(
             final @NonNull String... strings
     ) {
-        return Arrays.stream(strings).map(Suggestion::simple).collect(Collectors.toList());
+        return Arrays.stream(strings).map(Suggestion::suggestion).collect(Collectors.toList());
     }
 }

--- a/cloud-core/src/test/java/org/incendo/cloud/parser/standard/ByteParserTest.java
+++ b/cloud-core/src/test/java/org/incendo/cloud/parser/standard/ByteParserTest.java
@@ -149,7 +149,7 @@ class ByteParserTest {
 
         final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Suggestion.simple(Byte.toString((byte) i)));
+            expectedSuggestions.add(Suggestion.suggestion(Byte.toString((byte) i)));
         }
 
         // Act
@@ -172,7 +172,7 @@ class ByteParserTest {
 
         final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Suggestion.simple(Byte.toString((byte) -i)));
+            expectedSuggestions.add(Suggestion.suggestion(Byte.toString((byte) -i)));
         }
 
         // Act

--- a/cloud-core/src/test/java/org/incendo/cloud/parser/standard/DurationParserSuggestionsTest.java
+++ b/cloud-core/src/test/java/org/incendo/cloud/parser/standard/DurationParserSuggestionsTest.java
@@ -76,7 +76,7 @@ class DurationParserSuggestionsTest {
                 input4
         ).list();
         Assertions.assertTrue(suggestions4.containsAll(suggestionList("1d2h", "1d2m", "1d2s")));
-        Assertions.assertFalse(suggestions4.contains(Suggestion.simple("1d2d")));
+        Assertions.assertFalse(suggestions4.contains(Suggestion.suggestion("1d2d")));
 
         final String input9 = "duration 1d22";
         final List<? extends Suggestion> suggestions9 = manager.suggestionFactory().suggestImmediately(
@@ -84,7 +84,7 @@ class DurationParserSuggestionsTest {
                 input9
         ).list();
         Assertions.assertTrue(suggestions9.containsAll(suggestionList("1d22h", "1d22m", "1d22s")));
-        Assertions.assertFalse(suggestions9.contains(Suggestion.simple("1d22d")));
+        Assertions.assertFalse(suggestions9.contains(Suggestion.suggestion("1d22d")));
 
         final String input5 = "duration d";
         final List<? extends Suggestion> suggestions5 = manager.suggestionFactory().suggestImmediately(

--- a/cloud-core/src/test/java/org/incendo/cloud/parser/standard/EitherParserTest.java
+++ b/cloud-core/src/test/java/org/incendo/cloud/parser/standard/EitherParserTest.java
@@ -97,11 +97,11 @@ class EitherParserTest {
 
         // Assert
         assertThat(suggestions).containsExactly(
-                Suggestion.simple("1"),
-                Suggestion.simple("2"),
-                Suggestion.simple("3"),
-                Suggestion.simple("true"),
-                Suggestion.simple("false")
+                Suggestion.suggestion("1"),
+                Suggestion.suggestion("2"),
+                Suggestion.suggestion("3"),
+                Suggestion.suggestion("true"),
+                Suggestion.suggestion("false")
         );
     }
 }

--- a/cloud-core/src/test/java/org/incendo/cloud/parser/standard/IntegerParserTest.java
+++ b/cloud-core/src/test/java/org/incendo/cloud/parser/standard/IntegerParserTest.java
@@ -143,7 +143,7 @@ class IntegerParserTest {
 
         final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Suggestion.simple(Integer.toString(i)));
+            expectedSuggestions.add(Suggestion.suggestion(Integer.toString(i)));
         }
 
         // Act
@@ -166,7 +166,7 @@ class IntegerParserTest {
 
         final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Suggestion.simple(Integer.toString(-i)));
+            expectedSuggestions.add(Suggestion.suggestion(Integer.toString(-i)));
         }
 
         // Act

--- a/cloud-core/src/test/java/org/incendo/cloud/parser/standard/LongParserTest.java
+++ b/cloud-core/src/test/java/org/incendo/cloud/parser/standard/LongParserTest.java
@@ -143,7 +143,7 @@ class LongParserTest {
 
         final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Suggestion.simple(Long.toString((long) i)));
+            expectedSuggestions.add(Suggestion.suggestion(Long.toString((long) i)));
         }
 
         // Act
@@ -166,7 +166,7 @@ class LongParserTest {
 
         final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Suggestion.simple(Long.toString((long) -i)));
+            expectedSuggestions.add(Suggestion.suggestion(Long.toString((long) -i)));
         }
 
         // Act

--- a/cloud-core/src/test/java/org/incendo/cloud/parser/standard/ShortParserTest.java
+++ b/cloud-core/src/test/java/org/incendo/cloud/parser/standard/ShortParserTest.java
@@ -143,7 +143,7 @@ class ShortParserTest {
 
         final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Suggestion.simple(Short.toString((short) i)));
+            expectedSuggestions.add(Suggestion.suggestion(Short.toString((short) i)));
         }
 
         // Act
@@ -166,7 +166,7 @@ class ShortParserTest {
 
         final List<Suggestion> expectedSuggestions = new ArrayList<>();
         for (int i = 0; i <= 9; i++) {
-            expectedSuggestions.add(Suggestion.simple(Short.toString((short) -i)));
+            expectedSuggestions.add(Suggestion.suggestion(Short.toString((short) -i)));
         }
 
         // Act

--- a/cloud-kotlin/cloud-kotlin-coroutines-annotations/src/test/kotlin/org/incendo/cloud/kotlin/coroutines/annotations/KotlinAnnotatedMethodsTest.kt
+++ b/cloud-kotlin/cloud-kotlin-coroutines-annotations/src/test/kotlin/org/incendo/cloud/kotlin/coroutines/annotations/KotlinAnnotatedMethodsTest.kt
@@ -165,11 +165,11 @@ class KotlinAnnotatedMethodsTest {
         @Suggestions("suspending-suggestions")
         suspend fun suspendingSuggestions(ctx: CommandContext<TestCommandSender>, input: String): Sequence<Suggestion> =
             withContext(Dispatchers.Default) {
-                (1..10).asSequence().map(Int::toString).map(Suggestion::simple)
+                (1..10).asSequence().map(Int::toString).map(Suggestion::suggestion)
             }
 
         @Suggestions("non-suspending-suggestions")
         fun suggestions(ctx: CommandContext<TestCommandSender>, input: String): Sequence<Suggestion> =
-            (1..10).asSequence().map(Int::toString).map(Suggestion::simple)
+            (1..10).asSequence().map(Int::toString).map(Suggestion::suggestion)
     }
 }

--- a/cloud-kotlin/cloud-kotlin-coroutines/src/test/kotlin/org/incendo/cloud/kotlin/coroutines/SuspendingArgumentParserTest.kt
+++ b/cloud-kotlin/cloud-kotlin-coroutines/src/test/kotlin/org/incendo/cloud/kotlin/coroutines/SuspendingArgumentParserTest.kt
@@ -51,7 +51,7 @@ class SuspendingArgumentParserTest {
         }
         val suspendingSuggestionProvider = suspendingSuggestionProvider<TestCommandSender> { _, _ ->
             delay(1L)
-            (1..3).asSequence().map(Number::toString).map(Suggestion::simple).asIterable()
+            (1..3).asSequence().map(Number::toString).map(Suggestion::suggestion).asIterable()
         }
 
         val manager = TestCommandManager()
@@ -64,9 +64,9 @@ class SuspendingArgumentParserTest {
 
         manager.commandExecutor().executeCommand(TestCommandSender(), "test 123").await()
         assertThat(manager.suggestionFactory().suggest(TestCommandSender(), "test ").await().list()).containsExactly(
-            Suggestion.simple("1"),
-            Suggestion.simple("2"),
-            Suggestion.simple("3")
+            Suggestion.suggestion("1"),
+            Suggestion.suggestion("2"),
+            Suggestion.suggestion("3")
         )
     }
 


### PR DESCRIPTION
The plan is to also change the static factories on (Component)TooltipSuggestion to be called suggestion. This makes static imports much cleaner when creating a variety of suggestions with and without tooltips for example.