### PR TITLE
fix: expose Immutables annotations to consumers

### DIFF
--- a/gradle/build-logic/src/main/kotlin/CloudBaseConventions.kt
+++ b/gradle/build-logic/src/main/kotlin/CloudBaseConventions.kt
@@ -32,8 +32,9 @@ class CloudBaseConventions : Plugin<Project> {
         target.gradle.startParameter.excludedTaskNames.add("checkstyleTest")
 
         target.dependencies {
-            "compileOnly"(libs.bundles.immutables)
-            "annotationProcessor"(libs.bundles.immutables)
+            "compileOnlyApi"(libs.immutablesValueAnnotations)
+            "compileOnlyApi"(libs.immutablesAnnotate)
+            "annotationProcessor"(libs.immutablesValue)
 
             "testImplementation"(libs.bundles.baseTestingDependencies)
             "testRuntimeOnly"("org.junit.platform:junit-platform-launcher")

--- a/gradle/build-logic/src/main/kotlin/CloudPublishingConventions.kt
+++ b/gradle/build-logic/src/main/kotlin/CloudPublishingConventions.kt
@@ -6,11 +6,17 @@ import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.project
 import org.incendo.cloudbuildlogic.city
+import org.incendo.cloudbuildlogic.javadoclinks.JavadocLinksExtension
 import org.incendo.cloudbuildlogic.jmp
 
 class CloudPublishingConventions : Plugin<Project> {
     override fun apply(target: Project) {
         target.plugins.apply("org.incendo.cloud-build-logic.publishing")
+
+        target.extensions.configure(JavadocLinksExtension::class) {
+            exclude(target.libs.immutablesValueAnnotations)
+            exclude(target.libs.immutablesAnnotate)
+        }
 
         if (!target.name.endsWith("-bom")) {
             target.dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,8 @@ geantyref = { group = "io.leangen.geantyref", name = "geantyref", version.ref = 
 jmhCore = { group = "org.openjdk.jmh", name = "jmh-core", version.ref = "jmh" }
 jmhGeneratorAnnprocess = { group = "org.openjdk.jmh", name = "jmh-generator-annprocess", version.ref = "jmh" }
 apiguardian = { group = "org.apiguardian", name = "apiguardian-api", version.ref = "apiguardian" }
-immutables = { group = "org.immutables", name = "value", version.ref = "immutables" }
+immutablesValue = { group = "org.immutables", name = "value", version.ref = "immutables" }
+immutablesValueAnnotations = { group = "org.immutables", name = "value-annotations", version.ref = "immutables" }
 immutablesAnnotate = { group = "org.immutables", name = "annotate", version.ref = "immutables" }
 
 # integration
@@ -72,7 +73,6 @@ cloud-build-logic = { module = "org.incendo:cloud-build-logic", version.ref = "c
 [bundles]
 coroutines = ["coroutinesCore", "coroutinesJdk8"]
 annotations = ["checkerQual", "apiguardian"]
-immutables = ["immutables", "immutablesAnnotate"]
 baseTestingDependencies = [
     "jupiterEngine",
     "jupiterParams",


### PR DESCRIPTION
Publish the lightweight value and annotate artifacts on consumers' compile classpaths while keeping the full Immutables processor isolated to annotation processing.

Exclude these artifacts from external Javadoc linking because they do not publish the required element-list or package-list files.

Fixes missing annotation warnings for consumers.