### PR TITLE
feat: Add convenience formatting caption methods.

### DIFF
--- a/cloud-core/src/main/java/org/incendo/cloud/context/CommandContext.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/context/CommandContext.java
@@ -172,6 +172,54 @@ public class CommandContext<C> implements MutableCloudKeyContainer {
     }
 
     /**
+     * Formats a {@code caption} using the given {@code formatter} and {@code recipient}.
+     *
+     * @param <T>       the message type produced by the formatter
+     * @param formatter the formatter
+     * @param recipient the recipient of the message.
+     * @param caption   the caption key
+     * @param variables the variables to use during formatting
+     * @return the formatted caption
+     */
+    public <T> @NonNull T formatCaption(
+            final @NonNull CaptionFormatter<C, T> formatter,
+            final @NonNull C recipient,
+            final @NonNull Caption caption,
+            final @NonNull CaptionVariable @NonNull... variables
+    ) {
+        return formatter.formatCaption(
+                caption,
+                recipient,
+                this.captionRegistry.caption(caption, recipient),
+                variables
+        );
+    }
+
+    /**
+     * Formats a {@code caption} using the given {@code formatter} and {@code recipient}.
+     *
+     * @param <T>       the message type produced by the formatter
+     * @param formatter the formatter
+     * @param recipient the recipient of the message.
+     * @param caption   the caption key
+     * @param variables the variables to use during formatting
+     * @return the formatted caption
+     */
+    public <T> @NonNull T formatCaption(
+            final @NonNull CaptionFormatter<C, T> formatter,
+            final @NonNull C recipient,
+            final @NonNull Caption caption,
+            final @NonNull List<@NonNull CaptionVariable> variables
+    ) {
+        return formatter.formatCaption(
+                caption,
+                recipient,
+                this.captionRegistry.caption(caption, recipient),
+                variables
+        );
+    }
+
+    /**
      * Returns the sender that executed the command.
      *
      * @return the command sender


### PR DESCRIPTION
The following PR adds convenience methods to allow caption formatting from the CommandContext for a different recipient that is **not** the command sender.

The benefit of this is to allow usage of the same mechanisms for formatting/sending captions for the sender AND the recipient of a command.

If there is an alternative or preferred way to achieve the same goal, please let me know and I'll close this PR.