### PR TITLE
Improve message of AmbiguousNodeException

### DIFF
--- a/cloud-core/src/main/java/org/incendo/cloud/CommandTree.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/CommandTree.java
@@ -1170,7 +1170,8 @@ public final class CommandTree<C> {
                     node.children()
                             .stream()
                             .filter(n -> n.component() != null)
-                            .collect(Collectors.toList())
+                            .collect(Collectors.toList()),
+                    null
             );
         }
 
@@ -1194,7 +1195,8 @@ public final class CommandTree<C> {
                             node.children()
                                     .stream()
                                     .filter(n -> n.component() != null)
-                                    .collect(Collectors.toList())
+                                    .collect(Collectors.toList()),
+                            nameOrAlias
                     );
                 }
             }

--- a/cloud-core/src/main/java/org/incendo/cloud/exception/AmbiguousNodeException.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/exception/AmbiguousNodeException.java
@@ -45,23 +45,27 @@ public final class AmbiguousNodeException extends IllegalStateException {
     private final CommandNode<?> parentNode;
     private final CommandNode<?> ambiguousNode;
     private final List<CommandNode<?>> children;
+    private final String ambiguousName;
 
     /**
      * Construct a new ambiguous node exception
      *
      * @param parentNode    Parent node
      * @param ambiguousNode Node that caused exception
+     * @param ambiguousName Ambiguous name or alias
      * @param children      All children of the parent
      */
     @API(status = API.Status.INTERNAL, consumers = "org.incendo.cloud.*")
     public AmbiguousNodeException(
             final @Nullable CommandNode<?> parentNode,
             final @NonNull CommandNode<?> ambiguousNode,
-            final @NonNull List<@NonNull CommandNode<?>> children
+            final @NonNull List<@NonNull CommandNode<?>> children,
+            final @Nullable String ambiguousName
     ) {
         this.parentNode = parentNode;
         this.ambiguousNode = ambiguousNode;
         this.children = children;
+        this.ambiguousName = ambiguousName;
     }
 
     /**
@@ -91,13 +95,28 @@ public final class AmbiguousNodeException extends IllegalStateException {
         return Collections.unmodifiableList(this.children);
     }
 
+    /**
+     * Returns the ambiguous name or alias of the node.
+     * Might be null if the reason for this exception is not an ambiguous name or alias (e.g. multiple child nodes with a 
+     * variable argument).
+     * 
+     * @return the ambiguous name or alias of the node
+     */
+    public @Nullable String getAmbiguousName() {
+        return this.ambiguousName;
+    }
+
     @Override
     public String getMessage() {
         final StringBuilder stringBuilder = new StringBuilder("Ambiguous Node: ")
                 .append(this.ambiguousNode.component().name())
                 .append(" cannot be added as a child to ")
-                .append(this.parentNode == null ? "<root>" : this.parentNode.component().name())
-                .append(" (All children: ");
+                .append(this.parentNode == null ? "<root>" : this.parentNode.component().name());
+        if (this.ambiguousName != null) {
+            stringBuilder.append(" because of ambiguous name ")
+            .append(this.ambiguousName);
+        }
+        stringBuilder.append(" (All children: ");
         final Iterator<CommandNode<?>> childIterator = this.children.iterator();
         while (childIterator.hasNext()) {
             stringBuilder.append(childIterator.next().component().name());

--- a/cloud-core/src/test/java/org/incendo/cloud/CommandTreeTest.java
+++ b/cloud-core/src/test/java/org/incendo/cloud/CommandTreeTest.java
@@ -446,6 +446,14 @@ class CommandTreeTest {
                 this.commandManager.command(this.commandManager.commandBuilder("ambiguous")
                         .literal("literal")));
         this.setup();
+
+        // Two literals with the same alias can not co-exist, causes AmbiguousNodeException
+        this.commandManager.command(this.commandManager.commandBuilder("ambiguous")
+                .literal("literal", "alias"));
+        assertThrows(AmbiguousNodeException.class, () ->
+                this.commandManager.command(this.commandManager.commandBuilder("ambiguous")
+                        .literal("literal2", "alias")));
+        this.setup();
     }
 
     @Test


### PR DESCRIPTION
Running this code
```
this.commandManager.command(this.commandManager.commandBuilder("test").literal("test2", "test3"));
this.commandManager.command(this.commandManager.commandBuilder("test").literal("test4", "test3"));
```
throws the following exception:
```
org.incendo.cloud.exception.AmbiguousNodeException: Ambiguous Node: test4 cannot be added as a child to test (All children: test2, test4)
```
The exception does not mention the name of the offending alias `test3` at all, which makes searching for the cause tedious in projects that have a lot of commands with a lot of aliases. My project also allows users to define their own aliases, which makes the situation even more confusing. This PR aims to improve this message to make it immediately clear what the offending alias is. Running the same code now gives the following output:
```
org.incendo.cloud.exception.AmbiguousNodeException: Ambiguous Node: test4 cannot be added as a child to test because of ambiguous name test3 (All children: test2, test4)
```
This PR also adds an additional test case for duplicate aliases.