### PR TITLE
perf(supertypes): add global super type cache

### DIFF
--- a/cloud-core/src/main/java/org/incendo/cloud/CommandTree.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/CommandTree.java
@@ -60,6 +60,7 @@ import org.incendo.cloud.exception.NoPermissionException;
 import org.incendo.cloud.exception.NoSuchCommandException;
 import org.incendo.cloud.internal.CommandNode;
 import org.incendo.cloud.internal.SuggestionContext;
+import org.incendo.cloud.internal.SuperTypeCache;
 import org.incendo.cloud.parser.ArgumentParseResult;
 import org.incendo.cloud.parser.aggregate.AggregateParser;
 import org.incendo.cloud.parser.flag.CommandFlagParser;
@@ -1034,7 +1035,7 @@ public final class CommandTree<C> {
         }
         final Set<Permission> failed = new HashSet<>();
         for (final Map.Entry<Type, Permission> entry : accessMap.entrySet()) {
-            if (GenericTypeReflector.isSuperType(entry.getKey(), sender.getClass())) {
+            if (SuperTypeCache.isSuperType(entry.getKey(), sender.getClass())) {
                 final PermissionResult result = this.commandManager.testPermission(sender, entry.getValue());
                 if (result.allowed()) {
                     return Optional.of(result);

--- a/cloud-core/src/main/java/org/incendo/cloud/help/StandardHelpHandler.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/help/StandardHelpHandler.java
@@ -23,7 +23,6 @@
 //
 package org.incendo.cloud.help;
 
-import io.leangen.geantyref.GenericTypeReflector;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -43,6 +42,7 @@ import org.incendo.cloud.help.result.MultipleCommandResult;
 import org.incendo.cloud.help.result.VerboseCommandResult;
 import org.incendo.cloud.internal.CommandInputTokenizer;
 import org.incendo.cloud.internal.CommandNode;
+import org.incendo.cloud.internal.SuperTypeCache;
 
 @API(status = API.Status.STABLE)
 public class StandardHelpHandler<C> implements HelpHandler<C> {
@@ -231,7 +231,7 @@ public class StandardHelpHandler<C> implements HelpHandler<C> {
 
     private boolean isAllowed(final C sender, final Command<C> command) {
         if (command.senderType().isPresent()) {
-            if (!GenericTypeReflector.isSuperType(command.senderType().get().getType(), sender.getClass())) {
+            if (!SuperTypeCache.isSuperType(command.senderType().get().getType(), sender.getClass())) {
                 return false;
             }
         }

--- a/cloud-core/src/main/java/org/incendo/cloud/internal/SuperTypeCache.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/internal/SuperTypeCache.java
@@ -1,0 +1,65 @@
+//
+// MIT License
+//
+// Copyright (c) 2024 Incendo
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package org.incendo.cloud.internal;
+
+import io.leangen.geantyref.GenericTypeReflector;
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apiguardian.api.API;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Global cache for {@link GenericTypeReflector#isSuperType(Type, Type)} calls.
+ *
+ * <p>{@code isSuperType} is called multiple times in cloud-core and platform-specific implementations.
+ * Caching the supertype check results permanently is safe (java types aren't mutable during runtime)
+ *
+ * @since 2.0.0
+ */
+@API(status = API.Status.INTERNAL, since = "2.0.0")
+public final class SuperTypeCache {
+
+    private static final Map<Type, Map<Class<?>, Boolean>> TYPE_CACHE = new ConcurrentHashMap<>();
+
+    private SuperTypeCache() {
+    }
+
+    /**
+     * Returns whether {@code superType} is a supertype of {@code subType}.
+     * All results of calls to this method are cached (for efficiency).
+     *
+     * @param superType the supertype
+     * @param subType the subtype to test
+     * @return true if the {@code superType} is a supertype pf {@code subType}
+     */
+    public static boolean isSuperType(final @NonNull Type superType, final @NonNull Class<?> subType) {
+        return TYPE_CACHE
+                .computeIfAbsent(superType, k -> new ConcurrentHashMap<>())
+                .computeIfAbsent(
+                        subType,
+                        k -> GenericTypeReflector.isSuperType(superType, subType)
+                );
+    }
+}

--- a/cloud-core/src/main/java/org/incendo/cloud/meta/SimpleCommandMeta.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/meta/SimpleCommandMeta.java
@@ -23,7 +23,6 @@
 //
 package org.incendo.cloud.meta;
 
-import io.leangen.geantyref.GenericTypeReflector;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -31,6 +30,7 @@ import java.util.Objects;
 import java.util.Optional;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.incendo.cloud.internal.SuperTypeCache;
 import org.incendo.cloud.key.CloudKey;
 
 /**
@@ -53,7 +53,7 @@ public class SimpleCommandMeta extends CommandMeta {
         if (value == null) {
             return Optional.empty();
         }
-        if (!GenericTypeReflector.isSuperType(key.type().getType(), value.getClass())) {
+        if (!SuperTypeCache.isSuperType(key.type().getType(), value.getClass())) {
             throw new IllegalArgumentException("Conflicting argument types between key type of "
                     + key.type().getType().getTypeName() + " and value type of " + value.getClass());
         }

--- a/cloud-core/src/main/java/org/incendo/cloud/syntax/StandardCommandSyntaxFormatter.java
+++ b/cloud-core/src/main/java/org/incendo/cloud/syntax/StandardCommandSyntaxFormatter.java
@@ -23,7 +23,6 @@
 //
 package org.incendo.cloud.syntax;
 
-import io.leangen.geantyref.GenericTypeReflector;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Iterator;
@@ -36,6 +35,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.component.CommandComponent;
 import org.incendo.cloud.internal.CommandNode;
+import org.incendo.cloud.internal.SuperTypeCache;
 import org.incendo.cloud.parser.aggregate.AggregateParser;
 import org.incendo.cloud.parser.flag.CommandFlag;
 import org.incendo.cloud.parser.flag.CommandFlagParser;
@@ -85,7 +85,7 @@ public class StandardCommandSyntaxFormatter<C> implements CommandSyntaxFormatter
                     Collections.emptyMap()
             );
             for (final Map.Entry<Type, Permission> entry : accessMap.entrySet()) {
-                if (GenericTypeReflector.isSuperType(entry.getKey(), sender.getClass())) {
+                if (SuperTypeCache.isSuperType(entry.getKey(), sender.getClass())) {
                     if (this.manager.testPermission(sender, entry.getValue()).allowed()) {
                         return true;
                     }


### PR DESCRIPTION
Same justifications as my other PR:

<img width="827" height="152" alt="image" src="https://github.com/user-attachments/assets/ba03c767-e383-481a-915c-31afa23f2d0a" />

The repeated calls to isSuperType were getting a little heavy, so I've taken the liberty of adding this global cache to cloud-core...
I've also moved some calls to the new cache on cloud-core itself (not necessarily appearing on the above image of spark), but thought it would be a nice idea anyways

isSuperType is used in a decent few platforms so it made the most sense to do a cache in the core and then I can PR it into the other respective repos🤔 