### PR TITLE
feat: add method to command meta for adding a key with no value #710

### DIFF
--- a/cloud-core/src/main/java/org/incendo/cloud/Command.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/Command.java
@@ -472,6 +472,27 @@ public class Command<C> {
         }
 
         /**
+         * Adds command meta with no value to the internal command meta-map
+         *
+         * @param key   meta key
+         * @return new builder instance using the inserted meta key
+         */
+        @API(status = API.Status.STABLE)
+        public @NonNull Builder<C> meta(final @NonNull CloudKey<Void> key) {
+            final CommandMeta commandMeta = CommandMeta.builder().with(this.commandMeta).with(key).build();
+            return new Builder<>(
+                    this.commandManager,
+                    commandMeta,
+                    this.senderType,
+                    this.commandComponents,
+                    this.commandExecutionHandler,
+                    this.permission,
+                    this.flags,
+                    this.commandDescription
+            );
+        }
+
+        /**
          * Supplies a command manager instance to the builder.
          * <p>
          * This will be used when attempting to

--- a/cloud-core/src/main/java/org/incendo/cloud/meta/CommandMetaBuilder.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/meta/CommandMetaBuilder.java
@@ -66,6 +66,19 @@ public class CommandMetaBuilder {
     }
 
     /**
+     * Stores the given {@code key} with no value.
+     *
+     * @param key   the key
+     * @return {@code this}
+     */
+    public @This @NonNull CommandMetaBuilder with(
+            final @NonNull CloudKey<Void> key
+    ) {
+        this.map.put(key, new Object());
+        return this;
+    }
+
+    /**
      * Builds a new {@link CommandMeta} instance using the stored {@code key}-{@code value} pairs.
      *
      * @return the instance


### PR DESCRIPTION
could add a different implementation of CloudKey that more directly represents this?