### PR TITLE
Fix infinite recursion when a `@Suggestions` method returns a `CompletableFuture`

### DIFF
--- a/cloud-annotations/src/main/java/org/incendo/cloud/annotations/suggestion/MethodSuggestionProvider.java
+++ b/cloud-annotations/src/main/java/org/incendo/cloud/annotations/suggestion/MethodSuggestionProvider.java
@@ -87,7 +87,7 @@ public final class MethodSuggestionProvider<C> extends AnnotatedMethodHandler<C>
     @SuppressWarnings("rawtypes")
     public static @NonNull CompletableFuture<Iterable<@NonNull Suggestion>> mapSuggestions(final @NonNull Object input) {
         if (input instanceof CompletableFuture) {
-            return mapSuggestions((CompletableFuture) input);
+            return mapFuture((CompletableFuture) input);
         }
         return CompletableFuture.completedFuture(mapCompleted(input));
     }

--- a/cloud-annotations/src/test/java/org/incendo/cloud/annotations/feature/MethodSuggestionProviderTest.java
+++ b/cloud-annotations/src/test/java/org/incendo/cloud/annotations/feature/MethodSuggestionProviderTest.java
@@ -95,7 +95,7 @@ class MethodSuggestionProviderTest {
                 named("set source", new TestClassSet()),
                 named("stream source", new TestClassStream()),
                 named("iterable source", new TestClassIterable()),
-                named("future list source", new TestClassFutureList()),
+                named("list future source", new TestClassFutureList()),
                 named("string list source", new TestClassListString()),
                 named("source with CommandInput injected", new TestClassCommandInput()),
                 named("source with injected value", new TestInjectedValue())

--- a/cloud-annotations/src/test/java/org/incendo/cloud/annotations/feature/MethodSuggestionProviderTest.java
+++ b/cloud-annotations/src/test/java/org/incendo/cloud/annotations/feature/MethodSuggestionProviderTest.java
@@ -26,6 +26,7 @@ package org.incendo.cloud.annotations.feature;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.incendo.cloud.CommandManager;
@@ -94,6 +95,7 @@ class MethodSuggestionProviderTest {
                 named("set source", new TestClassSet()),
                 named("stream source", new TestClassStream()),
                 named("iterable source", new TestClassIterable()),
+                named("future list source", new TestClassFutureList()),
                 named("string list source", new TestClassListString()),
                 named("source with CommandInput injected", new TestClassCommandInput()),
                 named("source with injected value", new TestInjectedValue())
@@ -153,6 +155,17 @@ class MethodSuggestionProviderTest {
                 final @NonNull String input
         ) {
             return Collections.singletonList("foo");
+        }
+    }
+
+    public static final class TestClassFutureList {
+
+        @Suggestions("suggestions")
+        public @NonNull CompletableFuture<@NonNull Iterable<@NonNull Suggestion>> suggestions(
+                final @NonNull CommandContext<TestCommandSender> context,
+                final @NonNull String input
+        ) {
+            return CompletableFuture.completedFuture(Collections.singletonList(Suggestion.suggestion("foo")));
         }
     }
 


### PR DESCRIPTION
`MethodSuggestionProvider#mapSuggestions` calls itself when the method's input (the `@Suggestions` method return value) is a `CompletableFuture`, instead of the unused `#mapFuture`, leading to a `StackOverflowError`.