### PR TITLE
perf(literals): add LiteralParseException

### DIFF
--- a/cloud-core/src/main/java/org/incendo/cloud/exception/parsing/LiteralParseException.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/exception/parsing/LiteralParseException.java
@@ -1,0 +1,52 @@
+//
+// MIT License
+//
+// Copyright (c) 2024 Incendo
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package org.incendo.cloud.exception.parsing;
+
+import org.apiguardian.api.API;
+
+/**
+ * Exception thrown when a {@link org.incendo.cloud.parser.standard.LiteralParser} fails to parse an input.
+ */
+@API(status = API.Status.STABLE)
+public class LiteralParseException extends RuntimeException {
+
+    /**
+     * Creates a new {@link LiteralParseException} for the provided mismatched {@code input} string.
+     *
+     * @param input the input that was not successfully parsed
+     */
+    public LiteralParseException(final String input) {
+        super(input, null, true, false);
+    }
+
+    /**
+     * Noop override - disables stacktraces for performance
+     *
+     * @return {@code this}
+     */
+    @Override
+    public final synchronized Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/cloud-core/src/main/java/org/incendo/cloud/parser/standard/LiteralParser.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/parser/standard/LiteralParser.java
@@ -36,6 +36,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.incendo.cloud.context.CommandContext;
 import org.incendo.cloud.context.CommandInput;
+import org.incendo.cloud.exception.parsing.LiteralParseException;
 import org.incendo.cloud.parser.ArgumentParseResult;
 import org.incendo.cloud.parser.ArgumentParser;
 import org.incendo.cloud.parser.ParserDescriptor;
@@ -82,7 +83,7 @@ public final class LiteralParser<C> implements ArgumentParser<C, String>, Blocki
             commandInput.readString();
             return ArgumentParseResult.success(this.name);
         }
-        return ArgumentParseResult.failure(new IllegalArgumentException(string));
+        return ArgumentParseResult.failure(new LiteralParseException(string));
     }
 
     @Override


### PR DESCRIPTION
<img width="1106" height="682" alt="image" src="https://github.com/user-attachments/assets/7893fad2-42db-4599-923f-8a03dc13b771" />

Adds a new exception for use within `LiteralParser` with a noop override for `fillInStackTrace`.
LiteralParsing usage was getting a little higher than we liked during higher load

The nature of this PR is a bit... *meh*, arguably understandable if this doesn't get merged considering it's adding a new exception (unintended functionality by introducing a new exception maybe?) 